### PR TITLE
[qt] Localize desktop UI strings using upstream Twine

### DIFF
--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -107,6 +107,7 @@ jobs:
               libxrandr-dev \
               ninja-build \
               qt6-base-dev \
+              qt6-l10n-tools \
               qt6-positioning-dev \
 
       - name: Install build tools and dependencies (macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if (NOT PLATFORM_IPHONE AND NOT PLATFORM_ANDROID)
   find_package(Qt6 COMPONENTS REQUIRED ${qt_components} OPTIONAL_COMPONENTS Positioning PATHS $ENV{QT_PATH} /opt/homebrew/opt/qt@6 /usr/local/opt/qt@6 /usr/lib/x86_64-linux-gnu/qt6)
 
   set(MINIMUM_REQUIRED_QT_VERSION 6.4.0)
-  if (Qt6Widgets_VERSION VERSION_LESS ${MINIMUM_REQUIRED_QT_VERSION})
+  if (Qt6Core_VERSION VERSION_LESS ${MINIMUM_REQUIRED_QT_VERSION})
     message(FATAL_ERROR "Unsupported Qt version: ${Qt6Widgets_VERSION}, the minimum required is ${MINIMUM_REQUIRED_QT_VERSION}")
   else()
     message(STATUS "Found Qt version: ${Qt6Widgets_VERSION}")

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -43459,6 +43459,31 @@ en = Auth failed: invalid login or password
 tags = qt
 en = Auth failed: %@
 
+[desktop_place_page]
+comment = Place page dialog window title
+tags = qt
+en = Place Page
+
+[desktop_place_page_bookmarked]
+comment = Place page dialog window title when the place is a bookmark
+tags = qt
+en = Place Page (bookmarked)
+
+[desktop_place_routes]
+comment = Place page row label listing public transit routes serving this stop
+tags = qt
+en = Routes
+
+[desktop_place_opening_hours]
+comment = Place page row label showing business hours
+tags = qt
+en = Opening hours
+
+[desktop_place_coordinates]
+comment = Place page row label showing latitude and longitude
+tags = qt
+en = Coordinates
+
 [[3d touch strings]]
 
 [route]

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -43089,6 +43089,376 @@ vi = Vùng đã tải về màu tím
 zh-Hans = 紫色已下载区域
 zh-Hant = 紫色已下載區域
 
+[[Qt desktop strings]]
+
+[desktop_preferences]
+tags = qt
+en = Preferences
+
+[desktop_preferences_ellipsis]
+tags = qt
+en = Preferences...
+
+[desktop_about]
+tags = qt
+en = About
+
+[desktop_about_ellipsis]
+tags = qt
+en = About...
+
+[desktop_exit]
+tags = qt
+en = Exit
+
+[desktop_upload_edits]
+tags = qt
+en = Upload Edits
+
+[desktop_welcome_to]
+tags = qt
+en = Welcome to %@
+
+[desktop_looking_for_position]
+tags = qt
+en = Looking for position...
+
+[desktop_navigation_bar]
+tags = qt
+en = Navigation Bar
+
+[desktop_public_transport]
+tags = qt
+en = Public transport
+
+[desktop_bookmarks_tooltip]
+tags = qt
+en = Show bookmarks and tracks; use ALT + RMB to add a bookmark
+
+[desktop_start_point]
+tags = qt
+en = Start point
+
+[desktop_intermediate_point]
+tags = qt
+en = Intermediate point
+
+[desktop_finish_point]
+tags = qt
+en = Finish point
+
+[desktop_route_point_tooltip]
+tags = qt
+en = Select mode and use SHIFT + LMB to set point
+
+[desktop_follow_route]
+tags = qt
+en = Follow route
+
+[desktop_follow_route_tooltip]
+tags = qt
+en = Build route and use ALT + LMB to emulate current position
+
+[desktop_clear_route]
+tags = qt
+en = Clear route
+
+[desktop_routing_settings]
+tags = qt
+en = Routing settings
+
+[desktop_create_feature]
+tags = qt
+en = Create Feature
+
+[desktop_create_feature_tooltip]
+tags = qt
+en = Push to select position, next push to create Feature
+
+[desktop_roads_selection_mode]
+tags = qt
+en = Roads selection mode
+
+[desktop_city_boundaries_selection_mode]
+tags = qt
+en = City boundaries selection mode
+
+[desktop_city_roads_selection_mode]
+tags = qt
+en = City roads selection mode
+
+[desktop_cross_mwm_segments_selection_mode]
+tags = qt
+en = Cross MWM segments selection mode
+
+[desktop_mwms_borders_selection_mode]
+tags = qt
+en = MWMs borders selection mode
+
+[desktop_selection_mode_tooltip]
+tags = qt
+en = Select mode and use RMB to define selection box
+
+[desktop_offline_search]
+tags = qt
+en = Offline Search
+
+[desktop_ruler]
+tags = qt
+en = Ruler
+
+[desktop_ruler_tooltip]
+tags = qt
+en = Check this button and use ALT + LMB to set points
+
+[desktop_build_style]
+tags = qt
+en = Build style
+
+[desktop_recalculate_geometry_index]
+tags = qt
+en = Recalculate geometry index
+
+[desktop_debug_style]
+tags = qt
+en = Debug style
+
+[desktop_get_statistics]
+tags = qt
+en = Get statistics
+
+[desktop_run_tests]
+tags = qt
+en = Run tests
+
+[desktop_build_phone_package]
+tags = qt
+en = Build phone package
+
+[desktop_retry_downloading]
+tags = qt
+en = Retry downloading
+
+[desktop_system_of_measurement]
+tags = qt
+en = System of measurement
+
+[desktop_metric]
+tags = qt
+en = Metric
+
+[desktop_imperial_foot]
+tags = qt
+en = Imperial (foot)
+
+[desktop_use_larger_font_on_map]
+tags = qt
+en = Use larger font on the map
+
+[desktop_transliterate_to_latin]
+tags = qt
+en = Transliterate to Latin
+
+[desktop_developer_mode]
+tags = qt
+en = Developer Mode
+
+[desktop_night_mode]
+tags = qt
+en = Night Mode
+
+[desktop_enable_auto_regeneration_geometry_index]
+tags = qt
+en = Enable auto regeneration of geometry index
+
+[desktop_search_everywhere]
+tags = qt
+en = Everywhere
+
+[desktop_search_viewport]
+tags = qt
+en = Viewport
+
+[desktop_category_request]
+tags = qt
+en = Category request
+
+[desktop_unuploaded_edits_delete_map]
+tags = qt
+en = Some map edits are not uploaded yet. Are you sure you want to delete map anyway?
+
+[desktop_country]
+tags = qt
+en = Country
+
+[desktop_status]
+tags = qt
+en = Status
+
+[desktop_size]
+tags = qt
+en = Size
+
+[desktop_matched_by]
+tags = qt
+en = Matched by
+
+[desktop_rank]
+tags = qt
+en = Rank
+
+[desktop_locale_label]
+tags = qt
+en = locale:
+
+[desktop_search_query_label]
+tags = qt
+en = search query:
+
+[desktop_geographical_regions]
+tags = qt
+en = Geographical Regions
+
+[desktop_update_or_delete_region]
+tags = qt
+en = Do you want to update or delete %@?
+
+[desktop_update]
+tags = qt
+en = Update
+
+[desktop_delete_region]
+tags = qt
+en = Do you want to delete %@?
+
+[desktop_click_to_download]
+tags = qt
+en = Click to download
+
+[desktop_installed_click_to_delete]
+tags = qt
+en = Installed (click to delete)
+
+[desktop_out_of_date_click_to_update_or_delete]
+tags = qt
+en = Out of date (click to update or delete)
+
+[desktop_downloading_ellipsis]
+tags = qt
+en = Downloading ...
+
+[desktop_applying_ellipsis]
+tags = qt
+en = Applying ...
+
+[desktop_marked_for_download]
+tags = qt
+en = Marked for download
+
+[desktop_open_bookmark_files]
+tags = qt
+en = Open KML, KMZ, GPX, JSON, GeoJSON...
+
+[desktop_bookmark_files_filter]
+tags = qt
+en = KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)
+
+[desktop_select_bookmark_category_to_export]
+tags = qt
+en = Select one of the bookmark categories to export.
+
+[desktop_selected_item_not_bookmark_category]
+tags = qt
+en = Selected item is not a bookmark category.
+
+[desktop_export_gpx_caption]
+tags = qt
+en = Export GPX...
+
+[desktop_gpx_filter]
+tags = qt
+en = GPX files (*.gpx)
+
+[desktop_export_geojson_caption]
+tags = qt
+en = Export GeoJSON...
+
+[desktop_geojson_filter]
+tags = qt
+en = GeoJSON files (*.geojson);JSON files (*.json)
+
+[desktop_export_kmz_caption]
+tags = qt
+en = Export KMZ...
+
+[desktop_kmz_filter]
+tags = qt
+en = KMZ files (*.kmz)
+
+[desktop_bookmarks_exported]
+tags = qt
+en = Bookmarks successfully exported.
+
+[desktop_bookmarks_export_error]
+tags = qt
+en = Could not export bookmarks: %@
+
+[desktop_cannot_delete_last_category]
+tags = qt
+en = Could not delete the last category.
+
+[desktop_select_bookmark_item_to_delete]
+tags = qt
+en = Select category, bookmark or track to delete.
+
+[desktop_no_name]
+tags = qt
+en = No name
+
+[desktop_loading_in_progress]
+tags = qt
+en = Loading in progress...
+
+[desktop_mwms_borders_selection_settings]
+tags = qt
+en = MWMs borders selection settings
+
+[desktop_get_borders_from_packed_polygon]
+tags = qt
+en = Get borders from packed_polygon.bin
+
+[desktop_get_borders_from_poly_files]
+tags = qt
+en = Get borders from *.poly files
+
+[desktop_show_borders_with_vertices]
+tags = qt
+en = Show borders with vertices
+
+[desktop_show_just_borders]
+tags = qt
+en = Show just borders
+
+[desktop_show_bounding_box]
+tags = qt
+en = Show bounding box
+
+[desktop_enter_login]
+tags = qt
+en = Please enter Login
+
+[desktop_enter_password]
+tags = qt
+en = Please enter Password
+
+[desktop_auth_failed_invalid_login_or_password]
+tags = qt
+en = Auth failed: invalid login or password
+
+[desktop_auth_failed]
+tags = qt
+en = Auth failed: %@
+
 [[3d touch strings]]
 
 [route]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -103,6 +103,7 @@ sudo apt update && sudo apt install -y \
     ninja-build \
     python3 \
     qt6-base-dev \
+    qt6-l10n-tools \
     qt6-positioning-dev \
     libc++-dev \
     libfreetype-dev \
@@ -128,11 +129,6 @@ sudo apt update && sudo apt install -y \
 | GeoClue   | `2.5.7`         | `20.04` and older       | Install newer `geoclue-2.0` from [PPA](https://launchpad.net/~savoury1/+archive/ubuntu/backports) |
 | Qt 6      | `6.4.0`         | `22.04` and older       | Build and install Qt 6.4 manually |
 
-
-```bash
-sudo add-apt-repository -y ppa:savoury1/qt-6-2
-```
-
 #### Linux Mint
 
 Check which Ubuntu version is the `PACKAGE BASE` for your Linux Mint release [here](https://www.linuxmint.com/download_all.php),
@@ -155,6 +151,7 @@ sudo dnf install -y \
     qt6-qtpositioning \
     qt6-qtpositioning-devel \
     qt6-qtsvg-devel \
+    qt6-l10n-tools \
     sqlite-devel
 ```
 
@@ -171,6 +168,7 @@ sudo apk add \
     qt6-qtbase-dev \
     qt6-qtpositioning-dev \
     qt6-qtsvg-dev \
+    qt6-qttools \
     samurai \
     sqlite-dev
 ```

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -75,6 +75,7 @@ find_program(OMIM_LRELEASE_EXECUTABLE
     /opt/homebrew/bin
     /opt/homebrew/opt/qt@6/bin
     /usr/local/opt/qt@6/bin
+    /usr/lib/qt6/bin
 )
 if (NOT OMIM_LRELEASE_EXECUTABLE)
   message(FATAL_ERROR "lrelease is required to build Qt desktop translations")

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -67,6 +67,43 @@ omim_add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${RES_SOURCES} ${SRC})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON)
 
+find_program(OMIM_LRELEASE_EXECUTABLE
+  NAMES lrelease lrelease-qt6 lrelease6
+  HINTS
+    "$ENV{QT_PATH}/bin"
+    "${Qt6_DIR}/../../../bin"
+    /opt/homebrew/bin
+    /opt/homebrew/opt/qt@6/bin
+    /usr/local/opt/qt@6/bin
+)
+if (NOT OMIM_LRELEASE_EXECUTABLE)
+  message(FATAL_ERROR "lrelease is required to build Qt desktop translations")
+endif()
+
+file(GLOB_RECURSE QT_TRANSLATION_TS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/translations/*/omim.ts")
+set(QT_TRANSLATION_QM)
+foreach(ts ${QT_TRANSLATION_TS})
+  get_filename_component(lang_dir "${ts}" DIRECTORY)
+  get_filename_component(lang "${lang_dir}" NAME)
+  set(qm "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/translations/omim_${lang}.qm")
+  add_custom_command(
+    OUTPUT "${qm}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/translations"
+    COMMAND ${CMAKE_COMMAND}
+      -D "LRELEASE=${OMIM_LRELEASE_EXECUTABLE}"
+      -D "TS=${ts}"
+      -D "QM=${qm}"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/strict_lrelease.cmake"
+    DEPENDS "${ts}" "${CMAKE_CURRENT_SOURCE_DIR}/strict_lrelease.cmake"
+    COMMENT "Compiling Qt translation ${lang}"
+    VERBATIM
+  )
+  list(APPEND QT_TRANSLATION_QM "${qm}")
+endforeach()
+
+add_custom_target(desktop_translations ALL DEPENDS ${QT_TRANSLATION_QM})
+add_dependencies(${PROJECT_NAME} desktop_translations)
+
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
     generator  # For borders::LoadBorders
@@ -94,6 +131,26 @@ set(BUNDLE_EXECUTABLE ${BUNDLE_NAME})
 set(BUNDLE_FOLDER ${CMAKE_BINARY_DIR}/${BUNDLE_NAME}.app)
 set(RESOURCES_FOLDER ${BUNDLE_FOLDER}/Contents/Resources)
 set(DATA_DIR ${OMIM_ROOT}/data)
+
+if (PLATFORM_MAC)
+  set(QT_TRANSLATION_BUNDLE_QM)
+  foreach(qm ${QT_TRANSLATION_QM})
+    get_filename_component(qm_name "${qm}" NAME)
+    set(bundle_qm "${RESOURCES_FOLDER}/translations/${qm_name}")
+    add_custom_command(
+      OUTPUT "${bundle_qm}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCES_FOLDER}/translations"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${qm}" "${bundle_qm}"
+      DEPENDS "${qm}"
+      COMMENT "Copying Qt translation ${qm_name} to app bundle"
+      VERBATIM
+    )
+    list(APPEND QT_TRANSLATION_BUNDLE_QM "${bundle_qm}")
+  endforeach()
+
+  add_custom_target(desktop_bundle_translations ALL DEPENDS ${QT_TRANSLATION_BUNDLE_QM})
+  add_dependencies(${PROJECT_NAME} desktop_bundle_translations)
+endif()
 
 function(copy_resources)
   execute_process(COMMAND mkdir -p ${RESOURCES_FOLDER})
@@ -133,6 +190,8 @@ copy_resources(
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/)
 install(DIRECTORY ${OMIM_ROOT}/data DESTINATION ${CMAKE_INSTALL_PREFIX}/share/organicmaps/)
+install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/translations/"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/organicmaps/data/translations)
 
 if (PLATFORM_LINUX)
   install(FILES ${OMIM_ROOT}/packaging/app.organicmaps.desktop.metainfo.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo/)

--- a/qt/about.cpp
+++ b/qt/about.cpp
@@ -1,5 +1,6 @@
 #include "qt/about.hpp"
 #include "qt/html_processor.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "platform/platform.hpp"
 #include "platform/preferred_languages.hpp"
@@ -22,7 +23,7 @@ AboutDialog::AboutDialog(QWidget * parent)
 {
   QIcon icon(":/ui/logo.png");
   setWindowIcon(icon);
-  setWindowTitle(QMenuBar::tr("About"));
+  setWindowTitle(qt::Tr("desktop_about"));
 
   QLabel * labelIcon = new QLabel();
   labelIcon->setPixmap(icon.pixmap(128));
@@ -31,7 +32,7 @@ AboutDialog::AboutDialog(QWidget * parent)
 
   QVBoxLayout * versionBox = new QVBoxLayout();
   versionBox->addWidget(new QLabel(QCoreApplication::applicationName()));
-  QLabel * versionLabel = new QLabel("Version: " + QString::fromStdString(platform.Version()));
+  QLabel * versionLabel = new QLabel(qt::Tr("version") + ": " + QString::fromStdString(platform.Version()));
   versionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
   versionBox->addWidget(versionLabel);
   // TODO: insert maps data version.

--- a/qt/bookmark_dialog.cpp
+++ b/qt/bookmark_dialog.cpp
@@ -1,4 +1,5 @@
 #include "qt/bookmark_dialog.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "map/bookmark_helpers.hpp"
 #include "map/bookmark_manager.hpp"
@@ -27,29 +28,29 @@ BookmarkDialog::BookmarkDialog(QWidget * parent, Framework & framework)
 {
   setWindowModality(Qt::WindowModal);
 
-  QPushButton * closeButton = new QPushButton(tr("Close"), this);
+  QPushButton * closeButton = new QPushButton(Tr("close"), this);
   closeButton->setDefault(true);
   connect(closeButton, &QAbstractButton::clicked, this, &BookmarkDialog::OnCloseClick);
 
-  QPushButton * deleteButton = new QPushButton(tr("Delete"), this);
+  QPushButton * deleteButton = new QPushButton(Tr("delete"), this);
   connect(deleteButton, &QAbstractButton::clicked, this, &BookmarkDialog::OnDeleteClick);
 
-  QPushButton * importButton = new QPushButton(tr("Import KML, KMZ, GPX"), this);
+  QPushButton * importButton = new QPushButton(Tr("bookmarks_import"), this);
   connect(importButton, &QAbstractButton::clicked, this, &BookmarkDialog::OnImportClick);
 
-  QPushButton * exportKmzButton = new QPushButton(tr("Export KMZ"), this);
+  QPushButton * exportKmzButton = new QPushButton(Tr("export_file"), this);
   connect(exportKmzButton, &QAbstractButton::clicked, this, [this] { OnExportClick(FileType::Kml); });
 
-  QPushButton * exportGpxButton = new QPushButton(tr("Export GPX"), this);
+  QPushButton * exportGpxButton = new QPushButton(Tr("export_file_gpx"), this);
   connect(exportGpxButton, &QAbstractButton::clicked, this, [this] { OnExportClick(FileType::Gpx); });
 
-  QPushButton * exportGeoJsonButton = new QPushButton(tr("Export GeoJSON"), this);
+  QPushButton * exportGeoJsonButton = new QPushButton(Tr("export_file_geojson"), this);
   connect(exportGeoJsonButton, &QAbstractButton::clicked, this, [this] { OnExportClick(FileType::GeoJson); });
 
   m_tree = new QTreeWidget(this);
   m_tree->setColumnCount(2);
   QStringList columnLabels;
-  columnLabels << tr("Bookmarks and tracks") << "";
+  columnLabels << Tr("bookmarks_and_tracks") << "";
   m_tree->setHeaderLabels(columnLabels);
   m_tree->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectItems);
   connect(m_tree, &QTreeWidget::itemClicked, this, &BookmarkDialog::OnItemClick);
@@ -68,7 +69,7 @@ BookmarkDialog::BookmarkDialog(QWidget * parent, Framework & framework)
   verticalLayout->addLayout(horizontalLayout);
   setLayout(verticalLayout);
 
-  setWindowTitle(tr("Bookmarks and tracks"));
+  setWindowTitle(Tr("bookmarks_and_tracks"));
   resize(700, 600);
 
   BookmarkManager::AsyncLoadingCallbacks callbacks;
@@ -136,9 +137,8 @@ void BookmarkDialog::OnCloseClick()
 
 void BookmarkDialog::OnImportClick()
 {
-  auto const files = QFileDialog::getOpenFileNames(
-      this /* parent */, tr("Open KML, KMZ, GPX, JSON, GeoJSON..."), QString() /* dir */,
-      "KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)");
+  auto const files = QFileDialog::getOpenFileNames(this /* parent */, Tr("desktop_open_bookmark_files"),
+                                                   QString() /* dir */, Tr("desktop_bookmark_files_filter"));
 
   for (auto const & name : files)
   {
@@ -157,8 +157,8 @@ void BookmarkDialog::OnExportClick(FileType exportedFileType)
   {
     QMessageBox ask(this);
     ask.setIcon(QMessageBox::Information);
-    ask.setText(tr("Select one of the bookmark categories to export."));
-    ask.addButton(tr("OK"), QMessageBox::NoRole);
+    ask.setText(Tr("desktop_select_bookmark_category_to_export"));
+    ask.addButton(Tr("ok"), QMessageBox::NoRole);
     ask.exec();
     return;
   }
@@ -168,8 +168,8 @@ void BookmarkDialog::OnExportClick(FileType exportedFileType)
   {
     QMessageBox ask(this);
     ask.setIcon(QMessageBox::Warning);
-    ask.setText(tr("Selected item is not a bookmark category."));
-    ask.addButton(tr("OK"), QMessageBox::NoRole);
+    ask.setText(Tr("desktop_selected_item_not_bookmark_category"));
+    ask.addButton(Tr("ok"), QMessageBox::NoRole);
     ask.exec();
     return;
   }
@@ -178,14 +178,14 @@ void BookmarkDialog::OnExportClick(FileType exportedFileType)
   switch (exportedFileType)
   {
   case FileType::Gpx:
-    caption = tr("Export GPX...");
-    filter = tr("GPX files (*.gpx)");
+    caption = Tr("desktop_export_gpx_caption");
+    filter = Tr("desktop_gpx_filter");
     break;
   case FileType::GeoJson:
-    caption = tr("Export GeoJSON...");
-    filter = tr("GeoJSON files (*.geojson);JSON files (*.json)");
+    caption = Tr("desktop_export_geojson_caption");
+    filter = Tr("desktop_geojson_filter");
     break;
-  default: caption = tr("Export KMZ..."); filter = tr("KMZ files (*.kmz)");
+  default: caption = Tr("desktop_export_kmz_caption"); filter = Tr("desktop_kmz_filter");
   }
 
   auto const name = QFileDialog::getSaveFileName(this /* parent */, caption, QString() /* dir */, filter);
@@ -201,16 +201,16 @@ void BookmarkDialog::OnExportClick(FileType exportedFileType)
 
       QMessageBox ask(this);
       ask.setIcon(QMessageBox::Information);
-      ask.setText(tr("Bookmarks successfully exported."));
-      ask.addButton(tr("OK"), QMessageBox::NoRole);
+      ask.setText(Tr("desktop_bookmarks_exported"));
+      ask.addButton(Tr("ok"), QMessageBox::NoRole);
       ask.exec();
     }
     else
     {
       QMessageBox ask(this);
       ask.setIcon(QMessageBox::Critical);
-      ask.setText(tr("Could not export bookmarks: ") + result.m_errorString.c_str());
-      ask.addButton(tr("OK"), QMessageBox::NoRole);
+      ask.setText(Tr("desktop_bookmarks_export_error").arg(result.m_errorString.c_str()));
+      ask.addButton(Tr("ok"), QMessageBox::NoRole);
       ask.exec();
     }
   }, exportedFileType);
@@ -228,8 +228,8 @@ void BookmarkDialog::OnDeleteClick()
       {
         QMessageBox ask(this);
         ask.setIcon(QMessageBox::Information);
-        ask.setText(tr("Could not delete the last category."));
-        ask.addButton(tr("OK"), QMessageBox::NoRole);
+        ask.setText(Tr("desktop_cannot_delete_last_category"));
+        ask.addButton(Tr("ok"), QMessageBox::NoRole);
         ask.exec();
       }
       else
@@ -259,15 +259,15 @@ void BookmarkDialog::OnDeleteClick()
 
   QMessageBox ask(this);
   ask.setIcon(QMessageBox::Warning);
-  ask.setText(tr("Select category, bookmark or track to delete."));
-  ask.addButton(tr("OK"), QMessageBox::NoRole);
+  ask.setText(Tr("desktop_select_bookmark_item_to_delete"));
+  ask.addButton(Tr("ok"), QMessageBox::NoRole);
   ask.exec();
 }
 
-QTreeWidgetItem * BookmarkDialog::CreateTreeItem(std::string const & title, QTreeWidgetItem * parent)
+QTreeWidgetItem * BookmarkDialog::CreateTreeItem(QString const & title, QTreeWidgetItem * parent)
 {
   QStringList labels;
-  labels << QString::fromStdString(title) << tr(parent != nullptr ? "Show on the map" : "");
+  labels << title << (parent != nullptr ? Tr("zoom_to_country") : QString());
 
   QTreeWidgetItem * item = new QTreeWidgetItem(labels);
   if (parent)
@@ -284,7 +284,7 @@ void BookmarkDialog::FillTree()
   m_bookmarks.clear();
   m_tracks.clear();
 
-  auto categoriesItem = CreateTreeItem("Categories", nullptr);
+  auto categoriesItem = CreateTreeItem(Tr("categories"), nullptr);
 
   auto const & bm = m_framework.GetBookmarkManager();
 
@@ -292,7 +292,7 @@ void BookmarkDialog::FillTree()
   {
     for (auto catId : bm.GetUnsortedBmGroupsIdList())
     {
-      auto categoryItem = CreateTreeItem(bm.GetCategoryName(catId), categoriesItem);
+      auto categoryItem = CreateTreeItem(QString::fromStdString(bm.GetCategoryName(catId)), categoriesItem);
       m_categories[categoryItem] = catId;
 
       for (auto bookmarkId : bm.GetUserMarkIds(catId))
@@ -304,7 +304,8 @@ void BookmarkDialog::FillTree()
           name = measurement_utils::FormatLatLon(mercator::YToLat(bookmark->GetPivot().y),
                                                  mercator::XToLon(bookmark->GetPivot().x), true /* withComma */);
         }
-        auto bookmarkItem = CreateTreeItem(name + " (Bookmark)", categoryItem);
+        auto bookmarkItem =
+            CreateTreeItem(QString("%1 (%2)").arg(QString::fromStdString(name), Tr("bookmark")), categoryItem);
         m_bookmarks[bookmarkItem] = bookmarkId;
       }
 
@@ -313,8 +314,9 @@ void BookmarkDialog::FillTree()
         auto const track = bm.GetTrack(trackId);
         auto name = track->GetName();
         if (name.empty())
-          name = "No name";
-        auto trackItem = CreateTreeItem(name + " (Track)", categoryItem);
+          name = Tr("desktop_no_name").toStdString();
+        auto trackItem =
+            CreateTreeItem(QString("%1 (%2)").arg(QString::fromStdString(name), Tr("track_title")), categoryItem);
         trackItem->setForeground(0, Qt::darkGreen);
         m_tracks[trackItem] = trackId;
       }
@@ -322,7 +324,7 @@ void BookmarkDialog::FillTree()
   }
   else
   {
-    CreateTreeItem("Loading in progress...", categoriesItem);
+    CreateTreeItem(Tr("desktop_loading_in_progress"), categoriesItem);
   }
 
   m_tree->addTopLevelItem(categoriesItem);

--- a/qt/bookmark_dialog.hpp
+++ b/qt/bookmark_dialog.hpp
@@ -35,7 +35,7 @@ private slots:
 
 private:
   void FillTree();
-  QTreeWidgetItem * CreateTreeItem(std::string const & title, QTreeWidgetItem * parent);
+  QTreeWidgetItem * CreateTreeItem(QString const & title, QTreeWidgetItem * parent);
   void OnAsyncLoadingStarted();
   void OnAsyncLoadingFinished();
   void OnAsyncLoadingFileSuccess(std::string const & fileName, bool isTemporaryFile);

--- a/qt/editor_dialog.cpp
+++ b/qt/editor_dialog.cpp
@@ -1,5 +1,7 @@
 #include "qt/editor_dialog.hpp"
 
+#include "qt/qt_common/translations.hpp"
+
 #include "indexer/editable_map_object.hpp"
 #include "indexer/feature_utils.hpp"
 
@@ -50,7 +52,7 @@ EditorDialog::EditorDialog(QWidget * parent, osm::EditableMapObject & emo) : QDi
   // Names.
   if (emo.IsNameEditable())
   {
-    grid->addWidget(new QLabel(QString("Name:")), row, 0);
+    grid->addWidget(new QLabel(qt::Tr("name") + ":"), row, 0);
 
     QGridLayout * namesGrid = new QGridLayout();
     int namesRow = 0;
@@ -142,7 +144,7 @@ EditorDialog::EditorDialog(QWidget * parent, osm::EditableMapObject & emo) : QDi
     connect(buttonBox, &QDialogButtonBox::accepted, this, &EditorDialog::OnSave);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     // Delete button should send custom int return value from dialog.
-    QPushButton * deletePOIButton = new QPushButton("Delete POI");
+    QPushButton * deletePOIButton = new QPushButton(qt::Tr("editor_remove_place_button"));
     QSignalMapper * signalMapper = new QSignalMapper();
     connect(deletePOIButton, SIGNAL(clicked()), signalMapper, SLOT(map()));
     signalMapper->setMapping(deletePOIButton, QDialogButtonBox::DestructiveRole);

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -4,6 +4,7 @@
 #include "qt/screenshoter.hpp"
 
 #include "qt/qt_common/helpers.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "map/framework.hpp"
 
@@ -133,6 +134,9 @@ int main(int argc, char * argv[])
   else
     LOG(LCRITICAL, ("Invalid log level:", FLAGS_log_abort_level));
 
+  if (!FLAGS_lang.empty())
+    (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
+
   Q_INIT_RESOURCE(resources_common);
 
   InitializeFinalize mainGuard;
@@ -146,6 +150,8 @@ int main(int argc, char * argv[])
 #else
   QApplication::setApplicationName("Organic Maps");
 #endif
+  auto qtTranslator = qt::InstallTranslator(app, FLAGS_lang.empty() ? languages::GetCurrentOrig() : FLAGS_lang);
+  UNUSED_VALUE(qtTranslator);
 
 #ifdef DEBUG
   static bool constexpr developerMode = true;
@@ -167,7 +173,8 @@ int main(int argc, char * argv[])
       reader.ReadAsString(buffer);
     }
     RemovePTagsWithNonMatchedLanguages(languages::GetCurrentTwine(), buffer);
-    qt::InfoDialog eulaDialog(QCoreApplication::applicationName(), buffer.c_str(), nullptr, {"Accept", "Decline"});
+    qt::InfoDialog eulaDialog(QCoreApplication::applicationName(), buffer.c_str(), nullptr,
+                              {qt::Tr("accept"), qt::Tr("decline")});
     eulaAccepted = (eulaDialog.exec() == 1);
     settings::Set(settingsEULA, eulaAccepted);
   }
@@ -176,9 +183,6 @@ int main(int argc, char * argv[])
   if (eulaAccepted)  // User has accepted EULA
   {
     std::unique_ptr<qt::ScreenshotParams> screenshotParams;
-
-    if (!FLAGS_lang.empty())
-      (void)::setenv("LANGUAGE", FLAGS_lang.c_str(), 1);
 
     if (!FLAGS_kml_path.empty() || !FLAGS_points.empty() || !FLAGS_rects.empty())
     {

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -8,6 +8,7 @@
 #include "qt/preferences_dialog.hpp"
 #include "qt/qt_common/helpers.hpp"
 #include "qt/qt_common/scale_slider.hpp"
+#include "qt/qt_common/translations.hpp"
 #include "qt/routing_settings_dialog.hpp"
 #include "qt/screenshoter.hpp"
 #include "qt/search_panel.hpp"
@@ -147,13 +148,14 @@ MainWindow::MainWindow(Framework & framework, std::unique_ptr<ScreenshotParams> 
   setWindowIcon(QIcon(":/ui/logo.png"));
 
 #ifndef OMIM_OS_WINDOWS
-  QMenu * helpMenu = new QMenu(tr("Help"), this);
+  QMenu * helpMenu = new QMenu(Tr("help"), this);
   menuBar()->addMenu(helpMenu);
-  helpMenu->addAction(tr("OpenStreetMap Login"), QKeySequence(Qt::CTRL | Qt::Key_O), this, SLOT(OnLoginMenuItem()));
-  helpMenu->addAction(tr("Upload Edits"), QKeySequence(Qt::CTRL | Qt::Key_U), this, SLOT(OnUploadEditsMenuItem()));
-  helpMenu->addAction(tr("Preferences"), QKeySequence(Qt::CTRL | Qt::Key_P), this, SLOT(OnPreferences()));
-  helpMenu->addAction(tr("About"), QKeySequence(Qt::Key_F1), this, SLOT(OnAbout()));
-  helpMenu->addAction(tr("Exit"), QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(close()));
+  helpMenu->addAction(Tr("login_osm"), QKeySequence(Qt::CTRL | Qt::Key_O), this, SLOT(OnLoginMenuItem()));
+  helpMenu->addAction(Tr("desktop_upload_edits"), QKeySequence(Qt::CTRL | Qt::Key_U), this,
+                      SLOT(OnUploadEditsMenuItem()));
+  helpMenu->addAction(Tr("desktop_preferences"), QKeySequence(Qt::CTRL | Qt::Key_P), this, SLOT(OnPreferences()));
+  helpMenu->addAction(Tr("desktop_about"), QKeySequence(Qt::Key_F1), this, SLOT(OnAbout()));
+  helpMenu->addAction(Tr("desktop_exit"), QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(close()));
 #else
   {
     // create items in the system menu
@@ -163,12 +165,12 @@ MainWindow::MainWindow(Framework & framework, std::unique_ptr<ScreenshotParams> 
     item.fMask = MIIM_FTYPE | MIIM_ID | MIIM_STRING;
     item.fType = MFT_STRING;
     item.wID = IDM_PREFERENCES_DIALOG;
-    QByteArray const prefsStr = tr("Preferences...").toLocal8Bit();
+    QByteArray const prefsStr = Tr("desktop_preferences_ellipsis").toLocal8Bit();
     item.dwTypeData = const_cast<char *>(prefsStr.data());
     item.cch = prefsStr.size();
     ::InsertMenuItemA(menu, ::GetMenuItemCount(menu) - 1, TRUE, &item);
     item.wID = IDM_ABOUT_DIALOG;
-    QByteArray const aboutStr = tr("About...").toLocal8Bit();
+    QByteArray const aboutStr = Tr("desktop_about_ellipsis").toLocal8Bit();
     item.dwTypeData = const_cast<char *>(aboutStr.data());
     item.cch = aboutStr.size();
     ::InsertMenuItemA(menu, ::GetMenuItemCount(menu) - 1, TRUE, &item);
@@ -201,7 +203,8 @@ MainWindow::MainWindow(Framework & framework, std::unique_ptr<ScreenshotParams> 
 
     if (!text.empty())
     {
-      InfoDialog welcomeDlg(QString("Welcome to ") + caption, text.c_str(), this, QStringList(tr("Download Maps")));
+      InfoDialog welcomeDlg(Tr("desktop_welcome_to").arg(caption), text.c_str(), this,
+                            QStringList(Tr("download_maps")));
       if (welcomeDlg.exec() == QDialog::Rejected)
         bShowUpdateDialog = false;
     }
@@ -245,17 +248,17 @@ void MainWindow::LocationStateModeChanged(location::EMyPositionMode mode)
   {
     m_locationService->Start();
     m_pMyPositionAction->setIcon(QIcon(":/navig64/location-search.png"));
-    m_pMyPositionAction->setToolTip(tr("Looking for position..."));
+    m_pMyPositionAction->setToolTip(Tr("desktop_looking_for_position"));
     return;
   }
 
   m_pMyPositionAction->setIcon(QIcon(":/navig64/location.png"));
-  m_pMyPositionAction->setToolTip(tr("My Position"));
+  m_pMyPositionAction->setToolTip(Tr("core_my_position"));
 }
 
 void MainWindow::CreateNavigationBar()
 {
-  QToolBar * pToolBar = new QToolBar(tr("Navigation Bar"), this);
+  QToolBar * pToolBar = new QToolBar(Tr("desktop_navigation_bar"), this);
   pToolBar->setOrientation(Qt::Vertical);
   pToolBar->setIconSize(QSize(32, 32));
   {
@@ -279,27 +282,27 @@ void MainWindow::CreateNavigationBar()
     m_layers = new PopupMenuHolder(this);
 
     /// @todo Uncomment when we will integrate a traffic provider.
-    // m_layers->addAction(QIcon(":/navig64/traffic.png"), tr("Traffic"),
+    // m_layers->addAction(QIcon(":/navig64/traffic.png"), Tr("button_layer_traffic"),
     //                     std::bind(&MainWindow::OnLayerEnabled, this, TRAFFIC), true);
     // m_layers->setChecked(TRAFFIC, Framework::LoadTrafficEnabled());
 
-    m_layers->addAction(QIcon(":/navig64/subway.png"), tr("Public transport"),
+    m_layers->addAction(QIcon(":/navig64/subway.png"), Tr("desktop_public_transport"),
                         std::bind(&MainWindow::OnLayerEnabled, this, TRANSIT), true);
     m_layers->setChecked(TRANSIT, Framework::LoadTransitSchemeEnabled());
 
-    m_layers->addAction(QIcon(":/navig64/isolines.png"), tr("Isolines"),
+    m_layers->addAction(QIcon(":/navig64/isolines.png"), Tr("button_layer_isolines"),
                         std::bind(&MainWindow::OnLayerEnabled, this, ISOLINES), true);
     m_layers->setChecked(ISOLINES, Framework::LoadIsolinesEnabled());
     // TODO(AB): Are icons drawable? Fix and make different icons for different layers.
-    m_layers->addAction(QIcon(":/navig64/isolines.png"), tr("Outdoors"),
+    m_layers->addAction(QIcon(":/navig64/isolines.png"), Tr("button_layer_outdoor"),
                         std::bind(&MainWindow::OnLayerEnabled, this, OUTDOORS), true);
     m_layers->setChecked(OUTDOORS, Framework::LoadOutdoorsEnabled());
 
-    m_layers->addAction(QIcon(":/navig64/isolines.png"), tr("Hiking"),
+    m_layers->addAction(QIcon(":/navig64/isolines.png"), Tr("button_layer_hiking"),
                         std::bind(&MainWindow::OnLayerEnabled, this, HIKING), true);
     m_layers->setChecked(HIKING, Framework::IsHikingEnabled());
 
-    m_layers->addAction(QIcon(":/navig64/isolines.png"), tr("Cycling"),
+    m_layers->addAction(QIcon(":/navig64/isolines.png"), Tr("button_layer_cycling"),
                         std::bind(&MainWindow::OnLayerEnabled, this, CYCLING), true);
     m_layers->setChecked(CYCLING, Framework::IsCyclingEnabled());
 
@@ -308,8 +311,7 @@ void MainWindow::CreateNavigationBar()
 
     pToolBar->addSeparator();
 
-    pToolBar->addAction(QIcon(":/navig64/bookmark.png"),
-                        tr("Show bookmarks and tracks; use ALT + RMB to add a bookmark"), this,
+    pToolBar->addAction(QIcon(":/navig64/bookmark.png"), Tr("desktop_bookmarks_tooltip"), this,
                         SLOT(OnBookmarksAction()));
     pToolBar->addSeparator();
 
@@ -317,31 +319,31 @@ void MainWindow::CreateNavigationBar()
     m_routing = new PopupMenuHolder(this);
 
     // The order should be the same as in "enum class RouteMarkType".
-    m_routing->addAction(QIcon(":/navig64/point-start.png"), tr("Start point"),
+    m_routing->addAction(QIcon(":/navig64/point-start.png"), Tr("desktop_start_point"),
                          std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Start), false);
-    m_routing->addAction(QIcon(":/navig64/point-intermediate.png"), tr("Intermediate point"),
+    m_routing->addAction(QIcon(":/navig64/point-intermediate.png"), Tr("desktop_intermediate_point"),
                          std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Intermediate), false);
-    m_routing->addAction(QIcon(":/navig64/point-finish.png"), tr("Finish point"),
+    m_routing->addAction(QIcon(":/navig64/point-finish.png"), Tr("desktop_finish_point"),
                          std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Finish), false);
 
     QToolButton * toolBtn = m_routing->create();
-    toolBtn->setToolTip(tr("Select mode and use SHIFT + LMB to set point"));
+    toolBtn->setToolTip(Tr("desktop_route_point_tooltip"));
     pToolBar->addWidget(toolBtn);
     m_routing->setCurrent(m_pDrawWidget->GetRoutePointAddMode());
 
     QAction * act =
-        pToolBar->addAction(QIcon(":/navig64/routing.png"), tr("Follow route"), this, SLOT(OnFollowRoute()));
-    act->setToolTip(tr("Build route and use ALT + LMB to emulate current position"));
-    pToolBar->addAction(QIcon(":/navig64/clear-route.png"), tr("Clear route"), this, SLOT(OnClearRoute()));
-    pToolBar->addAction(QIcon(":/navig64/settings-routing.png"), tr("Routing settings"), this,
+        pToolBar->addAction(QIcon(":/navig64/routing.png"), Tr("desktop_follow_route"), this, SLOT(OnFollowRoute()));
+    act->setToolTip(Tr("desktop_follow_route_tooltip"));
+    pToolBar->addAction(QIcon(":/navig64/clear-route.png"), Tr("desktop_clear_route"), this, SLOT(OnClearRoute()));
+    pToolBar->addAction(QIcon(":/navig64/settings-routing.png"), Tr("desktop_routing_settings"), this,
                         SLOT(OnRoutingSettings()));
 
     pToolBar->addSeparator();
 
-    m_pCreateFeatureAction =
-        pToolBar->addAction(QIcon(":/navig64/select.png"), tr("Create Feature"), this, SLOT(OnCreateFeatureClicked()));
+    m_pCreateFeatureAction = pToolBar->addAction(QIcon(":/navig64/select.png"), Tr("desktop_create_feature"), this,
+                                                 SLOT(OnCreateFeatureClicked()));
     m_pCreateFeatureAction->setCheckable(true);
-    m_pCreateFeatureAction->setToolTip(tr("Push to select position, next push to create Feature"));
+    m_pCreateFeatureAction->setToolTip(Tr("desktop_create_feature_tooltip"));
     m_pCreateFeatureAction->setShortcut(QKeySequence::New);
 
     pToolBar->addSeparator();
@@ -349,35 +351,36 @@ void MainWindow::CreateNavigationBar()
     m_selection = new PopupMenuHolder(this);
 
     // The order should be the same as in "enum class SelectionMode".
-    m_selection->addAction(QIcon(":/navig64/selectmode.png"), tr("Roads selection mode"),
+    m_selection->addAction(QIcon(":/navig64/selectmode.png"), Tr("desktop_roads_selection_mode"),
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::Features), true);
-    m_selection->addAction(QIcon(":/navig64/city_boundaries.png"), tr("City boundaries selection mode"),
+    m_selection->addAction(QIcon(":/navig64/city_boundaries.png"), Tr("desktop_city_boundaries_selection_mode"),
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityBoundaries), true);
-    m_selection->addAction(QIcon(":/navig64/city_roads.png"), tr("City roads selection mode"),
+    m_selection->addAction(QIcon(":/navig64/city_roads.png"), Tr("desktop_city_roads_selection_mode"),
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityRoads), true);
-    m_selection->addAction(QIcon(":/navig64/test.png"), tr("Cross MWM segments selection mode"),
+    m_selection->addAction(QIcon(":/navig64/test.png"), Tr("desktop_cross_mwm_segments_selection_mode"),
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CrossMwmSegments), true);
-    m_selection->addAction(QIcon(":/navig64/borders_selection.png"), tr("MWMs borders selection mode"), this,
+    m_selection->addAction(QIcon(":/navig64/borders_selection.png"), Tr("desktop_mwms_borders_selection_mode"), this,
                            SLOT(OnSwitchMwmsBordersSelectionMode()), true);
 
     toolBtn = m_selection->create();
-    toolBtn->setToolTip(tr("Select mode and use RMB to define selection box"));
+    toolBtn->setToolTip(Tr("desktop_selection_mode_tooltip"));
     pToolBar->addWidget(toolBtn);
 
-    pToolBar->addAction(QIcon(":/navig64/clear.png"), tr("Clear selection"), this, SLOT(OnClearSelection()));
+    pToolBar->addAction(QIcon(":/navig64/clear.png"), Tr("clear"), this, SLOT(OnClearSelection()));
 
     pToolBar->addSeparator();
 
 #endif  // NOT BUILD_DESIGNER
 
     // Add search button with "checked" behavior.
-    m_pSearchAction =
-        pToolBar->addAction(QIcon(":/navig64/search.png"), tr("Offline Search"), this, SLOT(OnSearchButtonClicked()));
+    m_pSearchAction = pToolBar->addAction(QIcon(":/navig64/search.png"), Tr("desktop_offline_search"), this,
+                                          SLOT(OnSearchButtonClicked()));
     m_pSearchAction->setCheckable(true);
     m_pSearchAction->setShortcut(QKeySequence::Find);
 
-    m_rulerAction = pToolBar->addAction(QIcon(":/navig64/ruler.png"), tr("Ruler"), this, SLOT(OnRulerEnabled()));
-    m_rulerAction->setToolTip(tr("Check this button and use ALT + LMB to set points"));
+    m_rulerAction =
+        pToolBar->addAction(QIcon(":/navig64/ruler.png"), Tr("desktop_ruler"), this, SLOT(OnRulerEnabled()));
+    m_rulerAction->setToolTip(Tr("desktop_ruler_tooltip"));
     m_rulerAction->setCheckable(true);
     m_rulerAction->setChecked(false);
 
@@ -386,7 +389,7 @@ void MainWindow::CreateNavigationBar()
     // add my position button with "checked" behavior
 
     m_pMyPositionAction =
-        pToolBar->addAction(QIcon(":/navig64/location.png"), tr("My Position"), this, SLOT(OnMyPosition()));
+        pToolBar->addAction(QIcon(":/navig64/location.png"), Tr("core_my_position"), this, SLOT(OnMyPosition()));
     m_pMyPositionAction->setCheckable(true);
 
 #ifdef BUILD_DESIGNER
@@ -394,40 +397,41 @@ void MainWindow::CreateNavigationBar()
     if (!m_mapcssFilePath.isEmpty())
     {
       m_pBuildStyleAction =
-          pToolBar->addAction(QIcon(":/navig64/run.png"), tr("Build style"), this, SLOT(OnBuildStyle()));
+          pToolBar->addAction(QIcon(":/navig64/run.png"), Tr("desktop_build_style"), this, SLOT(OnBuildStyle()));
       m_pBuildStyleAction->setCheckable(false);
-      m_pBuildStyleAction->setToolTip(tr("Build style"));
+      m_pBuildStyleAction->setToolTip(Tr("desktop_build_style"));
 
-      m_pRecalculateGeomIndex = pToolBar->addAction(QIcon(":/navig64/geom.png"), tr("Recalculate geometry index"), this,
-                                                    SLOT(OnRecalculateGeomIndex()));
+      m_pRecalculateGeomIndex = pToolBar->addAction(
+          QIcon(":/navig64/geom.png"), Tr("desktop_recalculate_geometry_index"), this, SLOT(OnRecalculateGeomIndex()));
       m_pRecalculateGeomIndex->setCheckable(false);
-      m_pRecalculateGeomIndex->setToolTip(tr("Recalculate geometry index"));
+      m_pRecalculateGeomIndex->setToolTip(Tr("desktop_recalculate_geometry_index"));
     }
 
     // Add "Debug style" button
     m_pDrawDebugRectAction =
-        pToolBar->addAction(QIcon(":/navig64/bug.png"), tr("Debug style"), this, SLOT(OnDebugStyle()));
+        pToolBar->addAction(QIcon(":/navig64/bug.png"), Tr("desktop_debug_style"), this, SLOT(OnDebugStyle()));
     m_pDrawDebugRectAction->setCheckable(true);
     m_pDrawDebugRectAction->setChecked(false);
-    m_pDrawDebugRectAction->setToolTip(tr("Debug style"));
+    m_pDrawDebugRectAction->setToolTip(Tr("desktop_debug_style"));
     m_pDrawWidget->GetFramework().EnableDebugRectRendering(false);
 
     // Add "Get statistics" button
     m_pGetStatisticsAction =
-        pToolBar->addAction(QIcon(":/navig64/chart.png"), tr("Get statistics"), this, SLOT(OnGetStatistics()));
+        pToolBar->addAction(QIcon(":/navig64/chart.png"), Tr("desktop_get_statistics"), this, SLOT(OnGetStatistics()));
     m_pGetStatisticsAction->setCheckable(false);
-    m_pGetStatisticsAction->setToolTip(tr("Get statistics"));
+    m_pGetStatisticsAction->setToolTip(Tr("desktop_get_statistics"));
 
     // Add "Run tests" button
-    m_pRunTestsAction = pToolBar->addAction(QIcon(":/navig64/test.png"), tr("Run tests"), this, SLOT(OnRunTests()));
+    m_pRunTestsAction =
+        pToolBar->addAction(QIcon(":/navig64/test.png"), Tr("desktop_run_tests"), this, SLOT(OnRunTests()));
     m_pRunTestsAction->setCheckable(false);
-    m_pRunTestsAction->setToolTip(tr("Run tests"));
+    m_pRunTestsAction->setToolTip(Tr("desktop_run_tests"));
 
     // Add "Build phone package" button
-    m_pBuildPhonePackAction = pToolBar->addAction(QIcon(":/navig64/phonepack.png"), tr("Build phone package"), this,
-                                                  SLOT(OnBuildPhonePackage()));
+    m_pBuildPhonePackAction = pToolBar->addAction(QIcon(":/navig64/phonepack.png"), Tr("desktop_build_phone_package"),
+                                                  this, SLOT(OnBuildPhonePackage()));
     m_pBuildPhonePackAction->setCheckable(false);
-    m_pBuildPhonePackAction->setToolTip(tr("Build phone package"));
+    m_pBuildPhonePackAction->setToolTip(Tr("desktop_build_phone_package"));
 #endif  // BUILD_DESIGNER
   }
 
@@ -436,7 +440,7 @@ void MainWindow::CreateNavigationBar()
 
 #ifndef NO_DOWNLOADER
   pToolBar->addSeparator();
-  pToolBar->addAction(QIcon(":/navig64/download.png"), tr("Download Maps"), this, SLOT(ShowUpdateDialog()));
+  pToolBar->addAction(QIcon(":/navig64/download.png"), Tr("download_maps"), this, SLOT(ShowUpdateDialog()));
 #endif  // NO_DOWNLOADER
 
   if (m_screenshotMode)
@@ -453,17 +457,17 @@ Framework & MainWindow::GetFramework() const
 void MainWindow::CreateCountryStatusControls()
 {
   QHBoxLayout * mainLayout = new QHBoxLayout();
-  m_downloadButton = CreateBlackControl<QPushButton>("Download");
+  m_downloadButton = CreateBlackControl<QPushButton>(Tr("download"));
   mainLayout->addWidget(m_downloadButton, 0, Qt::AlignHCenter);
   m_downloadButton->setVisible(false);
   connect(m_downloadButton, &QAbstractButton::released, this, &MainWindow::OnDownloadClicked);
 
-  m_retryButton = CreateBlackControl<QPushButton>("Retry downloading");
+  m_retryButton = CreateBlackControl<QPushButton>(Tr("desktop_retry_downloading"));
   mainLayout->addWidget(m_retryButton, 0, Qt::AlignHCenter);
   m_retryButton->setVisible(false);
   connect(m_retryButton, &QAbstractButton::released, this, &MainWindow::OnRetryDownloadClicked);
 
-  m_downloadingStatusLabel = CreateBlackControl<QLabel>("Downloading");
+  m_downloadingStatusLabel = CreateBlackControl<QLabel>(Tr("downloading"));
   mainLayout->addWidget(m_downloadingStatusLabel, 0, Qt::AlignHCenter);
   m_downloadingStatusLabel->setVisible(false);
 
@@ -817,7 +821,7 @@ void MainWindow::ShowUpdateDialog()
 
 void MainWindow::CreateSearchBarAndPanel()
 {
-  CreatePanelImpl(0, Qt::RightDockWidgetArea, tr("Search"), QKeySequence(), nullptr);
+  CreatePanelImpl(0, Qt::RightDockWidgetArea, Tr("search"), QKeySequence(), nullptr);
 
   m_Docks[0]->setWidget(new SearchPanel(m_pDrawWidget, m_Docks[0]));
 }

--- a/qt/mwms_borders_selection.cpp
+++ b/qt/mwms_borders_selection.cpp
@@ -1,4 +1,5 @@
 #include "qt/mwms_borders_selection.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "base/assert.hpp"
 
@@ -11,7 +12,7 @@ namespace qt
 {
 MwmsBordersSelection::MwmsBordersSelection(QWidget * parent) : QDialog(parent)
 {
-  setWindowTitle("Mwms borders selection settings");
+  setWindowTitle(Tr("desktop_mwms_borders_selection_settings"));
 
   auto * grid = new QGridLayout;
   grid->addWidget(CreateSourceChoosingGroup(), 0, 0);
@@ -79,8 +80,8 @@ QGroupBox * MwmsBordersSelection::CreateSourceChoosingGroup()
 {
   auto * groupBox = new QGroupBox();
 
-  m_radioBordersFromPackedPolygon = new QRadioButton(tr("Get borders from packed_polygon.bin"));
-  m_radioBordersFromData = new QRadioButton(tr("Get borders from *.poly files"));
+  m_radioBordersFromPackedPolygon = new QRadioButton(Tr("desktop_get_borders_from_packed_polygon"));
+  m_radioBordersFromData = new QRadioButton(Tr("desktop_get_borders_from_poly_files"));
 
   m_radioBordersFromPackedPolygon->setChecked(true);
 
@@ -97,9 +98,9 @@ QGroupBox * MwmsBordersSelection::CreateViewTypeGroup()
 {
   auto * groupBox = new QGroupBox();
 
-  m_radioWithPoints = new QRadioButton(tr("Show borders with vertices"));
-  m_radioJustBorders = new QRadioButton(tr("Show just borders"));
-  m_radioBoundingBox = new QRadioButton(tr("Show bounding box"));
+  m_radioWithPoints = new QRadioButton(Tr("desktop_show_borders_with_vertices"));
+  m_radioJustBorders = new QRadioButton(Tr("desktop_show_just_borders"));
+  m_radioBoundingBox = new QRadioButton(Tr("desktop_show_bounding_box"));
 
   m_radioWithPoints->setChecked(true);
 

--- a/qt/osm_auth_dialog.cpp
+++ b/qt/osm_auth_dialog.cpp
@@ -1,4 +1,5 @@
 #include "qt/osm_auth_dialog.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "editor/osm_auth.hpp"
 
@@ -16,7 +17,6 @@ namespace qt
 {
 char const * kTokenKeySetting = "OsmTokenKey";
 char const * kTokenSecretSetting = "OsmTokenSecret";
-char const * kLoginDialogTitle = "OpenStreetMap Login";
 char const * kOsmLoginSetting = "OsmLogin";
 char const * kOauthTokenSetting = "OsmOauthToken";
 
@@ -28,7 +28,7 @@ OsmAuthDialog::OsmAuthDialog(QWidget * parent)
   QVBoxLayout * vLayout = new QVBoxLayout(parent);
 
   QHBoxLayout * loginRow = new QHBoxLayout();
-  loginRow->addWidget(new QLabel(tr("Username/email:")));
+  loginRow->addWidget(new QLabel(Tr("email_or_username") + ":"));
   QLineEdit * loginLineEdit = new QLineEdit();
   loginLineEdit->setObjectName("login");
   if (!isLoginDialog)
@@ -39,7 +39,7 @@ OsmAuthDialog::OsmAuthDialog(QWidget * parent)
   vLayout->addLayout(loginRow);
 
   QHBoxLayout * passwordRow = new QHBoxLayout();
-  passwordRow->addWidget(new QLabel(tr("Password:")));
+  passwordRow->addWidget(new QLabel(Tr("password") + ":"));
   QLineEdit * passwordLineEdit = new QLineEdit();
   passwordLineEdit->setEchoMode(QLineEdit::Password);
   passwordLineEdit->setObjectName("password");
@@ -48,12 +48,12 @@ OsmAuthDialog::OsmAuthDialog(QWidget * parent)
   passwordRow->addWidget(passwordLineEdit);
   vLayout->addLayout(passwordRow);
 
-  QPushButton * actionButton = new QPushButton(isLoginDialog ? tr("Login") : tr("Logout"));
+  QPushButton * actionButton = new QPushButton(isLoginDialog ? Tr("login") : Tr("logout"));
   actionButton->setObjectName("button");
   actionButton->setDefault(true);
   connect(actionButton, &QAbstractButton::clicked, this, &OsmAuthDialog::OnAction);
 
-  QPushButton * closeButton = new QPushButton(tr("Close"));
+  QPushButton * closeButton = new QPushButton(Tr("close"));
   connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
 
   QHBoxLayout * buttonsLayout = new QHBoxLayout();
@@ -62,7 +62,7 @@ OsmAuthDialog::OsmAuthDialog(QWidget * parent)
   vLayout->addLayout(buttonsLayout);
 
   setLayout(vLayout);
-  setWindowTitle(tr(kLoginDialogTitle));
+  setWindowTitle(Tr("login_osm"));
 }
 
 OsmAuthDialog::~OsmAuthDialog()
@@ -75,21 +75,21 @@ void SwitchToLogin(QDialog * dlg)
 {
   dlg->findChild<QLineEdit *>("login")->setEnabled(true);
   dlg->findChild<QLineEdit *>("password")->setEnabled(true);
-  dlg->findChild<QPushButton *>("button")->setText(dlg->tr("Login"));
+  dlg->findChild<QPushButton *>("button")->setText(Tr("login"));
 }
 
 void SwitchToLogout(QDialog * dlg)
 {
   dlg->findChild<QLineEdit *>("login")->setEnabled(false);
   dlg->findChild<QLineEdit *>("password")->setEnabled(false);
-  dlg->findChild<QPushButton *>("button")->setText(dlg->tr("Logout"));
-  dlg->setWindowTitle(dlg->tr(kLoginDialogTitle));
+  dlg->findChild<QPushButton *>("button")->setText(Tr("logout"));
+  dlg->setWindowTitle(Tr("login_osm"));
 }
 
 void OsmAuthDialog::OnAction()
 {
   auto actionButton = findChild<QPushButton *>("button");
-  bool const isLoginDialog = actionButton->text() == tr("Login");
+  bool const isLoginDialog = actionButton->text() == Tr("login");
   if (!isLoginDialog)
   {
     settings::Set(kOauthTokenSetting, std::string());
@@ -102,7 +102,7 @@ void OsmAuthDialog::OnAction()
 
   if (login.empty())
   {
-    setWindowTitle("Please enter Login");
+    setWindowTitle(Tr("desktop_enter_login"));
     return;
   }
 
@@ -110,7 +110,7 @@ void OsmAuthDialog::OnAction()
 
   if (password.empty())
   {
-    setWindowTitle("Please enter Password");
+    setWindowTitle(Tr("desktop_enter_password"));
     return;
   }
 
@@ -134,12 +134,12 @@ void OsmAuthDialog::OnAction()
         runOnMainThread = [this]() { SwitchToLogout(this); };
       }
       else
-        runOnMainThread = [this]() { setWindowTitle("Auth failed: invalid login or password"); };
+        runOnMainThread = [this]() { setWindowTitle(Tr("desktop_auth_failed_invalid_login_or_password")); };
     }
     catch (std::exception const & ex)
     {
-      auto const title = std::string("Auth failed: ") + ex.what();
-      runOnMainThread = [this, title]() { setWindowTitle(title.c_str()); };
+      auto const title = Tr("desktop_auth_failed").arg(ex.what());
+      runOnMainThread = [this, title]() { setWindowTitle(title); };
     }
     QMetaObject::invokeMethod(this, [actionButton, runOnMainThread = std::move(runOnMainThread)]()
     {

--- a/qt/place_page_dialog_common.cpp
+++ b/qt/place_page_dialog_common.cpp
@@ -1,4 +1,5 @@
 #include "qt/place_page_dialog_common.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include <QtWidgets/QPushButton>
 
@@ -8,32 +9,32 @@ void addCommonButtons(QDialog * this_, QDialogButtonBox * dbb, bool shouldShowEd
 {
   dbb->setCenterButtons(true);
 
-  QPushButton * fromButton = new QPushButton("Route From");
+  QPushButton * fromButton = new QPushButton(qt::Tr("p2p_from_here"));
   fromButton->setIcon(QIcon(":/navig64/point-start.png"));
   fromButton->setAutoDefault(false);
   this_->connect(fromButton, &QAbstractButton::clicked, this_, [this_] { this_->done(RouteFrom); });
   dbb->addButton(fromButton, QDialogButtonBox::ActionRole);
 
-  QPushButton * addStopButton = new QPushButton("Add Stop");
+  QPushButton * addStopButton = new QPushButton(qt::Tr("placepage_add_stop"));
   addStopButton->setIcon(QIcon(":/navig64/point-intermediate.png"));
   addStopButton->setAutoDefault(false);
   this_->connect(addStopButton, &QAbstractButton::clicked, this_, [this_] { this_->done(AddStop); });
   dbb->addButton(addStopButton, QDialogButtonBox::ActionRole);
 
-  QPushButton * routeToButton = new QPushButton("Route To");
+  QPushButton * routeToButton = new QPushButton(qt::Tr("p2p_to_here"));
   routeToButton->setIcon(QIcon(":/navig64/point-finish.png"));
   routeToButton->setAutoDefault(false);
   this_->connect(routeToButton, &QAbstractButton::clicked, this_, [this_] { this_->done(RouteTo); });
   dbb->addButton(routeToButton, QDialogButtonBox::ActionRole);
 
-  QPushButton * closeButton = new QPushButton("Close");
+  QPushButton * closeButton = new QPushButton(qt::Tr("close"));
   closeButton->setDefault(true);
   this_->connect(closeButton, &QAbstractButton::clicked, this_, [this_] { this_->done(place_page_dialog::Close); });
   dbb->addButton(closeButton, QDialogButtonBox::RejectRole);
 
   if (shouldShowEditPlace)
   {
-    QPushButton * editButton = new QPushButton("Edit Place");
+    QPushButton * editButton = new QPushButton(qt::Tr("edit_place"));
     this_->connect(editButton, &QAbstractButton::clicked, this_,
                    [this_] { this_->done(place_page_dialog::EditPlace); });
     dbb->addButton(editButton, QDialogButtonBox::AcceptRole);

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -2,6 +2,7 @@
 #include "qt/place_page_dialog_common.hpp"
 
 #include "qt/qt_common/text_dialog.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "indexer/validate_and_format_contacts.hpp"
 #include "map/place_page_info.hpp"
@@ -113,16 +114,17 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     };
 
     if (info.IsBookmark())
-      addEntry("Bookmark", "Yes");
+      addEntry("Bookmark", qt::Tr("yes").toStdString());
 
     // Wikipedia fragment
     if (auto const & wikipedia = info.GetMetadata(feature::Metadata::EType::FMD_WIKIPEDIA); !wikipedia.empty())
     {
-      QLabel * name = new QLabel("Wikipedia");
+      QString const wikipediaLabel = qt::Tr("read_in_wikipedia");
+      QLabel * name = new QLabel(wikipediaLabel);
       name->setOpenExternalLinks(true);
       name->setTextInteractionFlags(Qt::TextBrowserInteraction);
-      name->setText(QString::fromStdString("<a href=\"" + feature::Metadata::ToWikiURL(std::string(wikipedia)) +
-                                           "\">Wikipedia</a>"));
+      name->setText(QString::fromStdString("<a href=\"" + feature::Metadata::ToWikiURL(std::string(wikipedia)) + "\">" +
+                                           wikipediaLabel.toStdString() + "</a>"));
       data->addWidget(name, row++, 0);
     }
 
@@ -136,7 +138,7 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
       data->addWidget(value, row++, 0, 1, 2);
 
-      QPushButton * wikiButton = new QPushButton("More...", value);
+      QPushButton * wikiButton = new QPushButton(qt::Tr("placepage_more_button") + "…", value);
       wikiButton->setAutoDefault(false);
       connect(wikiButton, &QAbstractButton::clicked, this, [this, description, title]()
       {
@@ -152,15 +154,15 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     /// a non-modal floating/dockable window.
     // Route refs
     if (auto routes = info.FormatRouteRefs(); !routes.empty())
-      addEntry("Routes", routes);
+      addEntry(qt::Tr("desktop_place_routes").toStdString(), routes);
 
     // Opening hours fragment
     if (auto openingHours = info.GetOpeningHours(); !openingHours.empty())
-      addEntry("Opening hours", std::string(openingHours));
+      addEntry(qt::Tr("desktop_place_opening_hours").toStdString(), std::string(openingHours));
 
     // Cuisine fragment
     if (auto cuisines = info.FormatCuisines(); !cuisines.empty())
-      addEntry("Cuisine", cuisines);
+      addEntry(qt::Tr("cuisine").toStdString(), cuisines);
 
     // Entrance fragment
     // TODO
@@ -168,7 +170,7 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     // Phone fragment
     if (auto phoneNumber = info.GetMetadata(feature::Metadata::EType::FMD_PHONE_NUMBER); !phoneNumber.empty())
     {
-      data->addWidget(new QLabel("Phone"), row, 0);
+      data->addWidget(new QLabel(qt::Tr("phone")), row, 0);
 
       QLabel * value = new QLabel(QString::fromStdString("<a href='tel:" + std::string(phoneNumber) + "'>" +
                                                          std::string(phoneNumber) + "</a>"));
@@ -179,19 +181,19 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
     // Operator fragment
     if (auto operatorName = info.GetMetadata(feature::Metadata::EType::FMD_OPERATOR); !operatorName.empty())
-      addEntry("Operator", std::string(operatorName));
+      addEntry(qt::Tr("editor_operator").toStdString(), std::string(operatorName));
 
     // Wifi fragment
     if (info.HasWifi())
-      addEntry("Wi-Fi", "Yes");
+      addEntry(qt::Tr("category_wifi").toStdString(), qt::Tr("yes").toStdString());
 
     // Links fragment
     if (auto website = info.GetMetadata(feature::Metadata::EType::FMD_WEBSITE); !website.empty())
-      addEntry("Website", std::string(stripSchemeFromURI(website)), true);
+      addEntry(qt::Tr("website").toStdString(), std::string(stripSchemeFromURI(website)), true);
 
     if (auto email = info.GetMetadata(feature::Metadata::EType::FMD_EMAIL); !email.empty())
     {
-      data->addWidget(new QLabel("Email"), row, 0);
+      data->addWidget(new QLabel(qt::Tr("email")), row, 0);
 
       QLabel * value = new QLabel(
           QString::fromStdString("<a href='mailto:" + std::string(email) + "'>" + std::string(email) + "</a>"));
@@ -227,11 +229,12 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     if (auto wikimedia_commons = info.GetMetadata(feature::Metadata::EType::FMD_WIKIMEDIA_COMMONS);
         !wikimedia_commons.empty())
     {
-      data->addWidget(new QLabel("Wikimedia Commons"), row, 0);
+      QString const commonsLabel = qt::Tr("wikimedia_commons");
+      data->addWidget(new QLabel(commonsLabel), row, 0);
 
       QLabel * value = new QLabel(QString::fromStdString(
-          "<a href='" + feature::Metadata::ToWikimediaCommonsURL(std::string(wikimedia_commons)) +
-          "'>Wikimedia Commons</a>"));
+          "<a href='" + feature::Metadata::ToWikimediaCommonsURL(std::string(wikimedia_commons)) + "'>" +
+          commonsLabel.toStdString() + "</a>"));
       value->setOpenExternalLinks(true);
       value->setTextInteractionFlags(Qt::TextBrowserInteraction);
 
@@ -240,17 +243,18 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
     // Level fragment
     if (auto level = info.GetMetadata(feature::Metadata::EType::FMD_LEVEL); !level.empty())
-      addEntry("Level", std::string(level));
+      addEntry(qt::Tr("level").toStdString(), std::string(level));
 
     // ATM fragment
     if (info.HasAtm())
-      addEntry("ATM", "Yes");
+      addEntry(qt::Tr("category_atm").toStdString(), qt::Tr("yes").toStdString());
 
     // Latlon fragment
 
     {
       ms::LatLon const ll = info.GetLatLon();
-      addEntry("Coordinates", strings::to_string_dac(ll.m_lat, 7) + ", " + strings::to_string_dac(ll.m_lon, 7));
+      addEntry(qt::Tr("desktop_place_coordinates").toStdString(),
+               strings::to_string_dac(ll.m_lat, 7) + ", " + strings::to_string_dac(ll.m_lon, 7));
     }
 
     data->setColumnStretch(0, 0);
@@ -274,6 +278,5 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
   setLayout(layout);
 
-  auto const ppTitle = std::string("Place Page") + (info.IsBookmark() ? " (bookmarked)" : "");
-  setWindowTitle(ppTitle.c_str());
+  setWindowTitle(info.IsBookmark() ? qt::Tr("desktop_place_page_bookmarked") : qt::Tr("desktop_place_page"));
 }

--- a/qt/preferences_dialog.cpp
+++ b/qt/preferences_dialog.cpp
@@ -10,6 +10,7 @@
 #include "platform/style_utils.hpp"
 
 #include "qt/qt_common/helpers.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include <QLocale>
 #include <QtGui/QIcon>
@@ -36,18 +37,18 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
 {
   QIcon icon(":/ui/logo.png");
   setWindowIcon(icon);
-  setWindowTitle(tr("Preferences"));
+  setWindowTitle(Tr("desktop_preferences"));
 
   QButtonGroup * unitsGroup = new QButtonGroup(this);
-  QGroupBox * unitsRadioBox = new QGroupBox("System of measurement");
+  QGroupBox * unitsRadioBox = new QGroupBox(Tr("desktop_system_of_measurement"));
   {
     QHBoxLayout * layout = new QHBoxLayout();
 
-    QRadioButton * radioButton = new QRadioButton("Metric");
+    QRadioButton * radioButton = new QRadioButton(Tr("desktop_metric"));
     layout->addWidget(radioButton);
     unitsGroup->addButton(radioButton, static_cast<int>(Units::Metric));
 
-    radioButton = new QRadioButton("Imperial (foot)");
+    radioButton = new QRadioButton(Tr("desktop_imperial_foot"));
     layout->addWidget(radioButton);
     unitsGroup->addButton(radioButton, static_cast<int>(Units::Imperial));
 
@@ -80,14 +81,14 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
     });
   }
 
-  QCheckBox * largeFontCheckBox = new QCheckBox("Use larger font on the map");
+  QCheckBox * largeFontCheckBox = new QCheckBox(Tr("desktop_use_larger_font_on_map"));
   {
     largeFontCheckBox->setChecked(framework.LoadLargeFontsSize());
     connect(largeFontCheckBox, &QCheckBox::stateChanged,
             [&framework](int i) { framework.SetLargeFontsSize(static_cast<bool>(i)); });
   }
 
-  QCheckBox * transliterationCheckBox = new QCheckBox("Transliterate to Latin");
+  QCheckBox * transliterationCheckBox = new QCheckBox(Tr("desktop_transliterate_to_latin"));
   {
     transliterationCheckBox->setChecked(framework.LoadTransliteration());
     connect(transliterationCheckBox, &QCheckBox::stateChanged, [&framework](int i)
@@ -98,7 +99,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
     });
   }
 
-  QCheckBox * developerModeCheckBox = new QCheckBox("Developer Mode");
+  QCheckBox * developerModeCheckBox = new QCheckBox(Tr("desktop_developer_mode"));
   {
     bool developerMode;
     if (settings::Get(settings::kDeveloperMode, developerMode) && developerMode)
@@ -107,7 +108,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
             [](int i) { settings::Set(settings::kDeveloperMode, static_cast<bool>(i)); });
   }
 
-  QLabel * mapLanguageLabel = new QLabel("Map Language");
+  QLabel * mapLanguageLabel = new QLabel(Tr("change_map_locale"));
   QComboBox * mapLanguageComboBox = new QComboBox();
   {
     // The property maxVisibleItems is ignored for non-editable comboboxes in styles that
@@ -136,25 +137,22 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
     });
   }
 
-  QLabel * bookmarksPlacementLabel = new QLabel("Bookmark's text placement");
+  QLabel * bookmarksPlacementLabel = new QLabel(Tr("bookmarks_text_placement_title"));
   QComboBox * bookmarksPlacementCB = new QComboBox();
   {
     using settings::Placement;
 
-    QStringList lst;
-    for (int i = 0; i < static_cast<int>(Placement::Count); ++i)
-      lst << QString::fromStdString(ToString(static_cast<Placement>(i)));
-
-    bookmarksPlacementCB->addItems(lst);
-
-    bookmarksPlacementCB->setCurrentText(QString::fromStdString(ToString(Framework::GetBookmarksTextPlacement())));
+    bookmarksPlacementCB->addItem(Tr("off"));
+    bookmarksPlacementCB->addItem(Tr("show_to_the_right"));
+    bookmarksPlacementCB->addItem(Tr("show_at_the_bottom"));
+    bookmarksPlacementCB->setCurrentIndex(static_cast<int>(Framework::GetBookmarksTextPlacement()));
 
     connect(bookmarksPlacementCB, &QComboBox::activated,
             [&framework](int index) { framework.SetBookmarksTextPlacement(static_cast<Placement>(index)); });
   }
 
   QButtonGroup * nightModeGroup = new QButtonGroup(this);
-  QGroupBox * nightModeRadioBox = new QGroupBox("Night Mode");
+  QGroupBox * nightModeRadioBox = new QGroupBox(Tr("desktop_night_mode"));
   {
     using namespace style_utils;
     QHBoxLayout * layout = new QHBoxLayout();
@@ -166,9 +164,9 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
       nightModeGroup->addButton(button, static_cast<int>(mode));
     };
 
-    addButton("Off", NightMode::Off);
-    addButton("On", NightMode::On);
-    addButton(tr("Follow system"), NightMode::System);
+    addButton(Tr("off"), NightMode::Off);
+    addButton(Tr("on"), NightMode::On);
+    addButton(Tr("follow_system"), NightMode::System);
 
     nightModeRadioBox->setLayout(layout);
 
@@ -200,7 +198,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
   }
 
 #ifdef BUILD_DESIGNER
-  QCheckBox * indexRegenCheckBox = new QCheckBox("Enable auto regeneration of geometry index");
+  QCheckBox * indexRegenCheckBox = new QCheckBox(Tr("desktop_enable_auto_regeneration_geometry_index"));
   {
     bool enabled = false;
     if (!settings::Get(kEnabledAutoRegenGeomIndex, enabled))
@@ -213,7 +211,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent, Framework & framework)
 
   QHBoxLayout * bottomLayout = new QHBoxLayout();
   {
-    QPushButton * closeButton = new QPushButton(tr("Close"));
+    QPushButton * closeButton = new QPushButton(Tr("close"));
     closeButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     closeButton->setDefault(true);
     connect(closeButton, &QAbstractButton::clicked, [this]() { done(0); });

--- a/qt/qt_common/CMakeLists.txt
+++ b/qt/qt_common/CMakeLists.txt
@@ -21,6 +21,8 @@ set(SRC
   spinner.hpp
   text_dialog.cpp
   text_dialog.hpp
+  translations.cpp
+  translations.hpp
 )
 
 omim_add_library(${PROJECT_NAME} ${SRC} ${RESOURCES})

--- a/qt/qt_common/scale_slider.cpp
+++ b/qt/qt_common/scale_slider.cpp
@@ -2,6 +2,7 @@
 
 #include "qt/qt_common/map_widget.hpp"
 #include "qt/qt_common/proxy_style.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "indexer/scales.hpp"
 
@@ -43,13 +44,13 @@ ScaleSlider::ScaleSlider(Qt::Orientation orient, QWidget * parent) : QSlider(ori
 // static
 void ScaleSlider::Embed(Qt::Orientation orient, QToolBar & toolBar, MapWidget & mapWidget)
 {
-  toolBar.addAction(QIcon(":/common/plus.png"), tr("Scale +"), &mapWidget, SLOT(ScalePlus()));
+  toolBar.addAction(QIcon(":/common/plus.png"), qt::Tr("zoom_in"), &mapWidget, SLOT(ScalePlus()));
   {
     auto slider = std::make_unique<ScaleSlider>(orient, &toolBar);
     mapWidget.BindSlider(*slider);
     toolBar.addWidget(slider.release());
   }
-  toolBar.addAction(QIcon(":/common/minus.png"), tr("Scale -"), &mapWidget, SLOT(ScaleMinus()));
+  toolBar.addAction(QIcon(":/common/minus.png"), qt::Tr("zoom_out"), &mapWidget, SLOT(ScaleMinus()));
 }
 
 double ScaleSlider::GetScaleFactor() const

--- a/qt/qt_common/text_dialog.cpp
+++ b/qt/qt_common/text_dialog.cpp
@@ -1,4 +1,5 @@
 #include "qt/qt_common/text_dialog.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QPushButton>
@@ -11,7 +12,7 @@ TextDialog::TextDialog(QWidget * parent, QString const & htmlOrText, QString con
   textEdit->setReadOnly(true);
   textEdit->setHtml(htmlOrText);
 
-  auto * closeButton = new QPushButton("Close");
+  auto * closeButton = new QPushButton(qt::Tr("close"));
   closeButton->setDefault(true);
   connect(closeButton, &QAbstractButton::clicked, this, &TextDialog::OnClose);
 

--- a/qt/qt_common/translations.cpp
+++ b/qt/qt_common/translations.cpp
@@ -1,0 +1,111 @@
+#include "qt/qt_common/translations.hpp"
+
+#include "platform/platform.hpp"
+#include "platform/preferred_languages.hpp"
+
+#include "base/logging.hpp"
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDir>
+#include <QtCore/QTranslator>
+
+#include <algorithm>
+#include <cctype>
+#include <vector>
+
+namespace qt
+{
+namespace
+{
+std::string NormalizeLocale(std::string locale)
+{
+  std::replace(locale.begin(), locale.end(), '_', '-');
+  return locale;
+}
+
+std::string ToLowerAscii(std::string value)
+{
+  for (char & c : value)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return value;
+}
+
+std::string GetBaseLocale(std::string locale)
+{
+  auto const pos = locale.find_first_of("-_ ");
+  if (pos != std::string::npos)
+    locale.resize(pos);
+  return NormalizeLocale(std::move(locale));
+}
+
+std::string GetTwineLocale(std::string const & locale)
+{
+  auto const lower = ToLowerAscii(locale);
+  if (lower.starts_with("zh"))
+  {
+    for (char const * s : {"hant", "tw", "hk", "mo"})
+      if (lower.find(s) != std::string::npos)
+        return "zh-Hant";
+    return "zh-Hans";
+  }
+
+  return GetBaseLocale(locale);
+}
+
+void AddLocale(std::vector<std::string> & locales, std::string locale)
+{
+  locale = NormalizeLocale(std::move(locale));
+  if (!locale.empty() && std::find(locales.begin(), locales.end(), locale) == locales.end())
+    locales.emplace_back(std::move(locale));
+}
+
+std::vector<std::string> GetLocaleCandidates(std::string const & locale)
+{
+  std::vector<std::string> locales;
+  AddLocale(locales, locale);
+  AddLocale(locales, GetTwineLocale(locale));
+  AddLocale(locales, languages::GetCurrentOrig());
+  AddLocale(locales, languages::GetCurrentTwine());
+  AddLocale(locales, "en");
+  return locales;
+}
+
+QStringList GetTranslationDirs()
+{
+  QString const appDir = QCoreApplication::applicationDirPath();
+
+  return {
+      QDir(appDir).filePath("translations"),
+      QDir(appDir).filePath("../Resources/translations"),
+      QDir(QString::fromStdString(GetPlatform().ResourcesDir())).filePath("translations"),
+  };
+}
+}  // namespace
+
+std::unique_ptr<QTranslator> InstallTranslator(QCoreApplication & app, std::string const & locale)
+{
+  auto translator = std::make_unique<QTranslator>();
+  for (auto const & language : GetLocaleCandidates(locale))
+  {
+    QString const fileName = QString("omim_%1.qm").arg(QString::fromStdString(language));
+    for (QString const & dir : GetTranslationDirs())
+    {
+      QString const path = QDir(dir).filePath(fileName);
+      if (translator->load(path))
+      {
+        app.installTranslator(translator.get());
+        LOG(LINFO, ("Loaded Qt translation", path.toStdString()));
+        return translator;
+      }
+    }
+  }
+
+  LOG(LWARNING, ("Failed to load Qt translation for locale", locale));
+  return {};
+}
+
+QString Tr(char const * id, int n)
+{
+  return qtTrId(id, n);
+}
+}  // namespace qt

--- a/qt/qt_common/translations.hpp
+++ b/qt/qt_common/translations.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QtCore/QString>
+#include <QtCore/QTranslator>
+
+#include <memory>
+#include <string>
+
+class QCoreApplication;
+
+namespace qt
+{
+std::unique_ptr<QTranslator> InstallTranslator(QCoreApplication & app, std::string const & locale);
+QString Tr(char const * id, int n = -1);
+}  // namespace qt

--- a/qt/routing_settings_dialog.cpp
+++ b/qt/routing_settings_dialog.cpp
@@ -1,5 +1,7 @@
 #include "qt/routing_settings_dialog.hpp"
 
+#include "qt/qt_common/translations.hpp"
+
 #include "map/framework.hpp"
 
 #include "routing/router.hpp"
@@ -101,7 +103,7 @@ RoutingSettings::RoutingSettings(QWidget * parent, Framework & framework, kml::T
   : QDialog(parent)
   , m_framework(framework)
 {
-  setWindowTitle("Routing settings");
+  setWindowTitle(Tr("desktop_routing_settings"));
   QVBoxLayout * layout = new QVBoxLayout(this);
 
   {

--- a/qt/search_panel.cpp
+++ b/qt/search_panel.cpp
@@ -1,5 +1,6 @@
 #include "qt/search_panel.hpp"
 #include "qt/draw_widget.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "search/search_params.hpp"
 
@@ -56,10 +57,10 @@ SearchPanel::SearchPanel(DrawWidget * drawWidget, QWidget * parent)
   QButtonGroup * searchModeButtons = new QButtonGroup(this);
   QGroupBox * groupBox = new QGroupBox();
   QHBoxLayout * modeLayout = new QHBoxLayout();
-  QRadioButton * buttonE = new QRadioButton(tr("Everywhere"));
+  QRadioButton * buttonE = new QRadioButton(Tr("desktop_search_everywhere"));
   modeLayout->addWidget(buttonE);
   searchModeButtons->addButton(buttonE, static_cast<int>(search::Mode::Everywhere));
-  QRadioButton * buttonV = new QRadioButton(tr("Viewport"));
+  QRadioButton * buttonV = new QRadioButton(Tr("desktop_search_viewport"));
   modeLayout->addWidget(buttonV);
   searchModeButtons->addButton(buttonV, static_cast<int>(search::Mode::Viewport));
   groupBox->setLayout(modeLayout);
@@ -67,7 +68,7 @@ SearchPanel::SearchPanel(DrawWidget * drawWidget, QWidget * parent)
   searchModeButtons->button(static_cast<int>(search::Mode::Everywhere))->setChecked(true);
   connect(searchModeButtons, SIGNAL(idClicked(int)), this, SLOT(OnSearchModeChanged(int)));
 
-  m_isCategory = new QCheckBox(tr("Category request"));
+  m_isCategory = new QCheckBox(Tr("desktop_category_request"));
   m_isCategory->setCheckState(Qt::Unchecked);
   connect(m_isCategory, &QCheckBox::stateChanged, std::bind(&SearchPanel::RunSearch, this));
 

--- a/qt/strict_lrelease.cmake
+++ b/qt/strict_lrelease.cmake
@@ -1,0 +1,38 @@
+# Wrapper around lrelease that fails the build on warnings or unfinished
+# translations. lrelease lacks a -Werror flag, so we run it via
+# execute_process and inspect the output ourselves.
+#
+# Required variables: LRELEASE, TS, QM.
+
+execute_process(
+  COMMAND "${LRELEASE}" "${TS}" -qm "${QM}"
+  RESULT_VARIABLE _result
+  OUTPUT_VARIABLE _output
+  ERROR_VARIABLE _error_output
+)
+
+# Forward lrelease's stdout/stderr to the build log so users still see progress.
+if(_output)
+  message(STATUS "${_output}")
+endif()
+if(_error_output)
+  message(STATUS "${_error_output}")
+endif()
+
+if(NOT _result EQUAL 0)
+  message(FATAL_ERROR "lrelease failed for ${TS} (exit ${_result})")
+endif()
+
+set(_combined "${_output}\n${_error_output}")
+
+# Any explicit Warning: line is a failure.
+if(_combined MATCHES "Warning:")
+  message(FATAL_ERROR "lrelease emitted a warning for ${TS}:\n${_combined}")
+endif()
+
+# The summary line looks like "Generated 861 translation(s) (861 finished and 0 unfinished)".
+# A non-zero unfinished count means a message escaped the --include all
+# fallback, which signals broken upstream data.
+if(NOT _combined MATCHES "0 unfinished")
+  message(FATAL_ERROR "lrelease reported unfinished translations for ${TS}:\n${_combined}")
+endif()

--- a/qt/translations/af/omim.ts
+++ b/qt/translations/af/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="af">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Terug</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Kanselleer</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Skrap</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Laai kaarte af</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Aflaai het misluk. Tik om weer te probeer.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Laai tans af…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Myle</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Soek</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Soek op die kaart</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Alle liggingsdienste vir hierdie toestel of toepassing is tans gedeaktiveer. Aktiveer dit asb. in Instellings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Beperkte akkuraatheid</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Om &#x27;n akkurate navigasie te verseker, maak dit &#x27;n presiese ligging in instellings moontlik.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Toon op die kaart</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Aflaai het misluk</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Probeer weer</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Oor Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis vir almal, gemaak met liefde</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Geen advertensies, geen nasporing, geen dataversameling</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Geen battery dreineer, werk vanlyn</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Vinnig, minimalisties, ontwikkel deur die gemeenskap</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Oopbrontoepassing geskep deur entoesiaste en vrywilligers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Liggingsinstellings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Sluit</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>’n Apparatuurversnelde OpenGL is nodig vir die toep. U toestel word ongelukkig nie gesteun nie.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Laai af</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Ontkoppel die USB-kabel of gebruik ’n geheuekaart om Organic Maps te gebruik</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Maak asb. eers spasie op die SD-kaart/USB-berging beskikbaar om die kaart te kan gebruik</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Voordat u die toep begin gebruik, moet u asb. die algemene wêreldkaart na u toestel aflaai.
+Dit sal %1 se spasie opneem.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Gaan na kaart</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Laai tans %1 af. U kan nou
+na die kaart gaan.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Laai %1 af?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Werk %1 by?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Wag</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Gaan voort</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Aflaai van %1 het misluk</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Voeg ’n nuwe lys toe</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Boekmerklysnaam</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Boekmerke</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Boekmerke en paaie</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Adres</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adres</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lys</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Instellings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Bewaar kaarte in</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Kies die vouer om kaarte na af te laai.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Afgelaaide kaarte</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 van %2 beskikbaar</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Skuif kaarte?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Fout by die skuig van kaartlêers</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Dit kan etlike minute duur.
+Wag asb.…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Afstandseenhede</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Kies tussen myle en kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Kanselleer aflaai</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Skryf ’n resensie</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Laai die kaart af</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Boekmerklyste</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Waar om te eet</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Kruideniersware</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Vervoer</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Brandstof</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkering</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Inkopies</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Tweedehandse</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Besienswaardighede</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Vermaak</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>OTM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Naglewe</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Gesinsvakansie</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apteek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospitaal</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pos</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polisie</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Herwinning</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Karavaanfasiliteite</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notas</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps-boekmerke is met u gedeel</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hallo!
+
+My boekmerke is aangeheg; open dit asb. in Organic Maps. Indien dit nie geïnstalleer is nie, kan u dit hier aflaai: https://omaps.app/get?kmz
+
+Geniet dit om met Organic Maps te reis!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Laai tans boekmerke</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Boekmerke is suksesvol gelaai! U kan dit op die kaart of op die boekmerkbestuurderskerm vind.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Kon nie boekmerke laai nie. Die lêer is dalk gekorrupteer of defektief.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Die lêertipe word nie deur die toepassing herken nie:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Kon nie lêer oopmaak nie %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Wysig</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>U ligging is nog nie vasgestel nie</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Jammer, Kaartbergingsinstellings is tans gedeaktiveer.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Die kaart word tans afgelaai.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Kyk my huidige posisie in Organic Maps! %1 of %2 Het u nie vanlyn kaarte nie? Laai hier af: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hallo, kyk my liggingmerker in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hallo, sien my huidige ligging op die Organic Maps-toep!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Dagsê,
+
+Ek is nou hier: %1. Klik op die skakel %2 of hierdie een %3 om die plek op die kaart te sien.
+
+Dankie.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Deel</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-pos</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Na knipbord gekopieer: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Gereed</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Is jy seker jy wil by jou OpenStreetMap-rekening afmeld?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Paaie</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lengte</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Deel my ligging</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Algemene instellings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Inligting</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigasie</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Knoppies + en - op die kaart</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Vertoon op die kaart</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nagstyl wanneer in die donker genavigeer word</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nagmodus</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Af</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Aan</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Outomaties</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektiefaansig</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-geboue</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-geboue is gedeaktiveer in batterybesparingsmodus</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Steminstruksies</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Kondig straatname aan</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Wanneer dit geaktiveer is, sal die naam van die straat of die uitgang waarop jy moet afdraai, hardop uitgespreek word.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Stemtaal</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Om &#x27;n stem van hoër gehalte af te laai, maak die Instellings-toep oop en gaan na Toeganklikheid → VoiceOver → Spraak → Stem.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Toets Stemmingsaanwysings (TTS, Teks-na-spraak)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kontroleer die volume of die stelsel se Teks-na-Spreek-instellings as jy nou nie die stem hoor nie.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nie beskikbaar</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Outomatiese zoem</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Afstand</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Bekyk op kaart</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Kieslys</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webwerf</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nuus</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Terugvoer</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Gradeer die toep</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Gereelde vrae</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Skenk</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Reeds geskenk</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Herinner later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Ondersteun Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Ondersteun die projek</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Kopiereg</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Rapporteer ’n fout</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Verbeter die pylrigting deur die selfoon in ’n agtbeweging te beweeg om die kompas te kalibreer.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Beweeg die selfoon in ’n agtvormige beweging om die kompas te kalibreer en die rigting van die pyl op die kaart vas te maak.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Langtik weer op die kaart om die koppelvlak te sien</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Werk alles by</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Kanselleer aflaai</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Afgelaai</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>In wagry</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Naby my</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kaarte</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Laai alles af</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Laai tans af:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Stop die navigasie om die kaart te skrap.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Slegs die roetes wat in hul geheel in ’n kaart is van ’n enkele streek is, kan geskep word.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Laai kaart af</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Probeer weer</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Skrap kaart</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Werk kaart by</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Liggingdienste</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bepaal vinnig jou benaderde ligging met behulp van Bluetooth, WiFi of mobiele netwerk</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Laai al die kaarte langs u roete af</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Om ’n roete te skep moet ons al die kaarte van u ligging na u bestemming aflaai en bywerk.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nie genoeg spasie nie</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Aktiveer asb. liggingdienste</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Bewaar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>skep</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rooi</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Geel</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blou</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Groen</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Pers</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranje</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Bruin</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pienk</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Donkerpers</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Ligblou</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Siaan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teël</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lemmetjie</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Donkeroranje</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grys</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blougrys</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Inligting</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps weergawe: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Uitsien</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Lig</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Donker</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Lig van dagbreek tot skemer</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Ander</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Skenk gratis kaarte sonder advertensies aan miljoene gebrui</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Rapporteer of maak verkeerde kaartdata reg</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Om vrywillig te wees</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Volg en kontak ons:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Die e-posleser is nie opgestel nie. Stel dit asb. op of kontak ons by %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>E-posstuurfout</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompaskalibrering</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Beskikbaar</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Gevind</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Werk by</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Misluk</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>boekmerk</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Wanneer u die roete volg, hou asb. die volgende in gedagte:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>– Padtoestande, verkeersreëls en padtekens neem kry voorkeur bo die navigasiewenke;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>– Die kaart kan onakkuraat wees en die voorgestelde roete is dalk nie die mees optimale manier om die bestemming te bereik nie;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Voorgestelde roetes moet slegs as aanbevelings geag word;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>Wees versigtig met die roetes in die grenssones: die roetes wat deur ons toep geskep word kan soms oor landsgrense in onwettige areas gaan.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Bly asb. paraat en veilig op die paaie!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Gaan GPS-sein na</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Kan nie roete bereken nie. Huidige GPD-koördinate kon nie geïdentifiseer word nie.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Kaan asb. u GPS-sein na. Met Wi-Fi sal u liggingakkuraatheid verbeter.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktiveer liggingdienste</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Kan nie huidige GPD-koördinate opspoor nie. Aktiveer liggingdienste om roete te bereken.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Kan nie roete opspoor nie</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Kan nie roete bereken nie.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Pas asb. u beginpunt of bestemming aan.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Pas beginpunt aan</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Roete is nie bereken nie. Kan nie beginpunt opspoor nie.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Kies asb. ’n beginpunt nader aan ’n pad.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Pas bestemming aan</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Roete is nie bereken nie. Kan nie die bestemming ospoor nie.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Kies asb. ’n bestemmingspunt wat nader aan ’n pad is.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Kan nie die tussenstop opspoor nie.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Werk asb. u tussenstop by.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Stelselfout</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Kan weens ’n toepassingfout nie ’n roete berkeen nie.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Probeer asb. weer</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nie nou nie</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Wil u die kaart aflaai en ’n meer optimale roete bereken wat oor meer as een kaart loop?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Laai bykomende kaarte af om ’n beter roete te bereken wat die grense van hierdie kaart oorskry.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Laai vereiste lêers af</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Laai af of werk alle kaarte langs die berekende pad by om ’n roete te bereken.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Om te begin met soek en roetebeskrywings te kan maak moet u die kaart aflaai. U het daarna nie meer ’n internetverbinding nodig nie.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Kies kaart</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Toon</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Versteek</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorieë</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Geskiedenis</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oeps, geen resultate gevind.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Laai die streek af waar jy soek of probeer om &#x27;n nabygeleë dorp/dorpnaam by te voeg.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Soekgeskiedenis</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Bekyk al u onlangse soektogte.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Wis soekgeskiedenis</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel vanaf wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>U ligging</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Begin</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Roete vanaf</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Roete na</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigering is slegs beskikbaar vanaf u huidige ligging.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Wil u ’n roete vanaf u huidige ligging beplan?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Volgende</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Van</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>tot</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Voeg skedule toe</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Skrap skedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Heeldag (24 uur)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Oop</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Gesluit</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Voeg nie-besigheidsure toe</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Besigheidsure</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Gevorderde modus</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Eenvoudige modus</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Nie-besigheidsure</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Voorbeeldwaardes</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Stel fout reg</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Kies Ligging</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Beskryf asb. die probleem in detail sodat die OpenStreetMap-gemeenskap dit kan regstel.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Of doen dit welf by https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Stuur</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Probleem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Hierdie plek bestaan nie</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Gesluit vir onderhoud</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Dupliseer plek</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Laai kaarte outomaties af</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daagliks</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Vandag gesluit</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Gesluit</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Vandag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Open oor %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Sluit oor %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Gesluit</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Wysig besigheidsure</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Het u nie ’n OpenStreetMap-rekening nie?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registreer by OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>OpenStreetMap-aantekening</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nie ingeteken nie</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Teken aan op OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Wagwoord</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Het u u wagwoord vergeet?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Teken af</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Wysig plek</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Voeg ’n taal toe</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Straat</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Gebounommer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sosiale media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Gebou</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Voeg ’n straat toe</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Voer asb. ’n straatnaam in</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Kies ’n taal</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Kies ’n straat</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kookkuns</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Kies kookkuns</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-posadres of gebruikersnaam</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Voeg telefoonnomer toe</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Verdieping</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Vlak: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alle wysigings aan kaarte word saam met die kaart geskrap.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Werk kaarte by</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Om ’n roete te skep moet u alle kaarte bywerk en die roete dan weer beplan.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Vind kaart</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Maak asb. seker u toestel het ’n internetverbinding.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nie genoeg spasie nie</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Skrap asb. enige onnodige data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Aantekenfout.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Bevestigde veranderinge</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Sleep die kaart om die kruis by die ligging van die plek of besigheid te plaas.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Wysig tans</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Voeg tans toe</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Naam van die plek</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Soos dit in die plaaslike taal geskryf is</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Gedetailleerde beskrywing van die probleem</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>’n Ander probleem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Voeg besigheid toe</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Geen voorwerp kan hier geplaas word nie</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Gemeenskap-geskepte OpenStreetMap-data vanaf %1. Kom meer te wete oor hoe om die kaart te redigeer en op te dateer by OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is &#x27;n gemeenskapsprojek om &#x27;n gratis en oop kaart te bou. Dit is die hoofbron van kaartdata in Organic Maps en werk soortgelyk aan Wikipedia. Jy kan plekke byvoeg of wysig en hulle word beskikbaar vir miljoene gebruikers regoor die wêreld.
+Sluit aan by die gemeenskap en help om &#x27;n beter kaart vir almal te maak!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Skep &#x27;n OpenStreetMap-rekening of meld aan om jou kaartwysigings aan die wêreld te publiseer.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 van %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Laai af oor ’n mobieledataverbinding?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Dit kan behoorlik duur wees met sommige planne of indien dooldata aktief is.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Voer ’n geldige gebounommer in</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Aantal verdiepings (maksimum van %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Die aantal verdiepings mag nie %1 oorskry nie</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Poskode</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Voer ’n geldige poskode in</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota aan OpenStreetMap-vrywilligers (opsioneel)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beskryf foute op die kaart of dinge wat nie met Organic Maps gewysig kan word nie.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Jou wysigings word opgelaai na die publieke &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-databasis. Moet asseblief nie persoonlike of kopiereginligting byvoeg nie.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Meer oor OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Jou redigeergeskiedenis</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Jou kaartdata notas</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operateur</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operateur: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Kan u nie &#x27;n geskikte kategorie vind nie?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps laat slegs toe om eenvoudige puntkategorieë by te voeg, dit beteken geen dorpe, paaie, mere, gebouomtrekke, ens. nie. Voeg asseblief sulke kategorieë direk by &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Kyk na ons &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;gids&lt;/a&gt; vir gedetailleerde stap-vir-stap instruksies.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>U het geen kaarte afgelaai nie</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Laai kaarte af om die ligging te soek en vanlyn te navigeer.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Huidige ligging is onbekend.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Meer</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Wysig boekmerk</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Persoonlike notas (teks of html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentaar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Wys alle lokale veranderinge af?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Wys af</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Skrap toegevoegde plek?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Skrap</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Plek bestaan nie</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Dui asb. die rede aan waarom u die plek skrap</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Voer ’n geldige telefoonnommer in</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Voer ’n geldige webadres in</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Voer ’n geldige e-posadres in</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Voer ’n geldige Facebook-webadres, -rekening of -bladnaam in</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Voer ’n geldige Instagram-gebruikersnaam of -webadres in</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Voer ’n geldige Twitter-gebruikersnaam of -webadres in</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Voer ’n geldige VK-gebruikersnaam of -webadres in</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Voer ’n geldige LINE-ID of -webadres in</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Voeg plek by OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Of laat alternatiewelik &#x27;n nota vir die OpenStreetMap-gemeenskap agter sodat iemand anders hier &#x27;n plek kan byvoeg of regstel.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Nota sal aan OpenStreetMap gestuur word</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Wil u dit na alle gebruikers stuur?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Maak seker u het geen privaat of persoonlike data ingevoer nie.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStraatMap-redigeerders sal die verandeirnge nagaan en u kontak indien hulle vrae het.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Opname van die spoor</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aanvaar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Weier</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Gebruik mobiele internet om gedetailleerde inligting te toon?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Gebruik altyd</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Slegs vandag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Moenie vandag gebruik nie</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiele internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobiele internet is nodig vir kaartbywerkkennisgewings en om wysigings op te laai.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Gebruik nooit</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Vra altyd</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Kaarte moet bygewerk word om verkeersdata te vertoon.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Vergroot lettergrootte op kaart</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Werk Organic Maps asb. by</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Verkeersdata is nie beskikbaar nie</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Staan logboekinskrywing toe</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Algemene terugvoer</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Ons gebruik die TTS-stelsel vir steminstruksies. Talle Android-toestelle gebruik Google TTS; u kan dit aflaai of bywerk deur Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Vir sommige tale sal u ’n spraaksintetiseerder of bykomende taalpakket vanaf die toepwinkel (Google Play, Galaxy Store, App Gallery, FDroid) moet installeer.
+Open u toestel se instellings → Taal en toevoer → Spraak → Teks na spraak afvoer.
+Hier kan u instellings vir spraaksintetisering bestuur (bv. laai taalpakket vir vanlyn gebruik af) en kies ’n ander teks-na-spraak-enjin.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Sien hierdie gids vir meer inligting</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterasie in Latynse alfabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Meer inligting</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Gebruik soek of tik op die kaart om &#x27;n roetebeginpunt by te voeg</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Gebruik soek of tik op die kaart om &#x27;n bestemmingspunt by te voeg</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Bestuur roete</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Beplan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Verwyder stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Voeg tussenstop toe</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Gespaar</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Meld asseblief aan by OpenStreetMap om al jou kaartwysigings outomaties op te laai. Kom meer te wete &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hier&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Bergtoegangprobleem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Eksterne bergspasie is nie toeganklik nie. Die SD-kaart is dalk verwyder, beskadig, of die lêerstelsel is leesalleen. Gaan u SD-kaart na of kontak ons by support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emuleer slegte bergspasie</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Voer asb. ’n korrekte naam in</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lyste</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Versteek alles</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Toon alles</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Skep ’n nuwe lys</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Voer leidrade en snitte in</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Kan nie deel nie weens ’n toepassingfout</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Deelfout</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Kan nie ’n leë lys deel nie</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Die naam kan nie leeg wees nie</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Voer asb. die lysnaam in</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nuwe lys</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Die naam is reeds in gebruik</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Kies asb. ’n ander naam</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Wag asb.…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefoonnommer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap-profiel</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Stel terug</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n tracks?</numerusform>
+<numerusform>%n tracks?</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privaatheid</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privaatheidsbeleid</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Gebruiksvoorwaardes</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Verkeer</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Staptoere</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Fietsroetes</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Moltrein</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kaartstyle en -lae</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Hierdie lys is leeg</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Tik op ’n plek op die kaart en dan op die sterikoon om ’n boekmerk toe te voeg</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Verander die kleur van alle boekmerke</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Verander die kleur van alle spore</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…nog</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Voer KMZ uit</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Voer GPX uit</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Voer GeoJSON uit</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Skrap lys</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Spoedkameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Plekbeskrywing</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kaartaflaaier</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Waarsku teen spoed</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Waarsku altyd</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Waarsku nooit</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energiebesparende modus</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Probeer batterygebruik verminder ten koste van sekere funksionaliteit.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nooit</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Wanneer battery laag as</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Altyd</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Boekmerkname op die kaart</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>As daar te veel boekmerke is, kan die vertoning van hul name op die kaart die app vertraag.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Wys aan die regterkant</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Wys onderaan</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aktiveer hierdie opsie tydelik om ’n gedetailleerde diagnosestaat van u probleem op te neem en handmatig na ons te stuur d.m.v. die “Rapporteer ’n fout” in die Help-dialoog. Sulke state kan liggingsinligting bevat.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Ompadopsies</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vermy tolgelde</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vermy grondpaaie</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vermy veerbootkruisings</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vermy snelweë</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Kan nie ’n roete bereken nie</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>’n Roete kon nie gevind word nie. Dit kan deur ’n ompadopsies of onvolledige OpenStreetMap-data veroorsaak word. Verander u omwegopsies en probeer weer.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definieer paaie om te vermy</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Ompadinstellings is geaktiveer</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Tolpaaie</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Grondpaaie</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Veerbootkruisings</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nee</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nee</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapasiteit: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netwerk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>U het aangekom!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Goed</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sorteer…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sorteer boekmerke</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Verstek</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Volgens tipe</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Volgens afstand</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Volgens datum</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Op Naam</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>&#x27;n week gelede</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>’n Maand gelede</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Meer as ’n maand gelede</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Meer as ’n jaar gelede</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Naby my</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Ander</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Roeteberekening het misluk</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Aankoms om %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Om ’n roete te bereken moet u alle kaarte van die pad aflaai en bywerk.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>U het die wêreldkaart verander! Moet dit nie vir uself hou nie; Vertel u vriende en wysig dit saam.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Deel met vriende</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Nou gesluit</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Open môre om %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Open %1 om %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Open om %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Sluit om %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Voeg besigheidsure toe</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Wagwoord (ten minste 8 karakters)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Ongeldige gebruikersnaam of wagwoord.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-rekening</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Laaste oplaai</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Dankie</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Pleknaam</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefoon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Let wel</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Aflaaifout</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Kies kategorie</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Gewild</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kategorieë</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Voeg nuwe plekke tot die kaart toe, en wysig bestaandes direk vanuit die toep.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Verander ligging</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>U benodig meer spasie om af te laai. Skrap asb. enige onnodige data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ek het Organic Maps verbeter</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Gedetailleerde kommentaar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>U het kaartveranderinge voorgestel wat na die OpenStreetMap-gemeenskap gestuur sal word. Beskryf asb. enige bykomende detail wat nie in Organic Maps gewysig kan word nie.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>’n Fout het voorgekom toe u ligging vasgestel is. Maak seker u toestel werk deeglik en probeer later weer.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Liggingsdienste is gedeaktiveer</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aktiveer toegang tot geoligging in die toestelinstellings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Instellings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tik op ligging</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Kies Terwyl u die toep gebruik</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Kies Privaatheid</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Kies Liggingdienste</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Skakel Liggingdienste aan</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Of gaan voort om Organic Maps sonder ligging te gebruik</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Bespreek</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Bel</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Boekmerknaam</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Skrap boekmerk</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Jou nota sal na OpenStreetMap gestuur word</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…meer</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Werk by</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Deaktiveer opname van u onlangs berese roete?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Deaktiveer</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Bekyk</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps gebruik u ligging in die agtergrond om u onlangs berese roete op te neem.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Algemene instellings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Die toepassing moet bygewerk word om verkeersdata te vertoon.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Loglêergrootte: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Sleep hier om te verwyder</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Vervang Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Begin vanaf</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Meld asseblief aan by OpenStreetMap om al jou kaartwysigings outomaties op te laai. Kom meer te wete</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hier</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Versteek skerm</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 van %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Laai tans %1 af…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Pas tans %1 toe…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Die naam is te lank</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nuwe lêers is bespeur</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Skakel om</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Fout</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Sommige lêers is nie omgeskakel nie.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>’n Fout het voorgekom</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Gewild</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Versteek van die kaart</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>’n Fout het voorgekom toe etikette gelaai word, probeer weer</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Regs</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Onderkant</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Kom ons gaan</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Bestemming</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Hersentreer</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Soekresultate</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Dan</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Wil u die roete herbou?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Toetsbord is nie beskikbaar terwyl u bestuur nie</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Kan nie ’n roete vanaf u huidige ligging bou nie</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Kan nie ’n roete na u bestemming vind nie. Kies asb. ’n ander eindpunt</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Geen GPS-sein. Beweeg asb. na ’n oop area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Kan nie nn roete bou nie. Spesifiseer asb. ander roetepunte</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Laai vermiste kaarte op u toestel af om ’n roete te skep</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>’n Fout het voorgekom. Herbegin asb. die toepassing</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Die roete sal vanaf u huidige ligging herbou word</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Die roete sal in ’n outoroete verander word</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nie alle boekmerke word gewys nie</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Skakel oor na die foon om alle boekmerke te sien</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kameras</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Spoedkameras</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Laai asb. kaarte in die toep op u mobiele toestel af</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Afrit %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Versteksortering</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sorteer volgens tipe</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sorteer volgens afstand</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sorteer volgens datum</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sorteer volgens naam</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Kos</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Besienswaardighede</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parke</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swem</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Berge</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Diere</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotelle</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Geboue</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Geld</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Winkels</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkeerplekke</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Vulstasies</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Geneeskunde</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Soek in die lys</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Plekke van aanbidding</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Kies lys</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Moltreinnavigasie is nog nie in hierdie streek beskikbaar nie</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Moltreinroete nie gevind</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Kies asb. ’n begin- of eindpunt nader aan die moltreinstasie</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Kontoerlyne</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Om kontoerlyne te aktiveer moet u kaartdata vir hierdie area aflaai</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Die kontoerlyne is nog nie in hierdie area beskikbaar nie</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Styging</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Daling</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. hoogte</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. hoogte</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Moeilikheid</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Afst.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tyd:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoem in om isolyne te bekyk</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Laai tans af</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Laai die wêreldkaart af</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Kan nie vouer skep en lêers op internetoestelgeheue of SD-kaart skuif nie</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Skyffout</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Koppelingsfout</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Ontkoppel USB-kabel</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Hou die skerm aan</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Wanneer dit geaktiveer is, sal die skerm altyd aan wees wanneer die kaart vertoon word.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Toon op grendelskerm</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Indien geaktiveer, sal die toep op die grendelskerm werk selfs indien die toestel vergrendel is.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kaarttaal</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kaartdata vanad OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/af/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Dankie dat u ons gemeenskapsgeboude kaarte gebruik!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Met jou skenkings en ondersteuning kan ons die beste kaarte in die wêreld skep!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Hou jy van ons app? Doner asseblief om die ontwikkeling te ondersteun! Hou jy nog nie daarvan nie? Laat weet ons asseblief hoekom, en ons sal dit regstel!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>As jy &#x27;n sagtewareontwikkelaar ken, kan jy hom of haar vra om &#x27;n funksie te implementeer wat jy nodig het.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tik enige plek op die kaart om enigiets te kies. Tik lank om te versteek en om die koppelvlak terug te wys.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Het jy geweet dat jou huidige ligging op die kaart gekies kan word?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Jy kan help om ons app in jou taal te vertaal.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Ons app is ontwikkel deur &#x27;n paar entoesiaste en die gemeenskap.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Jy kan maklik die kaartdata regstel en verbeter.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Ons hoofdoel is om vinnige, privaatheidsgerigte, maklik-om-te-gebruik kaarte te bou wat jy sal liefhê.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Jy gebruik nou Organic Maps op die foon se skerm</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Jy gebruik nou Organic Maps op die motor se skerm</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Jy is gekoppel aan Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Gaan voort op die foon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Na die kar se skerm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps benodig liggingtoegang. Gaan die kennisgewing op jou foon na wanneer dit veilig is.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Hierdie toepassing benodig jou toestemming</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto het &#x27;n liggingtoestemming nodig om effektief te werk</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Gee toestemmings</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Stap</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webblaaier is nie beskikbaar nie</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Voer alle boekmerke en snitte uit</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Stelsel spraak sintese instellings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Spraaksintese-instellings is nie gevind nie. Is jy seker jou toestel ondersteun dit?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Deur-ry</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Vee die soektog uit</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoem in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoem uit</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Kieslys skakel</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Bekyk spyskaart</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Maak oop in &#x27;n ander toepassing</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Selfdiens</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Kies opsie</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Buitelug sitplek</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Vir die mees akkurate navigasie, beveel ons aan dat u kragbesparingsmodus in die foon se batteryinstellings deaktiveer.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Registreer roete</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop roete-opname</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Spooropname</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop sonder om te stoor</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Voortgaan met Opname</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Stoor na Boekmerke en paaie?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Roete is leeg - niks om te red nie</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kan nie vouerkeusedialoog vertoon nie, want geen geskikte toepassing is op jou toestel geïnstalleer nie. Installeer asseblief &#x27;n lêerbestuurder-toepassing en probeer weer</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Kies Kleur</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Wysig Roete</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Geen toepassing geïnstalleer wat die ligging kan oopmaak nie</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Outo in navigasie</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Volg die stelsel</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Deel spoor</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Verwyder %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Moeilikheidsgraad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Maklik</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Matig</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Moeilik</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Werk tans by</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Werk afgelaaide kaarte by</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Die bywerk van kaarte hou die inligting oor voorwerpe aktueel</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Werk by (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Werk later handmatig by</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Skrap trajek</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Is jy seker jy wil hierdie snit uitvee?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Trajeknaam</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Skuif</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trajek</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Verander kleur</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kaart</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Wil jy &#x27;n foutverslag aan die ontwikkelaars stuur?
+Ons maak staat op ons gebruikers aangesien Organic Maps nie outomaties enige foutinligting insamel nie. By voorbaat dankie vir die ondersteuning van Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktiveer iCloud-sinchronisasie</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-sinchronisasie is &#x27;n eksperimentele kenmerk wat ontwikkel word. Maak seker dat jy &#x27;n rugsteun van al jou boekmerke en snitte gemaak het.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud is gedeaktiveer</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aktiveer asseblief iCloud in jou toestel se instellings om hierdie kenmerk te gebruik.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktiveer</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Ondersteuning</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-sinchronisasie mislukking</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Fout: Kon nie sinchroniseer nie weens verbindingsfout</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Fout: Kon nie sinchroniseer nie weens iCloud-kwota oorskry</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Fout: iCloud is nie beskikbaar nie</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Onlangs geskrap lyste</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Vee uit</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Vee alles uit</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Herstel</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Herstel Alles</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Dra by tot OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Voeg Plek By</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Werk die Kaart By om By te Dra</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Jy moet die %1 kaart na die nuutste weergawe bywerk voordat jy tot die OpenStreetMap-data kan bydra</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My posisie</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My plekke</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Interne privaat berging</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interne gedeelde berging</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kaart</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Eksterne gedeelde berging</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wi-Fi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Poskode</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kaartpunt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>myl</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>vt.</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Om roetes te vertoon, moet die kaarte opgedateer word.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Uitgang</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ingang</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Moltreinkaart is onbeskikbaar</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Jy</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Pers afgelaaide streke</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Om die ligging in die agtergrond op te spoor, is nodig om die funksionaliteit van die app ten volle te geniet. Dit word gebruik vir navigasie en om jou onlangs gereisde roete te stoor.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Om jou ligging te bepaal is nodig vir navigasie en om jou onlangs gereisde roete te stoor.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Aanmelding met wagwoord</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Teken aan met blaaier</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Onlangs gebruik</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Boekmerkkleur is verander</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Spoorkleur is verander</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Glyers</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROOI</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GROEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLOU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB-hekskleur #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rooster</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ar/omim.ts
+++ b/qt/translations/ar/omim.ts
@@ -1,0 +1,3946 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ar">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>رجوع</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>إلغاء</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>حذف</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>تنزيل الخرائط</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>فشلت عملية التنزيل، انقر لإعادة المحاولة.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>جاري التنزيل…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>الكيلومترات</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>الأميال</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>لاحقاً</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>البحث</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>ابحث في الخريطة</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>التطبيق أو جميع خدمات تحديد المواقع معطلة لديك في الوقت الحالي. الرجاء تفعيلها في الإعدادات.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>دقة محدودة</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>لضمان التنقل الدقيق، قم بتمكين الموقع الدقيق في الإعدادات.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>عرض على الخريطة</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>فشلت عملية تنزيل</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>محاولة مرة أخرى</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>حول Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>مجاني للجميع ، مصنوع من الحب</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• لا إعلانات ، لا تتبع ، لا جمع البيانات</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• لا يوجد استنزاف للبطارية، يعمل دون اتصال بالإنترنت</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• سريع وبسيط، تم تطويره بواسطة المجتمع</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>تطبيق مفتوح المصدر الذي أنشأه المتحمسون والمتطوعون.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>إعدادات الموقع</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>إغلاق</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>يتطلب التطبيق OpenGL مع تسريع الأجهزة. لسوء الحظ، جهازك غير مدعوم.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>تنزيل</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>الرجاء فصل كابل الناقل التسلسلي الشامل أو إدخال بطاقة الذاكرة من أجل استخدام Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>الرجاء إخلاء بعض المساحة أولاً في بطاقة SD/تخزين USB لاستخدام التطبيق.</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>قبل البدء في استخدام التطبيق، يرجى تنزيل خريطة نظرة عامة على العالم على جهازك.
+سيستخدم %1 من مساحة التخزين.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>الذهاب الى الخريطة</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>تنزيل %1. يمكنك الآن
+المتابعة الى الخريطة.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>هل تريد تنزيل %1؟</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>هل تريد تحديث %1 ؟</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>توقيف مؤقت</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>استمرار</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>فشلت عملية تنزيل %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>إضافة قائمة جديدة</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>اسم قائمة الإشارات المرجعية</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>الإشارات المرجعية</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>الإشارات المرجعية والمسارات</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>الاسم</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>العنوان</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>قائمة</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>الإعدادات</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>مكان تخزين الخرائط</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>اختر المكان الذي ينبغي تنزيل الخرائط إليه.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>الخرائط المنزلة</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 فارغ من %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>هل تريد نقل الخرائط؟</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>فشلت عملية نقل ملفات الخرائط</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>يمكن أن تستغرق هذه العملية عدة دقائق.
+الرجاء الانتظار…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>وحدات القياس</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>اختر من بين الأميال و الكيلومترات</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>إلغاء التنزيل</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>اترك تعليقاً</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>نعم</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>تنزيل الخريطة</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>قائمة الإشارات المرجعية</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>أمكان لتناول الطعام</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>بقالية</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>مواصلات</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>وقود</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>مرافق ركن السيارات</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>تسوق</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>اليد الثانية</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>فندق</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>سياحة</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>تسلية</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>صراف آلي</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>أنشطة ترفيه ليلية</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>عطلة عائلية</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>بنك</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>صيدلية</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>مستشفى</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>مرحاض</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>بريد</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>شرطة</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>إعادة تدوير</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>ماء</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>منشآت للمنازل المتنقلة</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>ملاحظات</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>تم مشاركة إشارات Organic Maps المرجعية معك</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>مرحباً! ْ
+
+&#32;تم إرفاق إشاراتي المرجعية من تطبيق Organic Maps. الرجاء فتحهم إذا لديك تطبيق Organic Maps مثبتاً. أو، إذا لم يكن مثبتاً، قم بتنزيل التطبيق لنظام iOS أو أندرويد من خلال الضغط على هذا الرابط: https://omaps.app/get?kmz&#32;
+
+استمتع بالسفر مع Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>يتم تحميل الإشارات المرجعية</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>تم تحميل الإشارات المرجعية بنجاح! يمكنك العثور عليها على الخريطة أو على شاشة إدارة الإشارات المرجعية.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>فشلت عملية تحميل الإشارات المرجعية. قد يكون الملف تالف أو غير صالح.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>لم يتعرف التطبيق على نوع الملف:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>فشل فتح ملف %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>تعديل</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>لم يتم تحديد موقعك بعد</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>نأسف، اعدادات تخزين الخرائط معطلة حالياً.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>جاري الآن تنزيل الخريطة.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>مرحباً، تفقد الموقع الخاص بي على Organic Maps! %1 أو %2. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>مرحباً، تفقد الدبوس الخاص بي على خريطة Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>مرحباً، تحقق من موقعي الحالي على خريطة Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>ًمرحبا،
+
+أنا هنا الآن: %1. انقر على هذا الرابط %2 أو ذلك الرابط %3 لمشاهدة المكان على الخريطة.
+
+شكراً.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>مشاركة</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>البريد الالكتروني</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>تم النسخ الى الحافظة: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>تم</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>بيانات خريطة الشارع المفتوحة: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>هل أنت متأكد أنك تريد تسجيل الخروج من حساب OpenStreetMap الخاص بك؟</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>المسارات</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>الطول</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>مشاركة موقعي</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>الإعدادات العامة</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>معلومات</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>الملاحة</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>أزرار + و- على الخريطة</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>عرض على الشاشة</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>النمط الليلي عند التنقل في الظلام</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>الوضع الليلي</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>تعطيل</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>تشغيل</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>تلقائي</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>العرض المنظوري</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>مباني ثلاثية الأبعاد</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>يتم إيقاف تشغيل المباني ثلاثية الأبعاد في وضع توفير الطاقة</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>تعليمات صوتية</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>أعلن أسماء الشوارع</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>عند التمكين ، سيتم نطق اسم الشارع أو المخرج الذي سيتم تشغيله بصوت عالٍ.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>لغة الصوت</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>لتنزيل صوت بجودة أعلى، افتح تطبيق الإعدادات وانتقل إلى تسهيلات الاستخدام → VoiceOver → الكلام → الصوت.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>اختبار الاتجاهات الصوتية (TTS، تحويل النص إلى كلام)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>تحقق من مستوى الصوت أو إعدادات تحويل النص إلى كلام في النظام إذا كنت لا تسمع الصوت الآن.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>غير متاح</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>تكبير تلقائي</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>المسافة</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>مشاهدة على الخريطة</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>القائمة</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>الموقع الإلكتروني</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>أخبار</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>إرسال التعليقات</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>قيّم التطبيق</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>مساعدة</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>اسئلة مكررة</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>تبرع</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>تم التبرع</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>ذكر لاحقاً</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>ادعموا Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>دعم المشروع</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>حقوق النشر</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>الإبلاغ عن خطأ</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>قم بتحسين اتجاه السهم عن طريق تحريك الهاتف في حركة على شكل ثمانية لمعايرة البوصلة.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>حرك الهاتف في حركة على شكل ثمانية لمعايرة البوصلة وإصلاح اتجاه السهم على الخريطة.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>اضغط مطولاً على الخريطة مرة أخرى لرؤية الواجهة</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>تحديث الكل</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>إلغاء الكل</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>التي تم تنزيلها</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>مَصْفوف</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>قريب مني</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>الخرائط</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>تنزيل الكل</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>يتم التنزيل:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>لحذف الخريطة يرجى إيقاف الملاحة.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>يمكن فقط إنشاء المسارات التي توجد بشكل كامل ضمن خريطة دولة واحدة.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>تنزيل الخريطة</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>المحاولة مجدداً</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>حذف الخريطة</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>تحديث الخريطة</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>خدمات الموقع في جوجل بلاي</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>حدد موقعك التقريبي بسرعة باستخدام Bluetooth أو WiFi أو شبكة الهاتف المحمول</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>تنزيل الخرائط على طول طريقك</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>من أجل تعيين الطريق، نحتاج إلى تنزيل أو تحديث جميع الخرائط التي تغطي المنطقة من موقعك إلى وجهتك.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>لا يوجد مساحة كافية</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>الرجاء تفعيل خدمة تحديد الموقع الجغرافي</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>حفظ</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>إنشاء</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>أحمر</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>أصفر</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>أزرق</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>أخضر</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>أرجواني</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>برتقالي</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>بني</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>زهري</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>أرجواني داكن</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>أزرق فاتح</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>أزرق سماوي</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>أخضر فاتح</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>ليموني</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>برتقالي داكن</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>رمادي</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>رمادي أزرق</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>المعلومات</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps الإصدار: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>المظهر</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>فاتح</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>داكن</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>فاتح من الفجر حتى الغسق</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>آخر</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>اهْدِ خرائط مجانية بدون إعلانات لملايين المستخدمين!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>الإبلاغ عن بيانات الخريطة غير الصحيحة أو إصلاحها</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>للتطوع</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>تابعنا وتواصل معنا:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>لم يتم تنصيب البريد الإلكتروني. يرجى تفعيله أو استخدام أي وسيلة أخرى للاتصال بنا على %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>حدث خطأ في إرسال البريد الإلكتروني</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>معايرة البوصلة</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>متوفر</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>تم العثور على</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>تحديث</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>فشل</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>إشارة مرجعية</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>عند اتباع المسار، يُرجى الانتباه إلى ما يلي:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— إن ظروف الطريق وقوانين وإشارات المرور لها الأولوية على المشورة الملاحية دائماً;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— قد تكون الخريطة غير دقيقة وقد لا يكون المسار المقترح هو المسار الأمثل دائمًا للوصول إلى الوجهة.;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— يجب التعامل مع المسارات المقترحة كتوصيات فقط;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— تحذير بشأن المسارات في المناطق الحدودية: المسارات التي تم إنشاؤها بواسطة تطبيقنا قد تعبر أحياناً حدود الدول في أماكن غير مصرح بها.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>يجب أن تظل يقظًا وآمنًا على الطريق!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>تحقق من إشارة نظام تحديد الموقع الجغرافي</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>تعذر إنشاء مسار. لم نستطع تحديد الإحداثيات الجغرافية الحالية.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>الرجاء التحقق من إشارة نظام تحديد الموقع. إن تفعيل الWi-Fi سيحسب دقة الموقع.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>تفعيل خدمات الموقع الجغرافي</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>لم نستطع تحديد الإحداثيات الجغرافية الحالي. قم بتفعيل خدمات الموقع الجغرافي لحساب الطريق المناسب.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>تعذر إيجاد المسار</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>تعذر إنشاء مسار.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>الرجاء تعديل نقطة بدء أو تعديل وجهتك.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>تعديل نقطة البدء</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>لم يتم إنشاء المسار. تعذر تحديد موقع نقطة البدء.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>يُرجى تحديد نقطة بدء أكثر قربًا للطريق.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>تعديل الوجهة</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>لم يتم إنشاء المسار. تعذر تحديد موقع الوجهة.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>يُرجى تحديد نقطة وجهة تقع أكثر قربًا من الطريق.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>تعذر تحديد مكان النقطة الوسيطة.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>الرجاء ضبط النقطة الوسيطة الخاصة بك.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>خطأ في النظام</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>تعذر إنشاء مسار نتيجة وجود خطأ في التطبيق.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>الرجاء إعادة المحاولة</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>ليس الآن</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>هل ترغب في تنزيل الخريطة وإنشاء مسار أفضل يمتد عبر أكثر من خريطة؟</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>تنزيل خرائط إضافية لإنشاء مسار أفضل يعبر حافة هذه الخريطة.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>تنزيل الملفات المطلوبة</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>قم بتنزيل وتحديث كافة الخرائط ومعلومات التوجيه على طول الطريق المتوقع لحساب المسار.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>لبدء البحث وإنشاء الطرق، يرجى تنزيل الخريطة، ولن تحتاج إلى اتصال بالإنترنت بعد ذلك.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>اختيار الخريطة</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>عرض</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>إخفاء</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>التصنيفات</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>سجل البحث</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>المعذرة، لم أعثر على أية نتائج.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>قم بتنزيل المنطقة التي تبحث فيها أو حاول إضافة اسم بلدة/قرية قريبة.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>سجل البحث</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>عرض عمليات البحث الأخيرة.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>مسح سجل البحث</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>ويكيبيديا</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>مقالة من wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>مشاعات ويكيميديا</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>موقعك</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>ابدأ</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>الطريق من هنا</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>الطريق إلى</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>تتوفر الملاحة من خلال موقعك الحالي فقط.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>هل ترغب في أن نرسم مسار لك من موقعك الحالي؟</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>التالي</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>من الساعة</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>إلى</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>إضافة جدول</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>حذف جدول</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>طوال اليوم (٢٤ ساعة)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>مفتوح</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>مغلق</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>إضافة ساعات راحة</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>ساعات العمل</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>الوضع المتقدم</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>الوضع البسيط</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>ساعات الراحة</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>أمثلة على القيم</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>تصحيح الخطأ</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>اختر الموقع</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>يرجى وصف المشكلة بالتفاصيل حتى يتسنى لفريق خريطة الشارع المفتوحة إصلاح الخطأ.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>أو افعل ذلك بنفسك من خلال الموقع https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>إرسال</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>مشكلة</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>المكان غير موجود</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>مغلق للصيانة</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>مكان مكرر</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>التنزيل التلقائي</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>يومياً</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>٢٤/٧(ليلاً ونهاراً)</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>مغلق اليوم</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>مغلق</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>اليوم</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>يفتح بعد %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>يغلق في غضون %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>مغلق</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>حرر ساعات العمل</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>ليس لديك حساب في خريطة الشارع المفتوحة؟</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>التسجيل في خريطة الشارع المفتوحة</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>تسجيل الدخول</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>لم يتم تسجيل الدخول</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>تسجيل الدخول الى OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>كلمة المرور</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>هل نسيت كلمة المرور؟</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>تسجيل الخروج</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>تعديل المكان</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>إضافة لغة</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>الشارع</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>رقم المنزل</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>التفاصيل</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>وسائل التواصل الاجتماعي</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>البناء</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>إضافة شارع</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>الرجاء إدخال اسم الشارع</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>اختر اللغة</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>اختر الشارع</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>المطبخ</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>اختر المطبخ</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>البريد الإلكتروني أو اسم المستخدم</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>إضافة رقم هاتف</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>طابق</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>المستوى: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>سيتم حذف جميع التغييرات بالخريطة بالإضافة إلى حذف الخريطة نفسها.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>تحديث الخرائط</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>لإنشاء مسار، فأنت تحتاج إلى تحديث كافة الخرائط ثم إعادة تخطيط المسار مرة أخرى.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>ابحث عن خريطة</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>يرجى التحقق من الإعدادات والتأكد من اتصال جهازك بالإنترنت.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>لا تتوفر مساحة كافية</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>من فضلك، قم بإزالة البيانات غير الضرورية</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>خطأ في تسجيل الدخول.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>التعديلات التي تم التحقق منها</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>اسحب الخريطة لوضع الصليب في موقع المكان أو النشاط التجاري.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>يتم التعديل</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>يتم الإضافة</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>اسم المكان</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>كما هو مكتوب باللغة المحلية</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>الفئة</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>وصف مفصّل للمشكلة</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>مشكلة أخرى</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>إضافة مؤسسة</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>لا يمكن تحديد موقع الكائن هنا</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>بيانات OpenStreetMap التي أنشأها المجتمع اعتبارًا من %1. تعرف على المزيد حول كيفية تعديل الخريطة وتحديثها على OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) هو مشروع مجتمعي يهدف إلى إنشاء خريطة مجانية ومفتوحة. وهو المصدر الرئيسي لبيانات الخرائط في Organic Maps ويعمل بشكل مشابه لـويكيبيديا. يمكنك إضافة أو تعديل الأماكن لتصبح متاحة لملايين المستخدمين في جميع أنحاء العالم.
+انضم إلى المجتمع وساعد في إنشاء خريطة أفضل للجميع!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>أنشئ حساباً على OpenStreetMap أو سجّل الدخول لنشر تعديلاتك على الخريطة للعالم.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 من%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>تنزيل باستخدام بيانات الجوال؟</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>قد يكون هذا مكلفاً جداً في بعض الاحيان أو عند التجوال.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>أدخل رقم بناء صحيح</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>عدد الطوابق (بحد أقصى %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>يجب ألا يتجاوز عدد طوابق المبنى %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>الرمز البريدي</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>أدخل الرمز البريدي صالح</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>ملاحظة لمتطوعي OpenStreetMap (اختياري)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>يرجى وصف الأخطاء الموجودة على الخريطة أو العناصر التي لا يمكن تعديلها عبر البريد الإلكتروني Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>يتم تحميل تعديلاتك على قاعدة البيانات العامة &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Ar:About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. يرجى عدم إضافة معلومات شخصية أو محمية بحقوق الطبع والنشر.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>المزيد عن خريطة الشارع المفتوحة</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>سجل التحرير الخاص بك</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>ملاحظات بيانات الخريطة الخاصة بك</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>المشغل</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>المشغل: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>لا يمكن العثور على فئة مناسبة؟</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps تسمح بإضافة فئات النقاط البسيطة فقط، وهذا يعني عدم إضافة المدن والطرق والبحيرات وخطوط المباني، إلخ. يرجى إضافة هذه الفئات مباشرة إلى &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. راجع &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;دليلنا&lt;/a&gt; للحصول على إرشادات تفصيلية خطوة بخطوة.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>لم تقم بتنزيل أية خرائط</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>قم بتنزيل خرائط للبحث عن مكان واستخدام الملاحة بدون اتصال بالإنترنت.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>الموقع الحالي غير معروف.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>كم/ساعة</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ميل/ساعة</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>س</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>د</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>يوم</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>ث</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>المزيد</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>تحرير العلامة المرجعية</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>ملاحظات شخصية (نص أو html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>تعليق…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>هل تريد مسح كافة التغييرات المحلية؟</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>مسح</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>إزالة مكان الذي تمت إضافته؟</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>إزالة</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>المكان غير موجود</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>الرجاء توضيح سبب مسح هذا المكان</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>أدخل رقم هاتف صالح</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>أدخل عنوان ويب صالح</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>أدخل بريداً إلكترونياً صالحاً</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>أدخل اسم صفحة أو حساب أو عنوان ويب خاص بفيسبوك صالح</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>أدخل اسم حساب أو عنوان ويب خاص بإنستغرام صالح</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>أدخل اسم مستخدم او موقع ويب خاص بتويتر صالح</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>أدخل اسم حساب أو عنوان ويب خاص بموقع VK صالح</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>أدخل رقم تعريفي خاص بتطبيق LINE أو موقع ويب خاص بتطيق LINE صالح</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>أضف مكانًا إلى OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>أو، بدلاً من ذلك، اترك ملاحظة لمجتمع OpenStreetMap حتى يتمكن شخص آخر من إضافة أو إصلاح مكان هنا.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>سيتم إرسال ملاحظتك إلى OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>هل ترغب في إرساله لجميع المستخدمين؟</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>تأكد من أنك لم تقم بإدخال أية بيانات شخصية.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>سيتحقق محررو خرائط الشارع المفتوحة من التغييرات ويتواصلون معك إذا كان لديهم أي أسئلة.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>توقف</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>تسجيل المسار</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>قبول</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>رفض</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>استخدام بيانات الجوال لإظهار المعلومات التفصيلية؟</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>استخدام دائمًا</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>اليوم فقط</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>عدم الاستخدام اليوم</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>بيانات الجوال</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>إننا نحتاج بيانات الجوال لعرض معلومات تفصيلية عن الأماكن والإشارات المرجعية.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>عدم الاستخدام مطلقًا</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>السؤال دوماً</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>لعرض البيانات المرورية، يجب تحديث الخرائط.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>زيادة حجم الخط على الخريطة</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>الرجاء تحديث Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>البيانات المرورية غير متاحة</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>تفعيل التسجيل</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>تعقيب عام</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>نحن نستخدم نظام تحويل النص إلى كلام (TTS) للتعليمات الصوتية. تستخدم العديد من أجهزة أندرويد Google TTS، ويمكنك تنزيله أو تحديثه من متجر Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>بالنسبة لبعض اللغات، ستحتاج إلى تنزيل تطبيق تحويل النص إلى كلام أو حزمة لغات إضافية من متجر التطبيقات(متجر Play، Galaxy Store، App Gallery، FDroid).
+افتح إعدادات جهازك ثم اللغة والإدخال ثم تحويل النص إلى كلام.
+هنا يمكنك إدارة الإعدادات لأنظمة تحويل النص إلى كلا (على سبيل المثال، تنزيل حزمة اللغة للاستجدام دون اتصال انترنت).</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>لمزيد من المعلومات الرجاء مراجعة هذا الدليل.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>ترجمة حرفية إلى الأبجدية اللاتينية</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>معرفة المزيد</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>استخدام البحث أو حدّد إشارة مرجعية أو النقر على الخريطة لإضافة نقطة بداية الطريق</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>استخدام البحث أو حدّد إشارة مرجعية أو النقر على الخريطة لإضافة نقطة وجهة</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>إدارة المسار</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>خطة</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>إزالة نقطة توقف</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>إضافة نقطة توقف</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>حُفظت</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>برجاء تسجيل الدخول إلى OpenStreetMap لتحميل جميع تعديلات الخريطة تلقائيًا. تعرف على المزيد &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;هنا&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>مشكلة الوصول للتخزين</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>التخزين الخارجي غير متوفر، ربما تمت إزالة بطاقة SD، أو أنها تالفة أو نظام الملفات للقراءة فقط. افحصه أو راسلنا على support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>محاكاة التخزين السيء</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>الرجاء إدخال اسم صحيح</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>قوائم</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>إخفاء الكل</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>إظهار الكل</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n إشارة مرجعية</numerusform>
+<numerusform>%n إشارة مرجعية</numerusform>
+<numerusform>%n إشارتان مرجعيتان</numerusform>
+<numerusform>%n إشارات مرجعية</numerusform>
+<numerusform>%n إشارةً مرجعيةً</numerusform>
+<numerusform>%n إشارةً مرجعيةً</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>إنشاء قائمة جديدة</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>استيراد الإشارات المرجعية والمسارات</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>تعذرت المشاركة بسبب خطأ في التطبيق</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>خطأ في المشاركة</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>لا يمكن مشاركة قائمة فارغة</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>لا يمكن للاسم أن يكون فارغًا</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>يرجى إدخال اسم القائمة</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>قائمة جديدة</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>هذا الاسم موجود سابقا</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>يرجى اختيار اسم آخر</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>أرجو الإنتظار…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>رقم الهاتف</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>ملف الشخصي على خريطة الشارع المفتوحة</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>لم يتم العثور على أي ملف.</numerusform>
+<numerusform>تم العثور على %n ملف. يمكنك رؤيته بعد التحويل.</numerusform>
+<numerusform>تم العثور على %n ملفين. يمكنك رؤيتهما بعد التحويل.</numerusform>
+<numerusform>تم العثور على %n ملفات. يمكنك رؤيتها بعد التحويل.</numerusform>
+<numerusform>تم العثور على %n ملفًا. يمكنك رؤيتها بعد التحويل.</numerusform>
+<numerusform>تم العثور على %n ملفًا. يمكنك رؤيتها بعد التحويل.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>استعادة</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n مسار</numerusform>
+<numerusform>%n مسار</numerusform>
+<numerusform>%n مساران</numerusform>
+<numerusform>%n مسارات</numerusform>
+<numerusform>%n مسارًا</numerusform>
+<numerusform>%n المسارات</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>خصوصية</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>سياسة الخصوصية</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>شروط الاستخدام</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>حركة مرور</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>تضاريس</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>ركوب الدراجات</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>مترو الانفاق</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>أنماط الخريطة وطبقاتها</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>هذه اللائحة فارغة</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>لإضافة إشارة مرجعية ، اضغط على مكان على الخريطة ثم انقر على رمز النجمة</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>تغيير لون جميع الإشارات المرجعية</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>تغيير لون جميع المسارات</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…المزيد</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>تصدير KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>تصدير GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>تصدير GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>حذف القائمة</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>تحذيرات كاميرات السرعة</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>وصف المكان</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>مُنزّل الخريطة</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>التحذير من السرعة</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>حذرني دائما من</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>لا تحذرني من أبداً</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>وضع توفير الطاقة</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>عندما يتم اختيار الوضع التلقائي، يبدأ التطبيق بتعطيل الخصائص التي تستهلك البطارية بناءً على مستوى شحن البطارية الحالي.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>أبدًا</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>تلقائي</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>توفير الطاقة الأقصى</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>أسماء الإشارات المرجعية على الخريطة</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>إذا كان هناك عدد كبير جدًا من الإشارات المرجعية، فقد يؤدي عرض أسمائها على الخريطة إلى إبطاء التطبيق.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>عرض إلى اليمين</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>اعرض في الأسفل</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>هذا الخيار يقوم ببدأ تسجيل سجلات التطبيق لإغراض التشخيصة. يمكن أن يكون مفيدًا لفريق الدعم الخاص بنا لحل المشاكل التي تواجهكم داخل التطبيق. قم بتفعيل هذا الخيار بشكل مؤقت فقط في حالة طلب الدعم من Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>خيارات رسم المسار</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>تجنب الطرق ذات الرسوم</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>تجنب الطرق الغير معبدة</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>تجنب استخدام العبّارات</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>تجنب الطريق السريع</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>لا يمكن حساب الطريق</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>نأسف، لم نعثر على الطريق ربما بسبب الخيارات التي قمت بتحديدها. يرجى تغيير الإعدادات والمحاولة مجددًا.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>حدد الطرق التي يجب تجنبها</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>تم تفعيل خيارات رسم الطريق</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>طريق برسوم مرور</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>طريق غير معبد</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>استخدام عبّارة</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>نعم</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>لا</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>نعم</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>لا</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>السعة: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>الشبكة: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>لقد وصلت!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>موافق</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>ترتيب…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>رتّب العلامات المرجعية</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>بشكل افتراضي</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>حسب النوع</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>حسب المسافة</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>حسب التاريخ</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>بالاسم</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>منذ أسبوع</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>منذ شهر</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>منذ أكثر من شهر</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>منذ أكثر من سنة</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>قريب مني</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>أخرى</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>فشل في تخطيط المسار</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>وقت الوصول: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>لقد ساهمت بتحسين خريطة العالم. لا تخفي ذلك! أخبر أصدقائك، وحسنوها معاً.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>شارك مع الأصدقاء</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>مغلق الآن</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>يُفتتح غداً في %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>يفتح %1 في %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>يفتح في %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>يغلق في %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>أضف ساعات العمل</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>كلمة المرور (٨ أحرف بحد أدنى)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>اسم المستخدم أو كلمة المرور غير صالحة.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>حساب على خريطة الشارع المفتوحة</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>آخر تعديل</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>شكراً لك</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>اسم المكان</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>رقم الهاتف</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>يرجى العلم أنه،</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>خطأ بالتنزيل</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>اختر الفئة</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>رائج</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>جميع الفئات</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>قم بإضافة أماكن جديدة للخريطة، وعدل أماكن حالية مباشرة من التطبيق.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>تغيير الموقع</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>للتنزيل، فأنت تحتاج إلى توفير مساحة أكبر. من فضلك، الرجاء قم بحذف البيانات غير الضرورية.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>لقد قمت بتحسين خرائط تطبيق Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>تعليق مفصّل</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>سيتم إرسال التغييرات التي اقترحتها إلى مجتمع خريطة الشارع المفتوحة. اذكر التفاصيل التي لا يمكن تحريرها في Organic Maps</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>حدث خطأ أثناء البحث عن موقعك. تأكد من أن جهازك يعمل بشكل صحيح وأعد المحاولة لاحقًا.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>تم تعطيل خدمات تحديد الموقع الجغرافي</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>قم بإعطاء التطبيق السماحية بالوصول إلى الموقع الجغرافي في إعدادات الجهاز</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. افتح الإعدادات</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. انقر على الموقع</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. اختيار التفعيل أثناء استخدام التطبيق</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. حدد الخصوصية</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. حدد خدمات الموقع</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. قم بتشغيل خدمات الموقع</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>أو استمر في استخدام Organic Maps بدون تحديد الموقع</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>حجز</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>اتصال</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>اسم العلامة المرجعية</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>حذف العلامة المرجعية</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>سيتم إرسال ملاحظتك إلى OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…المزيد</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>تحديث</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>هل تريد تعطيل تسجيل مسارات سفرك؟</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>تعطيل</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>اتطلع على</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>يستخدم Organic Maps موقعك الجغرافي في الخلفية لتسجيل مسار سفرك الأخير.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>الإعدادات العامة</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>لعرض البيانات المرورية، يجب تحديث التطبيق.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>حجم ملف السجل: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>اسحب هنا للإزالة</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>استبدال التوقف</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>بدء من</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>برجاء تسجيل الدخول إلى OpenStreetMap لتحميل جميع تعديلات الخريطة تلقائيًا. تعرف على المزيد</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>هنا</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>إخفاء الشاشة</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 من %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>جاري التنزيل %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>جاري التطبيق %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>هذا الاسم طويل جداً</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>تم اكتشاف ملفات جديدة</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>تحول</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>خطأ</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>لم يتم تحويل بعض الملفات.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>حدث خطأ</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>رائج</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>إخفاء من الخريطة</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>حدث خطأ أثناء تحميل العلامات ، يرجى المحاولة مرة أخرى</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>صحيح</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>القاع</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>هيا بنا</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>جهة الوصول</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>العودة إلى الوسط</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>نتائج البحث</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>ثم</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>هل تريد إعادة رسم الطريق?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>لوحة الكتابة غير متاحة أثناء القيادة</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>لا يمكن رسم طريق من موقعك الحالي</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>لا يمكن رسم طريق لجهة الوصول. يرجي اختيار مكان آخر</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>لا توجد إشارة لنظام تحديد المواقع الجغرافية. يرجى الانتقال إلى منطقة مفتوحة</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>لا يمكن رسم طريق. يرجى تحديد أماكن أخرى على الطريق</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>كي تُنشئ مساراً، يجب أن تحمل الخرائط المفقودة على جهازك</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>حدث خطأ. يرجى إعادة تشغيل التطبيق</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>سيتم إعادة رسم الطريق من موقعك الحالي</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>سيتم تعديل الطريق ليكون خاص بالسيارة</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>لا يتم عرض جميع الإشارات المرجعية</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>قم بالتبديل إلى الهاتف لرؤية جميع الإشارات المرجعية</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>كاميرات السرعة</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>تحذير بشأن السرعة</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>يُرجى تحميل الخرائط في تطبيق Organic Maps على جهازك</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>المخرج رقم %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>ترتيب افتراضي</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>رتّب حسب النوع</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>رتّب حسب المسافة</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>رتّب حسب التاريخ</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>الترتيب حسب الاسم</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>طعام</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>أماكن سياحية</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>متاحف</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>حدائق</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>سباحة</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>جبال</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>حيوانات</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>فنادق</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>أبنية</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>نقود</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>متاجر</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>مواقف سيارات</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>محطات وقود</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>دواء</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>ابحث في القائمة</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>أماكن دينية</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>اختر القائمة</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>التنقل باستخدام مترو الأنفاق في هذه المنطقة غير متاح حتى الآن</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>لم يتم العثور على مسار مترو الأنفاق</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>يرجى اختيار نقطة بداية أو نهاية أقرب لمحطة مترو الأنفاق</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>تضاريس</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>لتفعيل الطبقة الطبوغرافية واستخدامها ، يرجى تحديث أو تنزيل خريطة المنطقة</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>الطبقة الطبوغرافية ليست متاحة بعد في هذه المنطقة</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>تصاعدي</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>تنازلي</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>أقل ارتفاع</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>أعلى ارتفاع</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>درجة الصعوبة</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>المسافة:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>المدة:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>قم بالتقريب لتكتشف خطوط الكنتور</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>جاري التنزيل</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>تنزيل الخريطة العامة للعالم</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>تعذر إنشاء المجلد ونقل الملفات على الذاكرة الداخلية للجهاز أو على بطاقة SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>حدث خطأ في التخزين</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>فشل الاتصال</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>إفصل سلك USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>إبقاء الشاشة قيد التشغيل</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>عند التمكين، ستكون الشاشة قيد التشغيل دائمًا عند عرض الخريطة.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>إظهار التطبيق فوق شاشة القفل</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>عند التفعيل، لن تحتاج لفتح قفل جهازك كل مرة أثناء تشغيل التطبيق.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>لغة الخريطة</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>بيانات الخريطة من خريطة الشارع المفتوحة</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/ar/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/ar/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Ar:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>شكرًا لك على استخدام الخرائط التي أنشأها مجتمعنا!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>بتبرعاتكم ودعمكم، يمكننا إنشاء أفضل الخرائط في العالم!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>هل تحب التطبيق لدينا؟ يرجى التبرع لدعم التنمية! لا أحب ذلك حتى الآن؟ واسمحوا لنا أن نعرف، وسوف نقوم بإصلاحه!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>إذا كنت تعرف أحد مطوري البرامج، فيمكنك أن تطلب منه تنفيذ الميزة التي تحتاجها.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>اضغط على أي مكان على الخريطة لتحديد أي شيء. اضغط لفترة طويلة لإخفاء الواجهة وإظهارها مرة أخرى.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>هل تعلم أنه يمكنك تحديد موقعك الحالي على الخريطة؟</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>يمكنك المساعدة في ترجمة تطبيقنا إلى لغتك.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>تم تطوير تطبيقنا من قبل عدد قليل من المتحمسين والمجتمع.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>يمكنك بسهولة إصلاح وتحسين بيانات الخريطة.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>هدفنا الرئيسي هو إنشاء خرائط سريعة وسهلة الاستخدام تركز على الخصوصية والتي ستعجبك.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>أنت تستخدم الآن Organic Maps على شاشة الهاتف</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>أنت تستخدم الآن Organic Maps على شاشة السيارة</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>أنت متصل بـ Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>تواصل على الهاتف</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>إلى شاشة السيارة</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps تحتاج إلى الوصول إلى الموقع. عندما يكون الوضع آمنًا، تحقق من الإشعار على هاتفك.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>هذا التطبيق يحتاج إلى إذنك</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps في Android Auto تحتاج إلى أذونات الموقع لتعمل بفعالية</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>أذونات المنح</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>الأنشطة الخارجية</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>متصفح الويب غير متوفر</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>مستوى الصوت</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>تصدير كافة الإشارات المرجعية والمسارات</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>إعدادات تركيب الكلام النظام</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>لم يتم العثور على إعدادات تركيب الكلام، هل أنت متأكد من أن جهازك يدعمها؟</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>خدمة من السيارة</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>مسح البحث</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>تكبير</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>تصغير</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>رابط القائمة</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>عرض القائمة</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>فتح في تطبيق آخر</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>الخدمة الذاتية</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>حدد الخيار</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>مقاعد خارجية</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>للحصول على التنقل الأكثر دقة، نوصي بتعطيل وضع توفير الطاقة في إعدادات بطارية الهاتف.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>تسجيل المسار</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>إيقاف تسجيل المسار</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>تسجيل المسار</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>التوقف بدون حفظ</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>متابعة التسجيل</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>حفظ في الإشارات المرجعية والمسارات؟</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>المسار فارغ - لا يوجد شيء للحفظ</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>غير قادر على عرض مربع حوار تحديد المجلد لأنه لا يوجد تطبيق مناسب مثبت على جهازك. يرجى تثبيت تطبيق مدير الملفات والمحاولة مرة أخرى.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>اختر اللون</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>تعديل المسار</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>لم يتم تثبيت أي تطبيق يمكنه فتح الموقع</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>تلقائي في التنقل</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>حسب النظام</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>شارك المسار</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>احذف %1؟</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>مستوى الصعوبة</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>سهل</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>معتدل</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>صعب</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>جاري التحديث</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>قم بتحديث الخرائط المُنزلة</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>تحديث الخرائط والاحتفاظ بالمعلومات حول الكائنات محدثة</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>تحديث (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>تحديث يدوياً في وقت لاحق</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>حذف المسار</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>هل أنت متأكد من رغبتك في حذف هذا المسار؟</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>اسم المسار</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>نقل</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>مسار</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>غير اللون</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>الخريطة</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>هل ترغب في إرسال تقرير عن الأخطاء إلى المطورين؟
+نحن نعتمد على مستخدمينا لأن تطبيق Organic Maps لا يجمع أي معلومات عن الأخطاء تلقائيًا. شكرًا لك مقدمًا على دعم الخرائط العضوية!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>تمكين مزامنة iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>تعد مزامنة iCloud ميزة تجريبية قيد التطوير. تأكد من عمل نسخة احتياطية لجميع الإشارات المرجعية والمسارات الخاصة بك.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>تم تعطيل iCloud</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>يرجى تمكين iCloud في إعدادات جهازك لاستخدام هذه الميزة.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>يُمكَِن</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>دعم</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>فشل مزامنة iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>خطأ: فشل المزامنة بسبب خطأ في الاتصال</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>خطأ: فشل في المزامنة بسبب تجاوز حصة iCloud النسبية</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>خطأ: iCloud غير متوفر</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>القوائم المحذوفة مؤخراً</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>مسح</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>حذف الكل</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>استرداد</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>استرداد الكل</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>ساهم في OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>أضف مكانًا</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>قم بتحديث الخريطة للمساهمة</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>يجب عليك تحديث خريطة %1 إلى أحدث إصدار قبل أن تتمكن من المساهمة في بيانات OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>ميغابايت</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>غيغابايت</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>موقعي</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>أماكني</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>وحدة التخزين الداخلية الخاصة</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>وحدة التخزين الداخلية المشتركة</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>بطاقة الذاكرة</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>وحدة تخزين خارجية مشتركة</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>إنترنت لا سلكي</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>الرمز البريدي</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>نقطة الخريطة</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>متر</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>كم</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ميل</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>قدم</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>لعرض المسارات، يجب تحديث الخرائط.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>خروج</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>المدخل</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>خريطة مترو الانفاق غير متوفرة</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>أنت</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>المناطق المُنزّلة باللون الأرجواني</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>المسار</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>إن تحديد موقعك الحالي في الخلفية أمر ضروري للاستمتاع بكامل وظائف التطبيق. حيث أنه يُستخدم بشكل أساسي في خيارات متابعة المسار وحفظ الطرق التي تنقلت معها مؤخرا.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>تستخدم خاصية تحديد الموقع الحالي في خيارات اتباع الطريق وحفظ أحدث مسار مشيت عليه.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>تسجيل الدخول باستخدام كلمة المرور</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>تسجيل الدخول باستخدام المتصفح</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>مستخدمة مؤخراً</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>تم تغيير لون الإشارات المرجعية</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>تم تغيير لون المسارات</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>الطيف</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>منزلقات</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>أحمر</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>أخضر</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>أزرق</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>الشبكة</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ast/omim.ts
+++ b/qt/translations/ast/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ast">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Desaniciar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Baxar mapes</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Baxando…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Quilómetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Más sero</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Guetar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Guetar nel mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Amosar nel mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Tentar de nueves</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Tocante a Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zarrar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Baxar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Dir al mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>¿Quies baxar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>¿Quies anovar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Siguir</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Amestar llista nueva</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadores</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Marcadores y trayeutos</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nome</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Señes</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Llista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Configuración</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Guardar mapes en</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Esbilla la carpeta onde tienen de baxase los mapes.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapes baxaos</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidaes de midida</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Encaboxar baxada</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Baxar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Llistes de marcadores</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Tresporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparcaderu</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Arruelu</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Caxeru automáticu</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bancu</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policía</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclaxe</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>¡Hola!
+
+Los mios marcadores tán axuntos; ábrilos n’Organic Maps. Si nun lu tienes instaláu, te lu puedes baxar equí: https://omaps.app/get?kmz
+
+¡Gocia viaxar con Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copióse nel cartafueyu: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Fecho</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trayeutos</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Llonxitú</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Compartir el mio allugamientu</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Información</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edificaciones 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar nomes de cais</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Pa descargar una voz de meyor calidá, abre l&#x27;app Axustes y ve a Accesibilidá → VoiceOver → Voz → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Probar indicaciones de voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Non disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distancia</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver nel mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menú</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Sitiu web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Noticies</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ayuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Entrugues frecuentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Ameyora la direición de la flecha moviendo’l teléfonu en forma d’ocho pa calibrar la brúxula.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mueve’l teléfonu en forma d’ocho para calibrar la brúxula y afitar la direición de la flecha nel mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Baxaos</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapes</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Baxando:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Baxar mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Desaniciar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Anovar mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nun hai espaciu bastante</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crear</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Información</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspeutu</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Claru</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Escuru</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Light from dawn till dusk</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>¡Regala mapes gratis y ensin anuncios a millones d&#x27;usuarios!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibración de la brúxula</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Anovar</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Comprueba la to señal GPS. Activar la wifi va ameyorar la exautitú del allugamientu.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Agora non</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Amosar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Anubrir</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categoríes</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historial de guetes</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article from wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Entamar</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Siguiente</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Tol día (24 hores)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mou avanzáu</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mou simplificáu</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valores d’exemplu</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Unviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Esti llugar nun esiste</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Llugar duplicáu</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Baxar mapes n’automático</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Güei</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Contraseña</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>¿Escaeciesti la contraseña?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar llugar</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Amestar una llingua</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Cai</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Númberu d’edificación</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalles</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Amestar una cai</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Pon el nome de la cai</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Escueyi una llingua</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Escueyi una cai</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cocina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Señes o nome d’usuariu</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Amestar teléfonu</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivel: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Anovar mapes</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nun hai espaciu bastante</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Desanicia los datos imprecisos</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Amestando</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nome del llugar</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoría</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Códigu postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>El to historial d’ediciones</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Desconózse l’allugamientu actual.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Más</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notes personales (testu o HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentariu…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>¿Quies desaniciar el llugar amestáu?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Desaniciar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>El llugar nun esiste</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Amestar llugar a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>La nota va unviase a OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>¿Quies unvialu a tolos usuarios?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Grabando’l trayeutu</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aceutar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Refugar</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usar siempres</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Namás güei</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Entrugar siempres</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>P’amosar datos de tráficu, tienen d’anovase los mapes.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Anueva Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Deprende más</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Desaniciar parada</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Amestar parada</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Guardáu</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Llistes</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcador</numerusform>
+<numerusform>%n marcadores</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar marcadores y trayeutos</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Llista nueva</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Escueyi otru nome</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Aguarda…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Númberu telefónicu</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil d’OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Atopóse %n ficheru. Pues velu dempués de la conversión.</numerusform>
+<numerusform>Atopáronse %n ficheros. Pues velos dempués de la conversión.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trayeutu</numerusform>
+<numerusform>%n trayeutos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidá</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráficu</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Senderismu</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismu</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos y capes del mapa</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta llista ta balera</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>… más</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Esportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Esportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Esportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Desaniciar llista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radares de velocidá</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descripción del llugar</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Alvertir al esceder la llende de velocidá</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mou d’aforru d’enerxía</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Enxamás</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Siempres</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opciones d’encaminamientu</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Nun pudo alcontrase una ruta. Quiciabes se deba a les opciones d’encaminamientu o a datos faltantes n’OpenStreetMap. Revisa les tos opciones d’encaminamientu y vuelvi intentalo.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidá: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rede: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Aportesti.</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenar…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Gracies</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Teléfonu</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Toles categoríes</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Los servicios d’ubicación tán desactivaos</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>… más</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Anovar</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>¡Vamos!</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultaos de la gueta</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Alvertencies de velocidá</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Comida</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museos</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montes</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animales</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteles</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edificaciones</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dineru</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Tiendes</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Aparcaderu</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gasolineres</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Guetar na llista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Llugares relixosos</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navegación per metro nesta rexón tovía nun ta disponible</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Curves de nivel</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Les curves de nivel entá nun tán disponibles nesta rexón</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascensu</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descensu</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevación mín.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevación máx.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultá</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tiempu:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Baxando</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Error nel discu</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Falló la conexón</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Llingua del mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Datos cartográficos d’OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Pues ayudar a traducir la nuesa aplicación na to llingua.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Agora tas utilizando Organic Maps na pantalla del teléfonu</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Agora tas utilizando Organic Maps na pantalla del coche</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Siguir nel móvil</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>El restolador web nun ta disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Esportar tolos marcadores y trayeutos</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Serviciu dende’l coche</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir n’otra aplicación</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoserviciu</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Esbilla una opción</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Grabar trayeutu</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Parar grabación del trayeutu</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Parar ensin guardar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Siguir grabando</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>¿Quies guardalu en Marcadores y trayeutos?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>El trayeutu ta baleru; nun hai nada pa guardar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Escueyi un color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar trayeutu</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Siguir el sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivel de dificultá</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderáu</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Anovando</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Anovar mapes baxaos</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trayeutu</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activar sincronización col iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud nun ta disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Llistes desaniciaes de recién</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>La mio posición</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Los mios llugares</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Tarxeta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Códigu postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Puntu nel mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Salida</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>El mapa del metro nun ta disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Rexones descargaes en moráu</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recently Used</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sliders</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RED</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GREEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/az/omim.ts
+++ b/qt/translations/az/omim.ts
@@ -1,0 +1,3932 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="az">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Geri</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Ləğv et</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Sil</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Xəritəni yüklə</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Yükləmə uğursuz oldu. Yenidən cəhd etmək üçün toxunun.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Endirilir…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometr</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mil</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Daha sonra</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Axtar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Xəritədə axtar</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Bütün Məkan Xidmətləri hazırda bu cihaz və ya tətbiq üçün deaktiv edilib. Zəhmət olmasa bunu parametrlərdən aktiv edin.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Məhdud dəqiqlik</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Dəqiq naviqasiyanı təmin etmək üçün parametrlərdə dəqiq bir yer təmin edin.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Xəritədə göstər</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Yükləmə uğursuz oldu</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Yenidən cəhd et</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps Haqqında</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Hər kəs üçün ödənişsiz və sevgi ilə hazırlanmış xəritə</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Reklam yoxdur, izləmə yoxdur, məlumatların toplanması yoxdur</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Batareyanın boşalması yoxdur, oflayn işləyir</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Sürətli, minimalist, icma tərəfindən hazırlanmışdır</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Həvəskarlar və könüllülər tərəfindən yaradılan açıq mənbə proqramı.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Məkan parametrləri</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Yaxın</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Tətbiq aparatla sürətləndirilmiş OpenGL tələb edir. Təəssüf ki, cihazınız dəstəklənmir.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Yüklə</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps&#x27;dan istifadə etmək üçün zəhmət olmasa USB kabeli ayırın və ya yaddaş kartı daxil edin</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Tətbiqdən istifadə etmək üçün SD kartda/USB yaddaş cihazında bir qədər yer boşaldın.</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Başlamazdan əvvəl gəlin ümumi dünya xəritəsini cihazınıza endirək.
+%1 yer tələb olunur.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Xəritəyə keçin</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 endirilir. İndi xəritəyə gedə bilərsiniz.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 endirilir?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 yenilənsin?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Dayan</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Davam et</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 endirmə uğursuz oldu</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Yeni Siyahı əlavə edin</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Əlfəcin siyahı adı</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Əlfəcinlər</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Əlfəcinlər və Qeydlər</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Ad</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Ünvan</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Siyahı</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Parametrlər</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Xəritələri yadda saxlayın</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Xəritələrin yüklənəcəyi qovluğu seçin</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Xəritələr</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2-nin %1-i boşdur</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Xəritələr köçürülsün?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Xəritə fayllarının köçürülmə xətası</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Bu proses bir neçə dəqiqə çəkə bilər.&#32;
+Zəhmət olmasa gözləyin.</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Ölçü vahidləri</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Mil və ya kilometr seçin</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Yükləməni ləğv et</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Şərh yaz</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Bəli</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Xəritəni yükləyin</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Əlfəcin siyahıları</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Harada yemək</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Ərzaq mağazası</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Nəqliyyat</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Yanacaq doldurma məntəqəsi</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Avtomobil dayanacağı</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Alış-veriş</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>İkinci əl</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Otel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Görməli yerlər</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Əyləncə</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Gecə həyatı</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Ailə tətili</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Aptek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Xəstəxana</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Ayaqyolu</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Poçt</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polis</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Təkrar emal</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Su</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Karvan qurğuları</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Qeydlər</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps əlfəcinləri sizinlə paylaşıldı</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Salam!
+
+Organic Maps əlfəcinlərim əlavə olunub. Zəhmət olmasa Organic Maps-da onları açın. Əgər onu quraşdırmamısınızsa, bu linkə daxil olub cihazınıza yükləyə bilərsiniz: https://omaps.app/get?kmz
+
+Organic Maps ilə səyahətdən həzz alın!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Əlfəcinlər yüklənir</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Əlfəcinlər uğurla yükləndi! Siz onları Xəritədə və ya Əlfəcin Menecer ekranında tapa bilərsiniz.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Əlfəcinlərin quraşdırılması uğursuz oldu. Fayl zədələnmiş və ya qüsurlu ola bilər.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Fayl növü tətbiq tərəfindən tanınmır:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Faylı açmaq alınmadı %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Redaktə et</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Məkanınız hələ müəyyən edilməyib</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Üzr istəyirik, Xəritə Yaddaşı parametrləri hazırda deaktivdir.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Xəritənin endirilməsi hazırda davam edir.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Salam, Organic Maps&#x27;da mənim hal-hazırda olduğum ünvanı yoxla! %1 və ya %2 Oflayn xəritələriniz yoxdur? Buradan endirin: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Salam, Organic Maps xəritəsində mənim pin kodumu yoxlayın!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, Organic Maps&#x27;da mənim hal-hazırda olduğum ünvana baxın!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Salam,
+
+Mən hazırda bu ünvandayam: %1. Xəritədə yeri görmək üçün %2 və ya %3 üzərinə klikləyin.
+
+Təşəkkür edirik.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Paylaşın</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-poçt</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Buferə kopyalandı: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Bitdi</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap datası: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>OpenStreetMap hesabınızdan çıxmaq istədiyinizə əminsiniz?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Marşrutlari</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Uzunluq</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Məkanımı Paylaşın</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Ümumi Parametrlər</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Məlumat</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Naviqasiya</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>+ və - düymələri xəritədə</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Xəritədə göstər</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Qaranlıqda naviqasiya edərkən gecə üslubu</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Gecə rejimi</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Bağlı</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Açıq</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Avtomatik</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektiv baxış</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D strukturları</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D binalar enerjiyə qənaət rejimində söndürülür</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Səsli təlimatlar</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Küçə adlarını elan edin</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Aktiv edildikdə, dönmək üçün küçənin və ya çıxışın adı ucadan səsləndiriləcək.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Audio Dil</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Daha yüksək keyfiyyətli səsi yükləmək üçün Parametrlər tətbiqini açın və Əlçatanlıq → VoiceOver → Nitq → Səs bölməsinə keçin.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test səsli göstərişlər (TTS, Text-to-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>İndi səs eşitmirsinizsə, səs səviyyəsini və ya sistemin mətndən nitqə çevirmə parametrlərini yoxlayın.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Mövcud deyil</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Avtomatik böyütmə</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Məsafə</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Xəritədə baxın</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menyu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Veb sayt</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Xəbərlər</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Rəy</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Proqramı qiymətləndirin</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Yardım</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Tez-tez soruşulan suallar</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Bağışlamaq</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Artıq ianə edildi</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Daha sonra xatırlat</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps-i dəstəkləmək</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Bu layihəni dəstəkləyin</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Müəllif hüququ</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Problemi bildirin</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Kompası kalibrləmək və ox istiqamətini yaxşılaşdırmaq üçün telefonu səkkiz rəqəmi şəklinə çevirin.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Kompası kalibrləmək və xəritədə oxun istiqamətini düzəltmək üçün telefonu səkkiz rəqəmlə hərəkət etdirin.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>İnterfeysi görmək üçün yenidən xəritəyə uzun müddət toxunun</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Hamısını yeniləyin</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Hamısını ləğv et</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Yükləmələr</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Növbədə</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Mənə yaxın</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Xəritələr</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Hamısını Yükləyin</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Endirilir:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Xəritəni təmizləmək üçün naviqasiyanı dayandırın.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Marşrutlar yalnız bir bölgənin xəritəsində tamamilə yaradıla bilər.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Xəritəni yükləyin</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Yenidən cəhd et</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Xəritəni silin</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Xəritəni yeniləyin</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Məkan Xidmətləri</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bluetooth, WiFi və ya mobil şəbəkə vasitəsilə təxmini yerinizi tez müəyyənləşdirin</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Marşrut boyunca bütün xəritələri endirin</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Marşrut yaratmaq üçün yerinizdən təyinat yerinə qədər bütün xəritələri endirməli və güncəlləşdirməliyik.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Kifayət qədər yer yoxdur</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Zəhmət olmasa məkan xidmətlərini aktivləşdirin</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Yadda saxla</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>yaratmaq</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Qırmızı</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Sarı</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Mavi</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Yaşıl</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Bənövşəyi</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Narıncı</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Qəhvəyi</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Çəhrayı</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tünd bənövşəyi</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Açıq mavi</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Göy-yaşıl</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Dəniz mavisi</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limon rəngi</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tünd narıncı</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Boz</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Mavi-boz</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Məlumat</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps versiyası: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Görünüş</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Parlaq</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tünd</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Şəfəqdən gün batana qədər açıq</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Digər</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Milyonlarla istifadəçiyə reklamsız, pulsuz xəritələr hədiyyə edin!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Yanlış xəritə məlumatlarını bildirin və ya düzəldin</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Könüllü olmaq</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>İzləyin və bizimlə əlaqə saxlayın:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-poçt müştəri xidməti hələ quraşdırılmayıb. Zəhmət olmasa e-poçt müştəri xidmətini konfiqurasiya edin və ya %1 vasitəsilə bizimlə əlaqə saxlayın.</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>E-poçt göndərmə xətası</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompas kalibrlənməsi</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Mövcuddur</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Tapıldı</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Yeniləyin</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Uğursuz</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>əlfəcin</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Marşrutunuzu izləyərkən aşağıdakıları yadda saxlayın:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Yol şəraiti, yol hərəkəti qaydaları və yol nişanları həmişə naviqasiya məsləhətindən üstündür;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Xəritə dəqiq olmaya bilər və tövsiyə olunan marşrut təyinat yerinə çatmağın ən yaxşı yolu olmaya bilər;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Təklif olunan marşrutlar yalnız tövsiyə kimi hesab edilməlidir;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Sərhəd bölgələrində marşrutlarla diqqətli olun: tətbiqimiz yaradılan marşrutlar bəzən icazə verilməyən yerlərdə ölkə sərhədlərini keçə bilər.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Xahiş edirəm, yolda diqqətli və təhlükəsiz olun!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS siqnalını yoxlayın</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Marşrut yaratmaq mümkün deyil. Cari GPS koordinatlarını müəyyən etmək mümkün olmadı.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Zəhmət olmasa GPS siqnalınızı yoxlayın. Wi-Fi-ı aktivləşdirmək məkan dəqiqliyini artırır.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Məkan xidmətlərini aktivləşdirin</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Cari GPS koordinatlarını müəyyən etmək mümkün deyil. Marşrutları hesablamaq üçün məkan xidmətlərini aktivləşdirin.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Marşrut müəyyənləşdirmək mümkün deyil</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Marşrut yaratmaq mümkün deyil.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Zəhmət olmasa başlanğıc nöqtənizi və ya təyinat yerinizi müəyyənləşdirin.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Başlanğıc nöqtəsini təyin edin</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Marşrut yaratmaq mümkün olmadı. Başlanğıc nöqtəsini təyin etmək mümkün deyil.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Zəhmət olmasa yola daha yaxın bir başlanğıc nöqtəsi seçin.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Hədəfinizi təyin edin</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Marşrut yaradılmadı. Təyinatı tapmaq mümkün deyil.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Zəhmət olmasa yola yaxın bir təyinat yeri seçin.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Aralıq nöqtəni tapmaq mümkün deyil.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Zəhmət olmasa aralıq nöqtənizi təyin edin.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistem xətası</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Tətbiq xətası səbəbindən marşrut yaratmaq mümkün olmadı.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Zəhmət olmasa bir daha cəhd edin</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>İndi yox</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Xəritəni endirmək və çoxsaylı xəritələr arasında daha rahat marşrut yaratmaq istərdinizmi?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Bu xəritənin sərhədlərini keçən daha rahat marşrut yaratmaq üçün xəritəni endirin.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Lazımi faylları yükləyin</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Marşrutu hesablamaq üçün proqnozlaşdırılan yol boyunca bütün xəritələri endirin və ya yeniləyin.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Axtarmaq və marşrut yaratmağa başlamaq üçün xəritəni endirin. Yüklədikdən sonra artıq internet bağlantısına ehtiyacınız olmayacaq.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Xəritə seçin</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Göstər</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Gizlət</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kateqoriyalar</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Keçmiş</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Üzr istəyirik, heç bir nəticə tapılmadı.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Axtardığınız bölgəni endirin və ya yaxınlıqdakı şəhər/kənd adını əlavə etməyə cəhd edin.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Axtarış tarixçəsi</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Son axtarışlara baxın.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Axtarış Tarixçəsini silin</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Vikipediya</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org saytından məqalə</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Məkanınız</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Başla</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Başlanğıc</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Son dayanacaq</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Naviqasiya yalnız cari yerinizdən mümkündür.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Hazırkı yerinizdən marşrut planlaşdırmağımızı istərdinizmi?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Sonrakı</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Açılır</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Bağlanır</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Plan əlavə edin</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Cədvəli silin</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Bütün gün (24 saat)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Açıq</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Bağlı</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Qeyri-iş saatları əlavə edin</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>İş saatları</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Qabaqcıl rejim</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Sadə rejim</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Qeyri-iş saatları</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Nümunə Dəyərləri</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Səhvi düzəldin</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Yer seçin</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>OpenStreetMap icmasının səhvi düzəldə bilməsi üçün problemi ətraflı təsvir edin.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Və ya bunu özünüz edin https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Göndər</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Məkan mövcud deyil</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Təmir səbəbindən bağlıdır</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Kopyalanmış yer</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Avtomatik yükləmə</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Hər gün</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>7/24</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Bu gün bağlıdır</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Bağlı</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Bu gün</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>%1 sonra açılır</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>%1 sonra bağlanır</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Bağlı</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>İş saatlarını redaktə edin</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>OpenStreetMap hesabınız yoxdur?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>OpenStreetMap üçün qeydiyyatdan keçin</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Daxil ol</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Giriş edilməyib</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMap-a daxil olun</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Parol</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Parolu unutmusunuz?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Çıxış</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Məkanı Redaktə edin</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Dil əlavə edin</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Küçə</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Bina nömrəsi</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Təfərrüatlar</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sosial Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>bina</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Küçə əlavə edin</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Küçə adını daxil edin</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Dil seçin</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Küçə seçin</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Mətbəx</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Mətbəx seçin</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-poçt və ya istifadəçi adı</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Telefon əlavə edin</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Mərtəbə</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Səviyyə: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Bütün xəritə dəyişiklikləri xəritə ilə birlikdə silinəcək.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Xəritələri yeniləyin</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Marşrut yaratmaq üçün bütün xəritələri yeniləməli və sonra marşrutu yenidən planlaşdırmalısınız.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Xəritəni tapın</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Zəhmət olmasa cihazınızın internetə qoşulduğundan əmin olun.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Kifayət qədər yer yoxdur</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Zəhmət olmasa lazımsız məlumatları silin</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Giriş xətası</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Təsdiqlənmiş Dəyişikliklər</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Xaç işarəsini yer və ya biznesin yerinə qoymaq üçün xəritəni dartın.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Redaktə</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Əlavə</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Yerin adı</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Yerli dildə yazıldığı kimi</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kateqoriya</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Problemin ətraflı təsviri</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Fərqli problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Təşkilat əlavə edin</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Burada obyekti yerləşdirmək mümkün deyil</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>%1 tarixinə icma tərəfindən yaradılmış OpenStreetMap datası. OpenStreetMap.org saytında xəritəni necə redaktə etmək və yeniləmək haqqında ətraflı məlumat əldə edin</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) pulsuz və açıq xəritə yaratmaq üçün icma layihəsidir. Bu, Organic Maps xəritə məlumatlarının əsas mənbəyidir və Vikipediya kimi fəaliyyət göstərir. Siz yerlər əlavə edib və ya redaktə edə bilərsiniz və onlar bütün dünyada milyonlarla istifadəçi üçün əlçatan olur. İcmaya qoşulun və hər kəs üçün daha yaxşı xəritə yaratmağa kömək edin!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>OpenStreetMap hesabı yaradın və ya xəritə redaktələrinizi dünyada dərc etmək üçün daxil olun.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Mobil şəbəkə vasitəsilə endirilsin?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Bəzi planlarda və ya rouminqlə bu olduqca bahalı hesab oluna bilərr.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Etibarlı bina nömrəsini daxil edin</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Mərtəbə sayı (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Mərtəbələrin sayı %1-dən çox olmamalıdır</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Poçt kodu</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Etibarlı poçt kodu daxil edin</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap könüllüləri üçün qeyd (isteğe bağlı)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Xəritədəki səhvləri və ya redaktə edilə bilməyən elementləri təsvir edinOrganic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Redaktələriniz ictimai &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Tr:About&quot;&gt;OpenStreetMap&lt;/a&gt; verilənlər bazasına yüklənir. Zəhmət olmasa şəxsi və ya müəllif hüquqları ilə qorunan məlumatları əlavə etməyin.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap haqqında əlavə məlumat</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Redaktə tarixçəniz</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Xəritə məlumatı qeydləriniz</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Uyğun kateqoriya tapa bilmirsiniz?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps yalnız sadə nöqtə kateqoriyaları əlavə etməyə imkan verir, yəni şəhərlər, yollar, göllər, binaların konturları və s. daxil deyil. Zəhmət olmasa belə kateqoriyaları birbaşa &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; saytına əlavə edin. Ətraflı addım-addım təlimat üçün &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;bələdç&lt;/a&gt;imizə baxın.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Siz heç bir xəritə endirməmisiniz</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Ünvanları tapmaq və oflayn naviqasiya etmək üçün xəritələri endirin.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Cari yer məlum deyil.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/saat</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mil/saat</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>saat</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>dəq</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>gün</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>san</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Digər</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Əlfəcini redaktə edin</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Şəxsi qeydlər (mətn və ya html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Şərh…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Bütün yerli dəyişikliklər ləğv edilsin?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>İmtina</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Əlavə edilmiş məkan silinsin?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Sil</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Bu yer mövcud deyil</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Zəhmət olmasa bu məkanı silməyin səbəbini göstərin</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Etibarlı telefon nömrəsi daxil edin</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Etibarlı veb ünvanı daxil edin</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Etibarlı e-poçt ünvanını daxil edin</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Etibarlı Facebook veb-ünvanı, hesabı və ya səhifə adını daxil edin</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Etibarlı Instagram veb ünvanı və ya hesab adını daxil edin</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Etibarlı Twitter veb-ünvanı və ya istifadəçi adı daxil edin</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Etibarlı VK veb-ünvanı və ya hesab adını daxil edin</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Etibarlı LINE veb-ünvanı və ya LINE ID daxil edin</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>OpenStreetMap-a Yer əlavə edin</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Yoxsa alternativ olaraq, OpenStreetMap icmasına bir qeyd buraxın ki, başqa biri burada bir yeri əlavə etsin və ya düzəldsin.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Qeyd OpenStreetMap-ə göndəriləcək</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Bunu bütün istifadəçilərə göndərmək istəyirsiniz?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Heç bir şəxsi məlumat daxil etmədiyinizə əmin olun.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap redaktorları dəyişikliklərinizi yoxlayacaq və hər hansı sualınız olarsa, sizinlə əlaqə saxlayacaq.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Dayan</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Marşrutu qeyd etmək</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Qəbul et</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Rədd et</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Ətraflı məlumatı görmək üçün mobil internetdən istifadə etmək istəyirsiniz?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>İstənilən vaxt istifadə edin</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Sadəcə bu gün</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Bu gün istifadə etməyin</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobil Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Xəritə yeniləmə bildirişləri və redaktələrin yüklənməsi üçün mobil internet tələb olunur.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Heç vaxt istifadə etməyin</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Həmişə Soruşun</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Nəqliyyat məlumatlarını göstərmək üçün xəritələr yenilənməlidir.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Xəritədə şrift ölçüsünü artırın</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Organic Maps&#x27;i yeniləyin</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Nəqliyyat məlumatları mövcud deyil</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Girişi aktivləşdirin</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Ümumi rəy</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Biz səsli təlimatlar üçün TTS sistemindən istifadə edirik. Əksər Android cihazları Google TTS-dən istifadə edir. Siz proqramı Google Play-dən yükləyə və ya yeniləyə bilərsiniz</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Bəzi dillər üçün proqram mağazasından (Google Play, Galaxy Store, App Gallery, FDroid) fərqli nitq sintezatoru və ya əlavə dil paketi quraşdırmalı ola bilərsiniz.&#32;
+Cihaz parametrləri → Dil və Daxiletmə → Nitq → Mətndən nitqə funksiyasını yandırın.&#32;
+Buradan siz nitq sintezi parametrlərini idarə edə bilərsiniz (məsələn, oflayn istifadə üçün dil paketini endirə bilərsiniz) və başqa mətndən-nitqə mühərrik seçə bilərsiniz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Əlavə məlumat üçün bu təlimatı nəzərdən keçirin.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Latın transliterasiyası</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Daha ətraflı</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Marşrutun başlanğıc nöqtəsi əlavə etmək üçün axtarışdan istifadə edin və ya xəritədə klikləyin</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Təyinat nöqtəsi əlavə etmək üçün axtarışdan istifadə edin və ya xəritədə klikləyin</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Marşrutu idarə et</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Kəsmə nöqtəsini silin</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Dayanacaq nöqtəsini əlavə edin</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Yadda saxlanıldı</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Bütün xəritə redaktələrinizi avtomatik yükləmək üçün OpenStreetMap-a daxil olun. &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;burada&lt;/a&gt; ətraflı məlumat əldə edin.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Yaddaş giriş problemi</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Xarici yaddaş mövcud deyil, ola bilsin ki, SD Kart çıxarılıb, zədələnib və ya fayl sistemi yalnız oxunur. Zəhmət olmasa yoxlayın və ya support@organicmaps.app ünvanında bizimlə əlaqə saxlayın</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Zədələnmiş yaddaşı təqlid edin</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Düzgün ad daxil edin</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Siyahılar</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hamısını gizlət</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Hamısını göstər</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n əlfəcin</numerusform>
+<numerusform>%n əlfəcinlər</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Yeni siyahı yaradın</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Əlfəcinləri və fraqmentləri idxal edin</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Tətbiq xətası səbəbindən paylaşmaq mümkün deyil</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Paylaşım xətası</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Boş siyahı paylaşıla bilməz</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Ad boş ola bilməz</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Siyahı adını daxil edin</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Yeni siyahı</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Bu ad artıq götürülüb</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Zəhmət olmasa başqa ad seçin</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Zəhmət olmasa, gözləyin…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefon nömrəsi</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profili</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fayl tapıldı. Onu dönüşümdən sonra görəcəksiniz.</numerusform>
+<numerusform>%n fayl tapıldı. Onları dönüşümdən sonra görəcəksiniz.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Bərpa</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n istiqamət</numerusform>
+<numerusform>%n istiqamətlər</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Məxfilik</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Gizlilik Siyasəti</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>İstifadə qaydaları</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Nəqliyyat</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Piyada gəzinti</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Velosiped gəzintisi</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Xəritə Üslubları və Qatları</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Bu siyahı boşdur</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Əlfəcin əlavə etmək üçün xəritədə yerə və sonra ulduz işarəsinə toxunun</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Bütün əlfəcinlərin rəngini dəyişdir</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Bütün treklərin rəngini dəyişdir</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…daha çox</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZ ixrac edin</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPX ixrac edin</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSON ixrac edin</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Siyahını silin</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Sürət kameraları</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Məkan Təsviri</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Xəritə yükləyicisi</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Sürətlə bağlı xəbərdarlıq edin</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Həmişə xəbərdar edin</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Heç xəbərdar etməyin</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Enerji qənaət rejimi</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Bəzi funksionallıq hesabına enerji istehlakını azaltmağa çalışın.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Heç vaxt</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Avtomatik</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Maksimum enerji qənaəti</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Xəritədə nişan adları</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Əgər çoxlu nişanlar varsa, onların adlarını xəritədə göstərmək tətbiqin işini ləngidə bilər.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Sağa göstər</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Aşağıda göstər</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Yardım dialoq qutusunda “Problemi bildir” istifadə etməklə probleminizlə bağlı ətraflı diaqnostik jurnalları qeyd etmək və bizə göndərmək üçün bu seçimi müvəqqəti aktivləşdirin. Qeydlərə məkan məlumatı daxil ola bilər</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Marşrutlaşdırma seçimləri</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Rüsumlardan çəkinin</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Asfaltsız yollardan çəkinin</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Bərə keçidlərindən çəkinin</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Magistral yoldan çəkinin</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Marşrutu hesablamaq mümkün deyil</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Təəssüf ki, seçdiyiniz seçimlərə görə marşrut tapa bilmədik. Seçimləri dəyişdirin və yenidən cəhd edin</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Qarşısını almaq üçün yolları müəyyənləşdirin</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Sürmə seçimləri aktiv edildi</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Ücrətli yol</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Asfaltsız yol</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Bərə keçidi</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Bəli</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Yox</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Var</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Yox</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Sıxlıq: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Şəbəkə: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Sən gəldin!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Yaxşı</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Çeşid…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Əlfəcinləri çeşidləyin</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Defoltolaraq</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Növünə görə</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Məsafəyə görə</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Tarixə görə</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Ada görə</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Bir həftə əvvəl</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Bir ay əvvəl</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Bir aydan çox əvvəl</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Bir ildən çox əvvəl</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Mənə yaxın</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Digərləri</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Marşrutun Planlaşdırılması uğursuz oldu</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Gəliş: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Marşrut hesablamaq üçün proqnozlaşdırılan yol boyunca bütün xəritəni endirin və yeniləyin.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Siz dünya xəritəsini dəyişdiniz. Gizlətməyin! Dostlarınıza deyin və birlikdə redaktə edin.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Dostlarınızla paylaşın</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>İndi bağlıdır</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Sabah açılır %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 %2 açılır</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Açılır %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Bağlanır %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Açılış saatlarını əlavə edin</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Parol (ən azı 8 simvol)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Yanlış istifadəçi adı və ya şifrə.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Hesabı</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Son yükləmə</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Təşəkkür edirik</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Yerin Adı</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Diqqət edin</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Yükləmə xətası</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Kateqoriya seçin</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Məşhur</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Bütün kateqoriyalar</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Xəritəyə yeni yerlər əlavə edin və mövcud yerləri birbaşa tətbiqdən redaktə edin.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Ünvanı dəyişdirin</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Endirmək üçün daha çox yerə ehtiyacınız var. Zəhmət olmasa önəmli olmayan məlumatları silin.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Organic Maps xəritələrini təkmilləşdirdim</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Ətraflı şərh</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Təklif etdiyiniz dəyişikliklər OpenStreetMap icmasına yerləşdiriləcək. Zəhmət olmasa Organic Maps&#x27;da redaktə edilə bilməyən əlavə detalları izah edin.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Məkanınızı axtararkən xəta baş verdi. Cihazınızın düzgün işlədiyini yoxlayın və sonra yenidən cəhd edin.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Məkan xidmətləri deaktiv edilib</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Cihaz parametrlərində geolokasiyaya girişi aktiv edin</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Parametrləri açın</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Məkan üzərinə toxunun</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. &quot;Tətbiqdən istifadə edərkən&quot; seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Məxfilik seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Məkan Xidmətləri seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Məkan Xidmətlərini yandırın</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Yoxsa Location olmadan Organic Maps-dən istifadə etməyə davam edin</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervasyon</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Zəng</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Əlfəcin Adı</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Əlfəcini silin</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Təklif etdiyiniz dəyişikliklər təqdim edildi</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…daha çox</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Yenilə</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Son səyahət etdiyiniz marşrutun qeydə alınması deaktiv edilsin?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Deaktiv edin</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Yoxla</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps son səyahət etdiyiniz marşrutu qeyd etmək üçün arxa fonda geolokasiyadan istifadə edir.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Ümumi Parametrlər</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Nəqliyyat məlumatlarına baxmaq üçün tətbiq yenilənməlidir.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Giriş faylının ölçüsü: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Silmək üçün bura çəkin</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Duruşu əvəz et</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Buradan başlayın</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Bütün xəritə redaktələrinizi avtomatik yükləmək üçün OpenStreetMap-a daxil olun.</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>burada</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ekranı Gizlət</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 endirilir…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 həyata keçirilir…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Bu ad çox uzundur</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Yeni fayllar aşkar edildi</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Çevir</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Səhv</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Bəzi fayllar çevrilmədi.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Xəta baş verdi</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Məşhur</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Xəritədən gizlədin</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Etiketləri yükləyərkən xəta baş verdi, zəhmət olmasa yenidən cəhd edin</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Sağ</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Aşağı</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Gedək</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Hədəf</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Yenidən mərkəzləşdirin</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Axtarış nəticələri</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Daha sonra</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Marşrutu yenidən yaratmaq istərdinizmi?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Sürücülük zamanı klaviatura istifadə edilə bilməz</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Cari məkanınızdan marşrut yaratmaq mümkün deyil</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Təyinat yerinə marşrut yaratmaq mümkün deyil. Zəhmət olmasa başqa nöqtə seçin</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS siqnalı yoxdur. Zəhmət olmasa açıq sahəyə keçin</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Marşrut yaratmaq mümkün deyil. Zəhmət olmasa başqa marşrut nöqtəsini göstərin</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Marşrutlar yaratmaq üçün əksik xəritələri cihazınıza endirin</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Xəta baş verdi. Zəhmət olmasa tətbiqi yenidən başladın</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Marşrut cari yerinizdən yenidən yaradılacaq</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Marşrut sürücülük marşrutuna çevriləcək</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Bütün əlfəcinlər göstərilmir</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Bütün əlfəcinləri görmək üçün telefona keçin</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Sürət kameraları</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Sürət xəbərdarlıqları</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Organic Maps tətbiqindən xəritələri cihazınıza endirin</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 çıxın</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Defolt olaraq çeşidləyin</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Növə görə çeşidləyin</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Məsafəyə görə çeşidləyin</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Tarixə görə çeşidləyin</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ada görə çeşidləyin</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Qida</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Görməli yerlər</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzeylər</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parklar</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Üzgüçülük</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Dağlar</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Heyvanlar</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Otellər</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Binalar</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Pul</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Ticarət mərkəzləri</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Dayanacaqlar</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Yanacaqdoldurma məntəqələri</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Dərman</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Siyahıda axtarın</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Dini yerlər</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Siyahı seçin</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro naviqasiyası bu ərazidə hələ mövcud deyil</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metro marşrutu tapılmadı</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Metro stansiyasına ən yaxın marşrutun başlanğıc və ya bitmə nöqtəsini seçin</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Ərazi</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Ərazi qatını aktivləşdirmək və istifadə etmək üçün xəritəni yeniləyin və ya endirin</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Bu bölgədə relyef təbəqəsi hələ mövcud deyil</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Qalxmaq</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Eniş</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. hündürlük</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. hündürlük</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Çətinlik</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Məsafə:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Müddət:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>İzohipləri görmək üçün xəritəni böyüdün</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Endirilir</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Dünya xəritəsini yükləyin</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Qovluq yaratmaq və faylları daxili cihazın yaddaşında və ya SD kartda köçürmək mümkün deyil</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk xətası</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Əlaqə xətası</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB kabelini ayırın</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Ekranı açıq saxlayın</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Aktiv edildikdə, xəritəyə baxarkən ekran həmişə açıq olacaq.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Kilid ekranında göstərin</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Aktivləşdirildikdən sonra proqram hər dəfə işlədikcə cihazınızın kilidini açmağa ehtiyac qalmayacaq.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Xəritə dili</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap-dan xəritə məlumatları</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsTR</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Tr:About</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>İcma tərəfindən yaradılmış xəritələrimizdən istifadə etdiyiniz üçün təşəkkür edirik!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Sizin ianələriniz və dəstəyinizlə biz dünyanın ən yaxşı xəritələrini yarada bilərik!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Tətbiqimizi bəyənirsiniz? İnkişafı dəstəkləmək üçün ianə edin! Hələ bəyənmirsiniz? Niyə belə olduğunu bizə bildirin, biz də düzəldək!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Əgər proqram tərtibatçısını tanıyırsınızsa, ona ehtiyac duyduğunuz funksiyanı əlavə etməsini xahiş edə bilərsiniz.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Nəyisə seçmək üçün xəritədə istənilən yerə toxunun. Gizlətmək və interfeysi geri göstərmək üçün uzun müddət toxunun.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Xəritədə cari yerinizi seçə biləcəyinizi bilirdinizmi?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Tətbiqimizi dilinizə tərcümə etməyə kömək edə bilərsiniz.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Tətbiqimiz bir neçə həvəskar və icma tərəfindən hazırlanıb.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Xəritə məlumatlarını asanlıqla düzəldə və təkmilləşdirə bilərsiniz.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Əsas məqsədimiz sizin sevəcəyiniz sürətli, məxfiliyə yönəlmiş, istifadəsi asan xəritələr yaratmaqdır.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>İndi telefon ekranında Organic Maps istifadə edirsiniz</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Hazırda avtomobil ekranında Organic Maps istifadə edirsiniz</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Siz Android Auto-a qoşulmusunuz</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Telefonda davam edin</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Avtomobil ekranına</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps Məkan məlumatlarına giriş tələb olunur. Təhlükəsiz olduqda telefonunuzdakı bildirişi yoxlayın.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Bu tətbiq sizin icazənizə ehtiyac duyur</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps Android Auto effektiv işləmək üçün yer icazələrinə ehtiyac duyur</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>İcazələr verin</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Yürüyüş</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Veb brauzer mövcud deyil</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Həcm</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Bütün Əlfəcinləri və Parçaları ixrac edin</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Sistem nitq sintezi parametrləri</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nitq sintezi parametrləri tapılmadı, cihazınızın bunu dəstəklədiyinə əminsiniz?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Sürüşmə</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Axtarışı təmizləyin</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Yaxınlaşdırma</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Küçült</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menyu keçidi</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Menyuya baxın</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Başqa Tətbiqdə Açın</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Özünəxidmət</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Seçim seçin</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Çöldə oturma</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Ən dəqiq naviqasiya üçün telefonun batareya parametrlərində enerjiyə qənaət rejimini söndürməyi tövsiyə edirik.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Marşrut qeydi</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Marşrut qeydini dayandır</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Marşrut yazısı</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Saxlamadan dayandırın</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Qeyd etməyə davam et</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Əlfəcinlər və qeydlərə yadda saxla?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Marşrut boşdur - saxlamaq üçün heç nə yoxdur</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Qovluq seçimi dialoqunu göstərmək mümkün deyil, çünki cihazınızda uyğun proqram quraşdırılmayıb. Lütfən, fayl meneceri proqramı quraşdırın və yenidən cəhd edin</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Rəngi seçin</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Marşrutu redaktə edin</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Məkanı aça biləcək proqram quraşdırılmayıb</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Naviqasiyada avtomatik</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Sistemə uyğun</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Yolunu paylaş</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>%1 silmək?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Çətinlik səviyyəsi</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Asan</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Orta</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Çətin</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Yenilənir</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Endirdiyiniz xəritələri yeniləyin</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Xəritələrin yenilənməsi obyektlər haqqında məlumatları yeni saxlayır</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Yeniləmə (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Daha sonra davamlı yeniləyin</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Qeydi silin</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Bu treki silmək istədiyinizə əminsiniz?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Yol qeydinin adı</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Hərəkət edin</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Yol qeydi</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Rəng dəyişdirin</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Xəritə</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>İnkişaf etdiricilərə səhv hesabatı göndərmək istərdinizmi?
+Organic Maps heç bir səhv məlumatını avtomatik olaraq toplamadığından, biz istifadəçilərimizin köməyinə güvənirik. Organic Maps-ı dəstəklədiyiniz üçün əvvəlcədən təşəkkür edirik!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud Sinxronizasiyasını aktivləşdirin</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud sinxronizasiyası inkişaf mərhələsində olan eksperimental xüsusiyyətdir. Bütün əlfəcinlərinizin və treklərinizin ehtiyat nüsxəsini yaratdığınızdan əmin olun.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Deaktivdir</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Bu funksiyadan istifadə etmək üçün cihazınızın parametrlərində iCloud-u aktiv edin.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktivləşdirin</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Yedəkləmə</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud sinxronizasiya uğursuzluğu</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Xəta: Bağlantı xətası səbəbindən sinxronizasiya alınmadı</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Xəta: iCloud kvotasını keçdiyinə görə sinxronizasiya alınmadı</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Xəta: iCloud mövcud deyil</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Son Silinmiş Siyahılar</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Sil</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Hamısını Sil</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Bərpa et</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Hamısını bərpa et</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap-ə töhfə ver</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Məkan əlavə et</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Töhfə vermək üçün xəritəni yenilə</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap məlumatlarına töhfə verməzdən əvvəl %1 xəritəsini ən son versiyaya yeniləməlisiniz</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Ünvanım</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Yerlərim</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Daxili xüsusi saxlama</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Daxili paylaşılan yaddaş</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD kart</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Xarici paylaşılan yaddaş</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Poçt kodu</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Xəritə Nöqtəsi</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mil</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>Addım</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Marşrutları göstərmək üçün xəritələr yenilənməlidir.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Çıx</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Giriş</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metro xəritəsi mövcud deyil</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Sən</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Bənövşəyi yüklənmiş regionlar</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Marşrut</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Tətbiqin xüsusiyyətlərini tam çıxarmaq üçün fonda cari yeri müəyyən etmək lazımdır. O, marşrutu izləmək və son səyahət edilmiş yolları saxlamaq seçimi üçün istifadə olunur.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Cari yerinizin müəyyən edilməsi marşrutun izlənməsi və son səyahət edilmiş yol seçimlərinin saxlanmasında istifadə olunur.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Şifrə ilə giriş</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Brauzerdən istifadə edərək giriş</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Son istifadə olunan</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Əlfəcinlərin rəngi dəyişdirildi</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Treklərin rəngi dəyişdirildi</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektr</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Slayderlər</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>QIRMIZI</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>YAŞIL</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>MƏRƏKƏBƏ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Rəng #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Şəbəkə</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/be/omim.ts
+++ b/qt/translations/be/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="be">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Выдаліць</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Спампаваць мапы</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Не ўдалося спампаваць. Націсніце, каб паспрабаваць зноў.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Спампоўванне…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Кіламетры</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Мілі</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Потым</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Пошук</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Пошук на карце</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Служба геалакацыі адключана для гэтай прылады або праграмы. Калі ласка, уключыце яе ў Наладах.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Абмежаваная дакладнасць</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Для забеспячэння дакладнай навігацыі ўключыце дакладнае месцазнаходжанне ў наладах.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Паказаць на карце</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Збой спампоўвання</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Паспрабаваць зноў</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Аб праграме Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Бясплатная для ўсіх, зробленая з любоўю</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Без рэкламы, без трэкінгу, без збірання вашых даных</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Без празмернай разрадкі батарэі, працуе ў аўтаномным рэжыме</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Хуткая, мінімалістычная, распрацаваная супольнасцю</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Праграма з адкрытым зыходным кодам, створаная энтузіястамі і валанцёрамі.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Налады месцазнаходжання</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Закрыць</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Для працы праграмы патрабуецца апаратнае паскарэнне OpenGL. На жаль, ваша прылада не падтрымліваецца.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Спампаваць</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Адключыце кабель USB або ўстаўце карту памяці, каб карыстацца Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Вызваліце месца на SD-карце/USB-сховішчы, каб карыстацца праграмай</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Перш чым пачаць карыстацца праграмай, спампуйце на сваю прыладу аглядную мапу свету.&#32;
+Для яе спатрэбіцца %1 у сховішчы.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Перайсці да мапы</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Спампоўванне %1. Цяпер вы можаце&#32;
+перайсці да мапы.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Спампаваць %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Абнавіць %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Прыпыніць</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Працягнуць</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Не ўдалося спампаваць %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Дадаць спіс</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Назва спісу закладак</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Закладкі</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Закладкі і трэкі</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Назва</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Адрас</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Спіс</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Налады</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Захоўваць мапы ў</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Выбар папкі для захоўвання спампаваных мап.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Спампаваныя мапы</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 вольна з %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Перамясціць мапы?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Памылка перамяшчэння файлаў мапы</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Гэта можа заняць некалькі хвілін.&#32;
+Калі ласка, пачакайце…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Адзінкі вымярэння</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Выбар паміж кіламетрамі і мілямі</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Скасаваць спампоўку</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Напісаць водгук</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Спампаваць мапу</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Спісы закладак</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Дзе паесці</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Прадукты</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Транспарт</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>АЗС</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Паркоўка</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Шопінг</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Сэканд-хэнд</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Гатэль</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Славутасці</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Забавы</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Банкамат</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Начное жыццё</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Сямейны адпачынак</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Банк</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Аптэка</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Бальніца</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Прыбіральня</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Пошта</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Паліцыя</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Перапрацоўка адходаў</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Вада</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Для аўтадамоў</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Нататкі</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>З вамі падзяліліся закладкамі Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Вітаю!
+
+У далучаным файле мае закладкі, яны адкрываюцца праграмай Organic Maps. Калі такая праграма ў вас не ўсталявана, яе можна спампаваць тут: https://omaps.app/get?kmz
+
+Прыемных падарожжаў з Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Загрузка закладак</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Закладкі паспяхова загружаны! Вы можаце іх убачыць на карце або ў захаваных закладках.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Не ўдалося загрузіць закладкі. Файл можа быць пашкоджаны або няспраўны.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Праграма не распазнае тып файла:&#32;
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Не ўдалося адкрыць файл %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Рэдагаваць</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ваша месцазнаходжанне яшчэ не вызначана</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>На жаль, налады сховішча мапы зараз адключаны.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Ідзе спампоўванне мапы.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Гэй, глядзі дзе я зараз на мапе Organic Maps! %1 або %2 Няма афлайн-мап? Спампуй тут: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Гэй, глядзі маю метку на Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Гэй, глядзі дзе я зараз на карце Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Прывітанне,&#32;
+&#32;
+Я зараз тут: %1. Перайдзі па гэтай %2 або гэтай %3 спасылцы, каб убачыць месца на карце.&#32;
+&#32;
+Дзякуй.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Абагуліць</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Электронная пошта</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Скапіявана ў буфер абмену: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Гатова</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Даныя OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Вы ўпэўнены, што хочаце выйсці са свайго ўліковага запісу OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Маршруты</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Даўжыня</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Абагуліць маё месцазнаходжанне</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Агульныя налады</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Інфармацыя</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Навігацыя</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Кнопкі «+» і «-» на мапе</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Адлюстраванне на карце</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Начны стыль пры навігацыі ў цемры</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Начны рэжым</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Выключаны</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Уключаны</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Аўтаматычна</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Перспектыва</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-будынкі</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>У рэжыме энергазберажэння 3D-будынкі адключаны</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Галасавыя інструкцыі</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Абвяшчаць назвы вуліц</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Калі ўключана, назва вуліцы або выезду, на які трэба павярнуць, будзе прамаўляцца ўслых.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Мова агучвання</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Каб спампаваць голас вышэйшай якасці, адкрыйце праграму Налады і перайдзіце ў Даступнасць → VoiceOver → Маўленне → Голас.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Тэставыя галасавыя ўказанні (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Калі вы зараз не чуеце голас, праверце гучнасць або налады сістэмнага сінтэзатара маўлення.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Недаступны</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Аўтаматычны маштаб</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Адлегласць</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Паглядзець на карце</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Меню</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Вэб-сайт</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Навіны</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Водгук</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Ацаніць праграму</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Даведка</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Пытанні і адказы</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Падтрымаць грашыма</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ужо ахвяравана</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Нагадаць пазней</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Падтрымаць Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Падтрымаць праект</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Аўтарскія правы</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Паведаміць аб памылцы</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Палепшыце кірунак стрэлкі, перамяшчаючы тэлефон у выглядзе васьмёркі, каб адкалібраваць компас.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Перамяшчайце тэлефон у выглядзе васьмёркі, каб адкалібраваць компас і зафіксаваць кірунак стрэлкі на карце.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Паўторнае працяглае націсканне верне бачнасць інтэрфейсу</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Абнавіць усе</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Скасаваць усе</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Спампаваныя</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>У чарзе</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Каля мяне</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Карты</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Спампаваць усе</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Спампоўванне:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Каб выдаліць мапу, спыніце навігацыю.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Маршруты можна пракладваць толькі ў межах мапы аднаго рэгіёна.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Спампаваць мапу</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Паспрабаваць зноў</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Выдаліць мапу</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Абнавіць мапу</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Службы месцазнаходжання Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Хуткае вызначэнне прыблізнага месцазнаходжання з дапамогай Bluetooth, WiFi або мабільнай сеткі</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Спампаваць усе мапы на вашым маршруце</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Каб пракласці маршрут, трэба спампаваць і абнавіць усе мапы на шляху руху.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Не хапае месца</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Уключыце геалакацыю</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Захаваць</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>стварыць</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Чырвоны</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Жоўты</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Сіні</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Зялёны</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Пурпурны</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Аранжавы</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Карычневы</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Ружовы</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Цёмна-пурпурны</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Блакітны</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Сіне-зялёны</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Смарагдавы</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Лайм</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Цёмна-аранжавы</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Шэры</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Блакітна-шэры</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Інфармацыя</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Версія Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Выгляд</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Светлы</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Цёмны</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Светлая ад світання да змяркання</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Іншы</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Падарыце бясплатныя мапы без рэкламы мільёнам карыстальнікаў!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Выправіць або паведаміць пра няправільныя даныя на карце</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Стаць валанцёрам</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Падпісвайцеся і пішыце нам:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Паштовы кліент не наладжаны. Наладзьце яго альбо звяжыцеся з намі па адрасе %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Памылка пры адпраўцы пошты</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Каліброўка компаса</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Даступныя</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Знойдзена</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Абнавіць</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Не ўдалося</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>закладка</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Падчас руху па маршруце памятайце:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Дарожныя ўмовы, правілы дарожнага руху і дарожныя знакі заўсёды маюць прыярытэт над падказкамі навігацыі;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Карта можа быць недакладнай, а прапанаваны маршрут не заўжды найлепшым;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Прапанаваныя маршруты трэба ўспрымаць толькі як рэкамендацыі;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Будзьце ўважлівы з маршрутамі ў памежных зонах: маршруты, пракладзеныя нашай праграмай, часам могуць перасякаць мяжу ў недазволеных месцах.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Будзьце пільнымі і паводзьце сябе бяспечна на дарозе!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Праверце сігнал GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Не ўдалося пракласці маршрут. Каардынаты GPS не вызначаны.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Калі ласка, праверце сігнал GPS. Для больш дакладнага вызначэння месцазнаходжання ўключыце Wi-Fi.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Уключыць геалакацыю</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Немагчыма вызначыць каардынаты GPS. Каб пракласці маршрут, уключыце геалакацыю.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Не ўдалося знайсці маршрут</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Не ўдалося пракласці маршрут.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Калі ласка, змяніце пункт адпраўлення або прызначэння.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Змяніце пункт адпраўлення</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Маршрут не пракладзены. Не знойдзены пункт адпраўлення.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Выберыце пункт адпраўлення бліжэй да дарогі.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Змяніце пункт прызначэння</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Маршрут не пракладзены. Не знойдзены пункт прызначэння.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Выберыце пункт прызначэння бліжэй да дарогі.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Не знойдзены прамежкавы пункт маршруту.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Змяніце прамежкавы пункт.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Памылка сістэмы</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Не ўдалося пракласці маршрут з-за памылкі праграмы.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Паспрабуйце зноў</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Не зараз</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Спампаваць мапу і пракласці лепшы маршрут праз некалькі мап?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Спампаваць дадатковыя мапы, каб пракласці лепшы маршрут, які перасякае межы гэтай мапы.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Спампуйце неабходныя файлы</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Спампуйце або абнавіце ўсе мапы і даныя навігацыі на шляху руху, каб пракласці маршрут.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Каб шукаць месцы і пракладваць маршруты, спампуйце мапу. Пасля гэтага падключэнне да інтэрнэту вам больш не спатрэбіцца.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Выбраць мапу</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Паказаць</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Схаваць</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Катэгорыі</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Гісторыя</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Нічога не знойдзена.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Спампуйце рэгіён, у якім вы шукаеце, або паспрабуйце дадаць назву бліжэйшага горада/вёскі.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Гісторыя пошуку</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Прагляд апошніх выкарыстаных пошукавых запытаў.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Ачысціць гісторыю пошуку</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Вікіпедыя</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Артыкул з wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Ваша месцазнаходжанне</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Пачаць</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Адсюль</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Дасюль</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Навігацыя магчыма толькі ад цяперашняга месцазнаходжання.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Хочаце перапракласці маршрут ад цяперашняга месцазнаходжання?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Далей</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>З</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Да</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Дадаць расклад</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Выдаліць расклад</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Цэлы дзень (24 гадзіны)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Адкрыта</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Закрыта</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Дадаць час, калі закрыта</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Час працы</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Пашыраны рэжым</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Просты рэжым</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Час, калі закрыта</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Прыклады значэнняў</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Выправіць памылку</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Выберыце месца</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Калі ласка, падрабязна апішыце праблему, каб супольнасць OpenStreetMap магла выправіць памылку.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Або зрабіце гэта самі на https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Адправіць</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Праблема</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Месца не існуе</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Закрыта на рамонт</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Месца паўтараецца</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Аўтаматычнае спампоўванне</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Штодзённа</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Сёння закрыта</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Закрыта</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Сёння</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Адчыняецца праз %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Зачыняецца праз %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Закрыта</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Правіць часы працы</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Не зарэгістраваныя на OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Зарэгістравацца на OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Увайсці</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Не ўвайшлі ў сістэму</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Увайсці ў OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Забылі пароль?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Выйсці</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Правіць месца</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Дадаць мову</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Вуліца</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Нумар будынка</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Падрабязнасці</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Сацыяльныя сеткі</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Будынак</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Дадаць вуліцу</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Увядзіце назву вуліцы</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Выбраць мову</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Выбраць вуліцу</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Кухня</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Выбраць кухню</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email або імя карыстальніка</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Дадаць тэлефон</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Паверх</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Узровень: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Разам з мапай будуць выдалены і ўсе вашы праўкі мапы.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Абнавіць мапы</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Каб стварыць маршрут, вам трэба абнавіць усе мапы і потым пракласці маршрут зноў.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Пошук мапы</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Праверце налады і ўпэўніцеся, што прылада падключана да інтэрнэту.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Не хапае месца</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Выдаліце непатрэбныя даныя</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Памылка аўтарызацыі.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Правераныя змены</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Перацягвайце мапу, каб паставіць крыжык на месцы або кампаніі.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Рэдагаванне</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Дадаванне</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Назва месца</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>На мясцовай мове</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Катэгорыя</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Падрабязнае апісанне праблемы</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Іншая праблема</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Дадаць установу</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Аб&#x27;ект не можа знаходзіцца тут</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Створаныя супольнасцю даныя OpenStreetMap па стане на %1. Даведайцеся больш пра тое, як рэдагаваць і абнаўляць мапу на OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) - гэта грамадскі праект па стварэнні бясплатнай і адкрытай мапы, і асноўная крыніца картаграфічных даных у Organic Maps, якая працуе падобна на Вікіпедыю. Кожны можа дадаваць або рэдагаваць месцы, якія ўбачаць мільёны карыстальнікаў па ўсім свеце.&#32;
+Далучайцеся да супольнасці і дапамажыце зрабіць лепшую мапу для ўсіх!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Стварыце ўліковы запіс OpenStreetMap або ўвайдзіце ў сістэму, каб апублікаваць праўкі мапы ўсім на свеце.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 з %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Спампаваць праз мабільны інтэрнэт?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Гэта можа быць даволі дорага з некаторымі тарыфнымі планамі або ў роўмінгу.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Увядзіце правільны нумар дома</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Колькасць паверхаў (максімум %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Колькасць паверхаў павінна быць не больш за %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Паштовы індэкс</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Увядзіце правільны паштовы індэкс</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Заўвага для валанцёраў OpenStreetMap (неабавязкова)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Апішыце памылкі на карце або рэчы, якія немагчыма адрэдагаваць з дапамогай Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Вашы праўкі запампоўваюцца ў публічную базу даных &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Не дадавайце асабістую інфармацыю або інфармацыю, якая абаронена аўтарскім правам.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Падрабязней пра OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Ваша гісторыя рэдагавання</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Вашы заўвагі пра даныя мапы</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Аператар</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Аператар: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Няма прыдатнай катэгорыі?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps дазваляе дадаваць на мапу толькі простыя тыпы аб&#x27;ектаў, гэта значыць без гарадоў, дарог, азёр і будынкаў. Калі ласка, дадавайце такія катэгорыі на сайце &lt;a href=&quot;https://www.openstreetmap.org/&quot;&gt;OpenStreetMap.org &lt;/a&gt;. Мы таксама рэкамендуем азнаёміцца з &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing/&quot;&gt;падрабязнымі інструкцыямі і іншымі праграмамі для рэдагавання мапы&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Вы не спампавалі ніводнай мапы</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Спампуйце мапы, каб шукаць месцы і карыстацца навігацыяй без інтэрнэту.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Месцазнаходжанне невядома.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>км/г</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>міль/г</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>г</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>хв</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>д</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>с</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Яшчэ</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Рэдагаваць закладку</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Асабістыя нататкі (тэкст або html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Каментарый…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Адмовіцца ад усіх лакальных змен?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Адмовіцца</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Выдаліць дададзенае месца?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Выдаліць</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Месца не існуе</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Калі ласка, укажыце прычыну выдалення</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Увядзіце правільны нумар тэлефона</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Увядзіце правільны вэб-адрас</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Увядзіце сапраўдны адрас электроннай пошты</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Увядзіце сапраўдны вэб-адрас уліковага запісу ці імя старонкі Facebook</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Увядзіце сапраўднае імя карыстальніка або спасылку Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Увядзіце сапраўднае імя карыстальніка або спасылку Twitter</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Увядзіце сапраўднае імя карыстальніка або спасылку VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Увядзіце сапраўдны LINE ID або вэб-адрас</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Дадаць месца ў OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Або пакіньце заўвагу для супольнасці OpenStreetMap, каб нехта іншы мог дадаць або выправіць месца.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Заўвага будзе адпраўлена на OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Хочаце адправіць усім карыстальнікам?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Упэўніцеся, што вы не ўвялі ніякіх асабістых даных.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Рэдактары OpenStreetMap правераць змены і звяжуцца з вамі, калі ў іх узнікнуць пытанні.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Спыніць</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Запіс маршруту</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Прыняць</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Адхіліць</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Выкарыстоўваць мабільны інтэрнэт для паказу больш падрабязнай інфармацыі?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Заўсёды</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Толькі сёння</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Не сёння</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Мабільны інтэрнэт</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Мабільны інтэрнэт патрабуецца для апавяшчэнняў пра абнаўленне мапы і каб запампоўваць праўкі.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ніколі не выкарыстоўваць</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Заўсёды пытаць</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Каб паказаць даныя пра заторы, трэба абнавіць мапы.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Павялічыць шрыфт мапы</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Абнавіце Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Даныя пра заторы недаступны</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Уключыць вядзенне журнала</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Агульны водгук</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Мы выкарыстоўваем сістэмны сінтэзатар маўлення (TTS). На большасці прылад Android выкарыстоўваецца Google TTS, яго можна спампаваць або абнавіць праз Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Для некаторых моў вам спатрэбіцца ўсталяваць сінтэзатар маўлення або дадатковы моўны пакет з крамы праграм (Google Play, Galaxy Store, App Gallery, F-Droid).&#32;
+Зайдзіце на вашай прыладзе ў Налады → Мова і ўвод → Маўленне → Сінтэз маўлення.&#32;
+Тут вы можаце задаць налады сінтэзу маўлення (напрыклад, спампаваць моўны пакет для выкарыстання без падключэння да інтэрнэту) або выбраць іншы сінтэзатар маўлення.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Больш падрабязная інфармацыя знаходзіцца ў гэтым кіраўніцтве.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Транслітарацыя лацінкай</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Даведацца больш</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Скарыстайцеся пошукам, абярыце закладку, або націсніце на карце, каб дадаць пачатак маршруту</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Скарыстайцеся пошукам, абярыце закладку, або націсніце на карце, каб дадаць пункт прызначэння</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Кіраваць маршрутам</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Пракласці</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Выдаліць прыпынак</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Дадаць прыпынак</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Захавана</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Увайдзіце ў OpenStreetMap, каб аўтаматычна запампоўваць усе свае праўкі мапы. Даведайцеся больш &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;тут&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Праблема з доступам да сховішча</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Знешняе сховішча недаступна. Магчыма, SD-карта была вынята або пашкоджана ці файлавая сістэма даступна толькі для чытання. Праверце SD-карту або зважыцеся з намі праз support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Эмуляваць дрэннае сховішча</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Увядзіце правільную назву</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Спісы</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Схаваць усе</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Паказаць усе</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n закладка</numerusform>
+<numerusform>%n закладкі</numerusform>
+<numerusform>%n закладак</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Стварыць новы спіс</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Імпартаваць закладкі і маршруты</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Немагчыма абагуліць з-за памылкі праграмы</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Памылка пры спробе абагульвання</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Нельга абагуліць пусты спіс</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Назва не можа быць пустой</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Увядзіце назву спіса</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Новы спіс</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Гэтая назва ўжо занятая</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Выберыце іншую назву</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Пачакайце…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Нумар тэлефона</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Профіль OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n файл знойдзены. Вы можаце ўбачыць яго пасля канвертавання.</numerusform>
+<numerusform>%n файлы знойдзеныя. Вы можаце ўбачыць іх пасля канвертавання.</numerusform>
+<numerusform>%n файлаў знойдзеная. Вы можаце ўбачыць іх пасля канвертавання.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Аднавіць</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n сцежка</numerusform>
+<numerusform>%n сцежкі</numerusform>
+<numerusform>%n сцежак</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Прыватнасць</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Палітыка прыватнасці</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Умовы выкарыстання</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Рух</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Пешыя маршруты</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Пакатушкі</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Метро</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Стылі і слаі мапы</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Гэты спіс пусты</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Каб дадаць закладку, дакраніцеся да месца на карце, а затым націсніце значок зорачкі</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Змяніць колер усіх закладак</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Змяніць колер усіх трэкаў</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…яшчэ</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Экспарт KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Экспарт GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Экспарт GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Выдаліць спіс</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Камеры хуткасці</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Апісанне месца</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Спампоўванне мап</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Папярэджваць калі хуткасць перавышана</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Заўсёды папярэджваць</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Ніколі не папярэджваць</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Рэжым энергазберажэння</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Адключэнне часткі функцый, каб паменшыць спажыванне зарада акумулятара.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Ніколі</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Аўтаматычна</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Заўсёды</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Назвы закладак на карце</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Паказ назваў вялікай колькасці закладак на карце можа замарудзіць працу праграмы.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Паказваць справа</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Паказваць знізу</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Часова ўключыце гэты параметр , каб запісаць і ўручную адправіць нам падрабязную інфармацыю пра знойдзеную праблему праз кнопку «Паведаміць аб памылцы» ў акне «Даведка». Журнал падзей можа змяшчаць даныя пра месцазнаходжанне.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Налады пракладвання маршрутаў</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Пазбягаць платных дарог</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Пазбягаць грунтавых дарог</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Пазбягаць паромаў</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Пазбягаць аўтамагістраляў</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Немагчыма пракласці маршрут</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Не ўдалося пракласці маршрут. Магчыма гэта звязана з наладамі пракладвання маршрутаў або няпоўнымі данымі OpenStreetMap. Змяніце налады і паспрабуйце зноў.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Вызначыць, якіх дарог пазбягаць</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Налады пракладвання маршрутаў уключаны</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Платная дарога</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Грунтавая дарога</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Паромная пераправа</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ёсць</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Няма</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Ёмістасць: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Сетка: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Вы прыбылі!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ок</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Сартаваць…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Сартаваць закладкі</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Прадвызначана</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Па тыпу</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Па адлегласці</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Па даце</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Па імені</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Тыдзень таму</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Месяц таму</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Больш за месяц таму</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Больш за год таму</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Каля мяне</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Іншыя</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Памылка пракладання маршрута</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Прыбыццё ў %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Спампуйце і абнавіце ўсе мапы на шляху, каб пракласці маршрут.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Вы змянілі мапу свету. Не хавайце гэта! Раскажыце сябрам і рэдагуйце разам.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Абагуліць з сябрамі</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Зараз закрыта</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Адкрыецца заўтра ў %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Адкрываецца ў %1 у %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Адкрываецца ў %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Закрываецца ў %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Дадаць часы працы</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Пароль (мінімум 8 сімвалаў)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Няправільныя імя карыстальніка альбо пароль.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Акаунт OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Апошняя запампоўка</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Дзякуй</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Назва месца</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Тэлефон</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Звярніце ўвагу</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Памылка спампоўкі</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Выбраць катэгорыю</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Папулярныя</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Усе катэгорыі</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Стварайце на карце новыя месцы і рэдагуйце наяўныя прама ў праграме.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Змяніце месцазнаходжанне</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Каб спампаваць, трэба больш месца. Выдаліце непатрэбныя даныя.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Я палепшыў мапы Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Падрабязны каментарый</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Прапанаваныя вамі змены будуць дасланы суполцы OpenStreetMap. Апішыце любыя дадатковыя дэталі, якія нельга рэдагаваць у Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Адбылася памылка пры пошуку месцазнаходжання. Праверце, што ваша прылада працуе як трэба, і паспрабуйце зноў.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Геалакацыя адключана</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Уключыце доступ да геалакацыі у наладах прылады</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Адкрыйце Налады</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Націсніце Геалакацыя</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Выберыце &quot;Падчас выкарыстання праграмы&quot;</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Абярыце Прыватнасць</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Выберыце Службы месцазнаходжання</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Уключыце Службы вызначэння месцазнаходжання</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Або працягвайце выкарыстоўваць Organic Maps без месцазнаходжання</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Забраніраваць</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Патэлефанаваць</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Назва закладкі</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Выдаліць закладку</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ваша нататка будзе адпраўлена ў OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…яшчэ</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Абнавіць</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Выключыць запіс вашага нядаўна пройдзенага маршрута?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Адключыць</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Паглядзі</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps выкарыстоўвае вашу геалакацыю ў фонавым рэжыме, каб запісваць ваш нядаўна пройдзены маршрут.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Агульныя налады</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Для паказу інфармацыі пра рух трэба абнавіць праграмы.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Памер файла журнала: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Перацягніце сюды, каб выдаліць</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Замяніць прыпынак</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Пачаць ад</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Калі ласка, увайдзіце ў OpenStreetMap, каб аўтаматычна загрузіць усе вашыя праўкі мапы. Даведайцеся больш</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>тут</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Схаваць экран</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 з %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Спампоўванне %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Прымяненне %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Гэтая назва надта доўгая</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Знойдзены новыя файлы</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Ператварыць</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Памылка</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Некаторыя файлы не ператварыліся.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Адбылася памылка</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Папулярнае</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Схаваць з мапы</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Адбылася памылка падчас загрузкі метак, калі ласка паспрабуйце зноў</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Справа</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Знізу</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Паехалі</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Пункт прызначэння</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Па цэнтры</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Вынікі пошуку</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Потым</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Хочаце перапракласці маршрут?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Клавіятура недасягальная падчас язды</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Не атрымалася пракласці маршрут ад вашага цяперашняга месцазнаходжання</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Не атрымалася пракласці маршрут да вашага пункту прызначэння. Выберыце іншы пункт прызначэння</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Няма сігналу GPS. Перамясціцеся на адкрытую прастору</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Не атрымалася пракласці маршрут. Выберыце іншыя кропкі маршрута</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Каб пракласці маршрут, спампуйце мапы, якіх не хапае на вашай прыладзе</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Адбылася памылка. Калі ласка, перазапусціце праграму</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Маршрут будзе перапракладзены ад вашага цяперашняга месцазнаходжання</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Маршрут будзе ператвораны ў аўтамабільны</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Не ўсе закладкі паказаны</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Пераключыцеся на тэлефон, каб убачыць усе закладкі</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Камеры</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Папяр. аб хуткасці</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Спампуйце мапы ў праграме Organic Maps на вашай прыладзе</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 з&#x27;езд</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Сартаваць па змаўчанні</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Сартаваць па тыпу</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Сартаваць па адлегласці</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Сартаваць па даце</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Сартаваць па імені</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Ежа</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Славутасці</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Музеі</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Паркі</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Плаванне</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Горы</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Жывёлы</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Гатэлі</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Будынкі</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Грошы</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Крамы</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Паркоўкі</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Запраўкі</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Медыцына</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Шукаць у спісе</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Святыя месцы</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Выбраць спіс</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Для гэтага рэгіёна навігацыя па метро яшчэ недаступна</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Маршрут на метро не знойдзены</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Выберыце пункт адпраўлення альбо прызначэння бліжэй да станцыі метро</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Рэльеф</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Каб задзейнічаць лініі рэльефу, трэба абнавіць мапу гэтага рэгіёна</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Для гэтага рэгіёна мапы рэльефу яшчэ недаступны</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Пад&#x27;ём</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Спуск</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Мін. вышыня</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Макс. вышыня</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Складанасць</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Адл.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Час:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Павялічце мапу, каб убачыць рэльеф</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Спампоўванне</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Спампаваць аглядную мапу свету</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Немагчыма стварыць папку і перамясціць файлы на ўнутраную памяць прылады або SD-карту</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Памылка дыска</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Памылка падлучэння</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Адлучыце кабель USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Трымаць экран уключаным</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Калі ўключана, экран не будзе гаснуць пакуль паказваецца мапа.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Паказваць на экране блакіроўкі</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Калі ўключана, вам не трэба разблакіраваць прыладу кожны раз падчас працы праграмы.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Мова мапы</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Даныя мапы з OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsRu</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/ru/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Дзякуй за выкарыстанне нашых мап, створаных супольнасцю!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Дзякуючы вашым ахвяраванням і падтрымцы мы можам стварыць лепшыя мапы ў свеце!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Вам падабаецца наша праграма? Калі ласка, ахвяруйце, каб падтрымаць яе распрацоўку. Яшчэ не падабаецца? Напішыце чаму, і мы гэта выправім!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Калі вы ведаеце распрацоўшчыка праграмнага забеспячэння, вы можаце папрасіць яго рэалізаваць неабходную вам функцыю.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Націсніце ў любое месца на карце, каб што-небудзь выбраць. Выкарыстоўвайце працяглае націсканне, каб схаваць або зноў паказаць інтэрфейс.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>А вы ведалі, што сваё месцазнаходжанне на карце можна выбраць?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Вы можаце дапамагчы перакласці нашу праграму на вашу мову.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Наша праграма распрацавана некалькімі энтузіястамі і супольнасцю.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Вы можаце лёгка выпраўляць і палепшаць даныя мапы.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Наша галоўная мэта - ствараць хуткія, арыентаваныя на прыватнасць і простыя ў выкарыстанні мапы, якія вам спадабаюцца.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Вы выкарыстоўваеце Organic Maps на экране тэлефона</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Вы выкарыстоўваеце Organic Maps на экране аўтамабіля</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Вы падключаны да Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Працягнуць на тэлефоне</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>На экран аўто</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps патрабуе доступу да месцазнаходжання. Калі будзе бяспечна, праверце апавяшчэнне на тэлефоне.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Гэтай праграме патрабуецца ваш дазвол</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Для эфектыўнай працы Organic Maps у Android Auto патрабуецца дазвол на вызначэнне месцазнаходжання</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Дазволіць</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Актыўны адпачынак</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Вэб-браўзер недаступны</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Гучнасць</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Экспартаваць усе закладкі і маршруты</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Сістэмныя налады сінтэзу маўлення</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Налады сінтэзу маўлення не знойдзены. Вы ўпэўнены, што ваша прылада падтрымлівае гэта?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>З акенцам для кіроўцаў</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Ачысціць пошук</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Наблізіць</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Аддаліць</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Спасылка на меню</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Паглядзець меню</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Адкрыць у іншай праграме</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Самаабслугоўванне</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Выберыце варыянт</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Месцы на адкрытым паветры</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Для найбольш дакладнай навігацыі рэкамендуем адключыць рэжым энергазберажэння ў наладах батарэі тэлефона.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Запіс маршруту</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Спыніць запіс маршруту</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Запіс маршруту</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Спыніць без захавання</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Працягнуць запіс</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Захаваць у закладкі і трэкі?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Маршрут пусты - няма чаго захоўваць</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Немагчыма паказаць акно выбару папкі, бо на вашай прыладзе не ўсталявана адпаведнай праграмы. Усталюйце файлавы менеджар і паўтарыце спробу.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Выберыце колер</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Рэдагаваць маршрут</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Не ўсталявана праграма, якая можа адкрыць месцазнаходжанне</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Аўто ў навігацыі</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Як у сістэме</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Падзяліцца трэкам</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Выдаліць %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Узровень складанасці</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Лёгкі</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Сярэдні</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Цяжкі</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Абнаўленне</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Абнавіце спампаваныя мапы</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Абнаўленне мап падтрымлівае актуальнасць звестак пра аб’екты</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Абнавіць (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Абнавіць пазней уручную</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Выдаліць трэк</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Вы ўпэўнены, што хочаце выдаліць гэты маршрут?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Назва трэка</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Перамясціць</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Сцежка</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Змяніць колер</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Карта</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Хочаце адправіць справаздачу пра памылку распрацоўшчыкам?
+Мы разлічваем на нашых карыстальнікаў, бо Organic Maps не збірае ніякай інфармацыі пра памылкі аўтаматычна. Загадзя дзякуем за падтрымку Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Уключыць сінхранізацыю з iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Сінхранізацыя з iCloud - гэта эксперыментальная функцыя, якая знаходзіцца ў стадыі распрацоўкі. Пераканайцеся, што вы зрабілі рэзервовую копію ўсіх сваіх закладак і трэкаў.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud адключаны</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Каб выкарыстоўваць гэту функцыю, уключыце iCloud у наладах прылады.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Уключыць</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Рэзервовае капіяванне</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Збой сінхранізацыі iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Памылка: не ўдалося сінхранізаваць з-за памылкі злучэння</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Памылка: не ўдалося сінхранізаваць з-за перавышэння квоты iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Памылка: iCloud недаступны</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Нядаўна выдаленыя спісы</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Ачысціць</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Выдаліць усё</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Аднавіць</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Аднавіць усё</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Унесці ўклад у OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Дадаць месца</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Абнавіць мапу, каб унесьці ўклад</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Перш чым унесці ўклад у даныя OpenStreetMap, неабходна абнавіць мапу %1 да апошняй версіі</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>МБ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ГБ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Маё месцазнаходжанне</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Мае месцы</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Унутранае прыватнае сховішча</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Унутранае агульнае сховішча</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-карта</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Знешняе агульнае сховішча</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Паштовы індэкс</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Месца на карце</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>м</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>км</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>міля</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>фут</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Абнавіце мапы, каб убачыць маршруты</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Выхад</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Уваход</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Карта метро недаступная</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Вы</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Фіялетавыя спампаваныя рэгіёны</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Маршрут</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Вызначэнне месцазнаходжання ў фонавым рэжыме неабходна для поўнага выкарыстання функцыянальнасці праграмы. Яно выкарыстоўваецца для навігацыі і захавання вашага нядаўна пройдзенага шляху.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Вызначэнне вашага месцазнаходжання неабходна для навігацыі і для захавання вашага нядаўна пройдзенага шляху.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Увайсці з паролем</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Уваход праз браўзер</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Нядаўна выкарыстоўваныя</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Колер закладак зменены</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Колер трэкаў зменены</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Спектр</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Слідары</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ЧЫРВОНЫ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ЗЕЛЕНЫ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>БЛАКІТНЫ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB шасцігранны колер #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Сетка</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/bg/omim.ts
+++ b/qt/translations/bg/omim.ts
@@ -1,0 +1,3933 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="bg">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Отмяна</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Изтриване</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Изтегляне на карти</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Изтеглянето се провали. Натиснете, за да опитате отново.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Теглене…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Километри</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Мили</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>По-късно</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Търсене</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Търсене в карта</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>В момента всички услуги за местоположение за това устройство или приложение са деактивирани. Моля, разрешете ги в Настройки.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ограничена точност</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>За да осигурите точна навигация, активирайте функцията &quot;Точно местоположение&quot; в настройките.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Показване на картата</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Изтеглянето се провали</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Опитайте отново</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>За „Organic Maps“</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Безплатно за всички, направени с любов</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Без реклами, без проследяване, без събиране на данни</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Без източване на батерията, работи офлайн</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Бърз, прост, разработен от общността</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Приложение с отворен код, създадено от ентусиасти и доброволци.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Настройки на местоположението</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Затваряне</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Приложението изисква хардуерно ускорение на OpenGL. За съжаление вашето устройство не се поддържа.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Изтегляне</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Моля, изключете USB кабела или поставете картата с памет, за да използвате Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Моля, първо освободете място на SD картата/USB паметта, за да можете да използвате приложението.</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Преди да започнете да използвате приложението, позволете ни да изтеглим основната карта на света на вашето устройство.&#32;
+Това ще използва %1 от паметта.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Към картата</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Изтегляне на %1. Вече можете да преминете към картата.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Изтегляне на %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Обновяване на %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Пауза</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Възобновяване</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Изтеглянето на %1 се провали</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Добавяне на нова група</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Име на група</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Отметки</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Отметки и пътеки</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Име</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Адрес</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Списък</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Настройки</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Запаметяване на карти в</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Изберете мястото, където картите трябва да се изтеглят</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Карти</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 свободни от %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Преместване на карти?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Грешка при преместването на картовите файлове</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Това може да отнеме няколко минути.
+Моля изчакайте…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Мерни единици</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Изберете между километри или мили</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Отмяна на изтегляне</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Напишете отзив</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Изтегляне на карта</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Списъци с отметки</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Места за хапване</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Продукти</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Транспорт</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Гориво</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Паркинг</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Шопинг</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Втора употреба</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Хотел</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Забележителности</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Развлечения</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Банкомат</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Нощен живот</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Семейна почивка</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Банка</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Аптека</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Болница</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Тоалетна</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Поща</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Полиция</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Рециклиране</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Вода</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>За RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Бележки</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Споделени са с вас отметки за Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Здравейте!
+
+Приложени са моите отметки; моля, отворете ги в Organic Maps. Ако нямате инсталирана програма, можете да я изтеглите оттук: https://omaps.app/get?kmz
+
+Наслаждавайте се на пътуванията с Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Зареждане на отметки</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Отметките са заредени успешно! Можете да ги откриете на картата или при секцията с отметки.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Качването на отметките се провали. Файлът може да бъде повреден или дефектен.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Типът на файла не се разпознава от приложението:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Неуспешно отваряне на файл %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Редакция</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Местоположението ви още не е определено</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Съжаляваме, но настройките за съхранение на карти в момента са деактивирани.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Изтеглянето на картата вече е в ход.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Хей, виж текущото ми местоположение в Organic Maps! %1 или %2</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Хей, виж какво съм отбелязал в Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Хей, виж текущото ми местоположение на картата в Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Здравей,
+
+Сега съм тук: %1. Натисни върху тази връзка %2 или тази %3, за да видиш мястото на картата.
+
+Благодаря.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Споделяне</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Имейл</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Копирано в клипборда: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Готово</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Данни на OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Сигурни ли сте, че искате да излезете от профила си в OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Пътеки</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Дължина</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Споделяне на местоположение</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Общи настройки</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Информация</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Навигация</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Бутони „+“ и „-“ на картата</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Показване на картата</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Нощен стил при навигация на тъмно</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Нощен режим</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Изключен</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Включен</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Автоматично</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Перспективен изглед</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D сгради</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D сградите са изключени в режим на пестене на енергия</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Гласови инструкции</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Обявете имена на улици</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Когато е активирано, името на улицата или изхода, по който да завиете, ще бъде произнесено на глас.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Език на инструкциите</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>За да изтеглите глас с по-високо качество, отворете приложението Настройки и отидете в Достъпност → VoiceOver → Реч → Глас.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Тестване на гласови указания (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Проверете силата на звука или системните настройки за преобразуване на текст в реч, ако сега не чувате гласа.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Не е налично</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Автоматично мащабиране</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Разстояние</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Преглед на картата</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Меню</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Уебсайт</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Новини</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Обратна връзка</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Оцени приложение</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Помощ</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Въпроси и отговори</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Дарете</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Вече дарено</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Напомни по-късно</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Подкрепи Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Подкрепете проекта</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Авторски права</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Докладване на проблем</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Подобрете посоката на стрелката, като движите телефона с движение тип &quot;осмица&quot;, за да калибрирате компаса.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Преместете телефона с движение тип &quot;осмица&quot;, за да калибрирате компаса и да фиксирате посоката на стрелката върху картата.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Докоснете отново картата, за да видите интерфейса</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Обновяване на всичко</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Отмяна на всичко</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Изтеглено</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>На опашка</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Близо до мен</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Карти</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Изтегляне на всичко</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Теглене:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>За да изтриете карта, моля спрете навигирането.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Могат да се създават само маршрути, които са изцяло в рамките на картата на един регион.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Изтегляне на карта</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Повторно</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Изтриване на карта</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Обновяване на карта</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Услуги за местоположение в Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Бързо определяне на приблизителното ви местоположение чрез Bluetooth, WiFi или мобилна мрежа</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Изтегляне на всички карти по вашия маршрут</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>За да създадем маршрут, трябва да изтеглим и актуализираме всички карти от местоположението ви до вашата дестинация.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Недостатъчно място</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Моля, разрешете услугите за местоположение</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Запазване</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>създаване</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Червено</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Жълто</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Синьо</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Зелено</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Лилаво</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Оранжево</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Кафяво</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Розово</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Тъмно Лилаво</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Светло Синьо</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Синьо</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Тюркоаз</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Светло Зелено</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Тъмно Оранжево</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Сиво</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Синкаво Сиво</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Информация</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Версия на Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Изглед</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Светъл</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Тъмен</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Светла от зори до здрач</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Друго</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Подарете безплатни карти без реклами на милиони потребители!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Докладване или поправяне на неправилни данни на картата</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>За доброволчество</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Следвайте и се свържете с нас:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Имейл клиентът не е настроен. Моля, конфигурирайте го или използвайте друг начин, за да се свържете с нас на %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Грешка при изпращане на поща</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Калибриране на компас</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Наличен</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Намерени</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Обновление</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Провал</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>отметка</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Когато следвате маршрута, моля, имайте предвид:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>- Пътната обстановка, законите за движение по пътищата и че пътните знаци винаги имат предимство пред пътеводителните подсказки;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>- Картата може да е неточна, а предложеният маршрут невинаги е най-оптималният начин за достигане до дестинацията;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>- Предложените маршрути са само препоръки;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>- Бъдете внимателни с маршрутите в гранични зони: маршрутите, създадени от нашето приложение, понякога могат да пресичат границите на страната на неразрешени места.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Моля, бъдете бдителни и безопасни по пътищата!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Проверете GPS сигнала</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Не е възможно да се създаде маршрут. Текущите GPS координати не могат да бъдат идентифицирани.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Моля, проверете GPS сигнала. Включването на Wi-Fi ще подобри точността на местоположението ви.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Активиране на услугите за местоположение</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Не е възможно да се определят GPS координатите. Активирайте услугите за местоположение, за да изчислите маршрута.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Не е намерен маршрут</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Не е възможно да се създаде маршрут.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Моля, коригирайте началната точка или дестинацията си.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Регулиране на началната точка</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Маршрутът не е създаден. Не може да се намери начална точка.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Моля, изберете начална точка, която е по-близо до път.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Регулиране на дестинацията</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Маршрутът не е създаден. Не е възможно да се открие дестинацията.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Моля, изберете крайна точка, разположена по-близо до път.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Не може да се открие междинната точка на маршрута.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Моля, коригирайте междинната си точка на маршрута.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Грешка в системата</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Не е възможно да се създаде маршрут поради грешка в приложението.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Моля, опитайте отново</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Не сега</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Бихте ли искали да изтеглите картата и да създадете по-оптимален маршрут, обхващащ повече от една карта?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>За да създадете по-добър маршрут с граничен преход, трябва да изтеглите картата.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Изтегляне на необходимите файлове</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>За да изчислите маршрут, изтеглете и актуализирайте всички карти и пътища по маршрута.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>За да започнете да търсите и създавате маршрути, изтеглете картата. Това ще ви позволи да пътувате без интернет връзка.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Избор на карта</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Показване</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Скриване</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Категории</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>История</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>За съжаление не са намерени резултати.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Изтеглете региона, в който търсите, или опитайте да добавите име на близък град/село.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>История на търсенията</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Преглед на последните търсения.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Изчистване на историята на търсенията</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Уикипедия</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Статия от wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Вашето местоположение</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Начало</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Маршрут от</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Маршрут към</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Навигацията е възможна само от текущото ви местоположение.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Искате ли да планираме маршрут от текущото ви местоположение?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Напред</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>От</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>До</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Добавяне на график</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Изтриване на график</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Цял ден (24 часа)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Отворено</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Добавяне на почивка</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Работно време</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Подробен режим</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Сбит режим</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Почивка</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Примерни стойности</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Поправяне на грешка</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Изберете местоположение</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Моля, опишете подробно проблема, за да може общността на OpenStreetMap да отстрани грешката.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Или го направете сами на https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Изпращане</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Проблем</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Мястото не съществува</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Затворено за ремонт</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Дубликат</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Автоматично изтегляне</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Ежедневно</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24 часа</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Затворено днес</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Днес</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Отваря се в %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Приключва в %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Редакция на работното време</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Нямате акаунт в OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Регистриране в OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Вход</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Не е влязъл в системата</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Влезте в OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Парола</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Забравили сте паролата си?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Изход</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Редакция на място</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Добавяне на език</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Улица</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Номер на сграда</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Подробности</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Социални медии</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Сграда</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Добавяне на улица</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Въведете име на улица</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Избор на език</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Избор на улица</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Кухня</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Избор на кухня</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Имейл или потребителско име</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Добави телефон</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Етаж</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Ниво: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Всички ваши редакции на картата ще бъдат изтрити заедно с нея.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Обновяване на карти</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>За да създадете маршрут, трябва да актуализирате всички карти и след това да планирате маршрута отново.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Намиране на карта</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Моля, проверете настройките си и се уверете, че устройството ви е свързано с интернет.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Няма достатъчно място</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Моля, изтрийте всички ненужни данни.</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Грешка при вход.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Потвърдени промени</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Плъзнете картата, за да поставите кръстчето на мястото на мястото или бизнеса.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Редактиране</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Добавяне</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Име на мястото</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Както е написано на местния език</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Категория</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Подробно описание на проблема</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Друг проблем</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Добавяне на бизнес</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Тук не може да бъде намерен обект</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Създадени от общността данни от OpenStreetMap към %1. Научете повече за това как да редактирате и актуализирате картата в OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) е общностен проект за създаване на безплатна и отворена карта. Той е основният източник на картографски данни в Organic Maps и работи подобно на Wikipedia. Можете да добавяте или редактирате места и те стават достъпни за милиони потребители по целия свят.
+Присъединете се към общността и помогнете за създаването на по-добра карта за всички!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Създайте акаунт в OpenStreetMap или влезте в него, за да публикувате своите редакции на картата в света.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 от %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Изтегляне чрез мобилни данни?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Това може да бъде значително скъпо при някои планове или при роуминг.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Въведете валиден номер на сграда</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Брой етажи (максимум %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Броят на етажите не трябва да надвишава %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Пощенски код</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Въведете валиден пощенски код</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Забележка към доброволците на OpenStreetMap (по избор)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Описване на грешки в картата или неща, които не могат да бъдат редактирани с Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Вашите редакции се качват в публичната база данни &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Bg:About&quot;&gt;OpenStreetMap&lt;/a&gt;. Моля, не добавяйте лична информация или информация, защитена с авторски права.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Повече за OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Вашата история на редактиране</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Бележки за данните на вашата карта</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Оператор</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Оператор: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Не можете да намерите подходяща категория?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps позволява да се добавят само прости категории точки, т.е. без градове, пътища, езера, очертания на сгради и т.н. Моля, добавяйте такива категории директно в &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Вижте нашето &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;ръководство&lt;/a&gt; за подробни инструкции стъпка по стъпка.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Не сте изтеглили никакви карти</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Изтеглете картите, от които се нуждаете, за да намирате места и да навигирате без интернет.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Настоящото местоположение е неизвестно.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>км/ч</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>мили/ч</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ч</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>мин</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>д</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>сек</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Още</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Редакция на отметка</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Лични бележки (текст или html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Коментиране…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Отхвърляне на всички локални промени?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Отхвърляне</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Изтриване на добавеното място?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Изтриване</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Мястото не съществува</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Моля, опишете причината за премахването</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Въведете валиден телефонен номер</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Въведете валиден уеб адрес</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Въведете валиден имейл</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Въведете валиден уеб адрес, акаунт или име на страница във Facebook</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Въведете валидно потребителско име за Instagram или уеб адрес</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Въведете валидно потребителско име в Twitter или уеб адрес</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Въведете валидно потребителско име на VK или уеб адрес</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Въведете валиден LINE ID или уеб адрес</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Добавяне на място в OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Или пък оставете бележка на общността на OpenStreetMap, за да може някой друг да добави или поправи мястото тук.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Бележката ще бъде изпратена на OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Искате ли да го изпратите на всички потребители?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Уверете се, че не сте въвели никакви лични данни.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Редакторите на OpenStreetMap ще проверят промените и ще се свържат с вас, ако имат въпроси.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Спри</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Записване на пътя</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Приемане</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Отказване</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Използване на мобилни данни за подробна информация?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Винаги</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Само днес</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Без днес</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Мобилни данни</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Мобилните данни са необходими за показване на подробна информация за местата, като например снимки, цени и отзиви.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Никога</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Винаги питай</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>За да се показват данни за трафика, картите трябва да са актуализирани.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Увеличаване на размера на шрифта в картата</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Моля, актуализирайте Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Няма налични данни за трафика</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Активиране на запис на дневник</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Обща обратна връзка</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Навигирането се озвучава от системен синтезатор на реч (TTS). Много устройства използват Google TTS, който може да бъде изтеглен или актуализиран от Google Play.</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>За някои езици може да се наложи да инсталирате допълнителен синтезатор на реч (TTS) от магазина за приложения (Google Play Магазин, Galaxy Store).
+За да настроите синтезатора на реч, отидете в Настройки → Езици и въвеждане → Синтезиран говор.
+Тук можете да инсталирате допълнителни езикови пакети или да изберете синтезатор на реч.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>За повече информация вижте това ръководство.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Изпиши на латиница</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Научете повече</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Използвайте търсене или докоснете картата, за да добавите начална точка на маршрута</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Използвайте търсене или докоснете картата, за да добавите точка на дестинация</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Управление на маршрут</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Планиране</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Премахване на спирка</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Добавяне на спирка</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Запазено</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Моля, влезте в OpenStreetMap, за да качвате автоматично всичките си редакции на картата. Научете повече &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;тук&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Проблем с достъпа до хранилището</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Външната памет на устройството не е налична, SD картата може да е била извадена, повредена или файловата система е само за четене. Проверете това и се свържете с нас support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Емулация на грешки с външна памет</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Моля, въведете правилно име</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Списъци</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Скриване на всичко</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Показване на всичко</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n отметки</numerusform>
+<numerusform>%n отметки</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Създаване на нов списък</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Импортиране на отметки и маршрути</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Не е възможно споделяне поради грешка в приложението</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Грешка при споделяне</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Не може да се споделя празен списък</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Името не може да бъде празно</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Моля, въведете името на списъка</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Нов списък</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Това име вече е заето</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Моля, изберете друго име</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Моля, изчакайте…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Телефонен номер</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Профил в OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Открит е %n файл. Можете да го видите след конвертирането.</numerusform>
+<numerusform>Открити са %n файла. Можете да ги видите след конвертирането.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Възстановяване</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n пътека</numerusform>
+<numerusform>%n пътеки</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Поверителност</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Политика за поверителност</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Условия за ползване</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Трафик</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Пешеходен туризъм</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Велосипеден туризъм</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Метро</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Стилове и слоеве на картата</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Този списък е празен</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>За да добавите отметка, докоснете място на картата, след което докоснете звездообразната икона.</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Промяна на цвета на всички отметки</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Промяна на цвета на всички маршрути</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…още</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Експорт на KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Експортиране на GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Експорт на GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Изтриване на списък</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Камери за скорост</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Описание на мястото</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Изтегляне на карти</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Да ви предупреди за превишена скорост</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Винаги се продупреждава</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Никога не се предупреждава</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Режим пестене на енергия</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Ако е активиран режима пестене на енергия, приложението ще деактивира функциите, консумиращи енергия, в зависимост от текущия заряд на телефона.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Никога</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Автоматично</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Максимално пестене на енергия</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Имената на отметките в картата</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ако има твърде много отметки, показването на имената им на картата може да забави работата на приложението.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Показване вдясно</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Показване в долната част</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Тази настройка е разрешена, за да се записват действия за диагностични цели, които помагат на нашия екип да идентифицира проблеми с приложението. Временно активирайте тази настройка само за изпращане на подробна информация за проблема, който сте открили с приложението.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Опции за маршрутизация</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Избягвайте платените пътища</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Избягвайте неасфалтирани пътища</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Избягване на преходи с ферибот</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Избягвайте магистралата</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Не е възможнос изчисляване на маршрут</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>За съжаление не успяхме да намерим маршрут, вероятно поради избраните от вас параметри. Моля, променете настройките и опитайте отново.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Определяне пътищата, които да се избягват</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Разрешени опции за маршрутизиране</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Път с винетка</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Път без настилка</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Преминаване с ферибот</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Капацитет: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Мрежа: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Пристигнахте!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ок</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Сортиране…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Сортиране на отметки</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>По подразбиране</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>По тип</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>По разстояние</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>По дата</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>По име</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Преди седмица</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Преди месец</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Преди повече от месец</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Преди повече от година</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>На близо</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Други</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Неуспешно планиране на маршрут</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Пристигане в %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Изтеглете и актуализирайте всички карти по проектирания път, за да изчислите маршрута.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Променили сте картата на света. Не го крийте, кажете на приятелите си и редактирайте заедно.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Споделяне с приятели</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Затворено сега</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Открива се утре в %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Отваря %1 в %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Отваря се в %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Затваря се в %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Добавяне на работно време</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Парола (поне 8 символа)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Невалидно потребителско име или парола.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Акаунт</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Последно качване</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Благодаря</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Име на място</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Телефон</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Моля, имайте предвид</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Грешка при изтегляне</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Избор на категория</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Популярно</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Всички категории</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Добавяне на нови места в картата и редакция на съществуващите директно от приложението.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Смяна на местоположение</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>За изтегляне ви е необходимо повече място. Моля, изтрийте всички ненужни данни.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Подобрих картите на Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Подробен коментар</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Предложените от вас промени по картата ще бъдат изпратени до общността на OpenStreetMap. Опишете всички допълнителни подробности, които не могат да бъдат въведени в Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Възникна грешка при търсенето на вашето местоположение. Проверете дали устройството ви работи правилно и опитайте отново по-късно.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Услугите за местоположение са деактивирани</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Разрешаване на достъпа до геолокация в настройките на устройството</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Отваряне на Настройки</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Натискане на Местоположение</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Избиране на Докато приложението се използва</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Изберете Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Изберете Услуги за местоположение</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Включете услугите за местоположение</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Или продължете да използвате Organic Maps без местоположение</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Резервиране</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Обаждане</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Име на отметка</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Изтриване на отметки</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Вашата бележка ще бъде изпратена до OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…още</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Обновление</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Деактивиране на записването на последния ви маршрут?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Деактивиране</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Виж</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps използва геопозицията ви във фонов режим за записване на последния ви маршрут.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Общи настройки</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>За да се показват данни за трафика, приложението трябва да се актуализира.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Размер на регистрационния файл: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Плъзнете тук, за да премахнете</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Замяна на спирката</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Започнете от</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Моля, влезте в OpenStreetMap, за да качвате автоматично всичките си редакции на картата. Научете повече</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>тук</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Скриване на екрана</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 от %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Теглене %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Прилагане %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Това име е твърде дълго</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Открити са нови файлове</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Конвертиране</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Грешка</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Някои файлове не са конвертирани.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Възникна грешка</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Популярно</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Скриване от картата</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Възникна грешка при зареждането на таговете, моля, опитайте отново</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Вдясно</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Дъно</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Да вървим</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Дестинация</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Повторно съсредоточаване на</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Резултати от търсенето</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>След това</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Искате ли да възстановите маршрута?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Клавиатурата не е достъпна по време на шофиране</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Невъзможност за създаване на маршрут от текущото ви местоположение</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Не можете да намерите маршрут до дестинацията си. Моля, изберете друга крайна точка</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Няма GPS сигнал. Моля, преместете се в открита зона</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Не може да се изгради маршрут. Моля, посочете други точки на маршрута</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>За да създадете маршрут, изтеглете липсващите карти на устройството си</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Възникна грешка. Моля, рестартирайте приложението</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Маршрутът ще бъде възстановен от текущото ви местоположение.</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Маршрутът ще бъде превърнат в автомобилен</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Не всички отметки се показват</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Превключване към телефона, за да видите всички отметки</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Камери за скорост</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Предупреждения за скорост</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Моля, изтеглете картите от приложението на мобилното си устройство</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 изход</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Сортиране по подразбиране</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Сортиране по тип</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Сортиране по разстояние</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Сортиране по дата</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Сортиране по име</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Храна</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Забележителности</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Музеи</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Паркове</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Плуване</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Планини</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Животни</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Хотели</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Сгради</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Пари</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Магазини</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Паркинги</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Бензиностанции</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Лечение</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Търсене в списъка</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Храмове</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Избор на списък</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Навигацията за метро все още не е налична в региона</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Не е открит маршрут за метро</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Моля, изберете начална или крайна точка по-близо до метростанция</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Терен</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>За да активирате и използвате топографския слой, моля, актуализирайте или изтеглете картата на района</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Топографският слой все още не е наличен в тази област</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Изкачване</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Спускане</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Мин. височина</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Макс. височина</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Трудност</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Разст.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Време:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Увеличете мащаба, за да разгледате изолиниите</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Изтегляне</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Изтегляне на осноената картата на света</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Невъзможност за създаване на папка и преместване на файлове в паметта на вътрешното устройство или sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Дискова грешка</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Неуспешно свързване</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Изключване на USB кабел</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Запазете екрана включен</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Когато е разрешено, екранът винаги ще бъде включен при показване на картата.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Показване на заключения екран</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Когато е разрешено, приложението ще работи на заключения екран, дори когато устройството е заключено.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Език на картата</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Картографски данни от OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Bg:About</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Благодарим ви, че използвате нашите карти, създадени от общността!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>С вашите дарения и подкрепа можем да създадем най-добрите карти в света!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Харесвате ли нашето приложение? Моля, дарете, за да подкрепите развитието! Все още не ви харесва? Моля, уведомете ни и ние ще го поправим!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ако познавате разработчик на софтуер, можете да го помолите да внедри функция, от която се нуждаете.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Докоснете навсякъде в картата, за да изберете нещо. Докоснете дълго, за да скриете и покажете интерфейса.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Знаете ли, че можете да изберете текущото си местоположение на картата?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Можете да помогнете за превода на нашето приложение на вашия език.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Нашето приложение е разработено от няколко ентусиасти и общността.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Можете лесно да коригирате и подобрите картографските данни.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Нашата основна цел е да създаваме бързи, фокусирани върху поверителността, лесни за използване карти, които ще харесате.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Вече използвате Organic Maps на екрана на телефона</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Вече използвате Organic Maps на екрана на автомобила</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Свързани сте с Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Продължете в телефона</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Към екрана на автомобила</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps се нуждае от достъп до местоположението. Когато е безопасно, проверете известието на телефона си.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Това приложение се нуждае от вашето разрешение</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps в Android Auto се нуждае от разрешение за местоположение, за да работи ефективно</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Предоставяне на разрешения</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Активен отдих</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Уеб браузърът не е наличен</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Сила на звука</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Експортиране на всички отметки и следи</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Настройки на системата за синтез на реч</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Настройките за синтез на речта не бяха открити, сигурни ли сте, че устройството ви ги поддържа?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>С прозорец за шофьори</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Изчистване на търсенето</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Увеличаване на мащаба</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Увеличаване на мащаба</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Връзка към менюто</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Преглед на менюто</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Отваряне в друго приложение</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Самообслужване</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Изберете опция</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Места за сядане на открито</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>За най-точна навигация препоръчваме да деактивирате режима за пестене на енергия в настройките на батерията на телефона.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Запис на маршрут</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Спри запис на маршрут</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Записване на трак</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Спрете без запазване</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Продължи записа</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Запазване в отметки и пътеки?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Маршрутът е празен - няма какво да запазвате</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Не може да се покаже диалогов прозорец за избор на папка, тъй като на вашето устройство не е инсталирано подходящо приложение. Моля, инсталирайте приложение за управление на файлове и опитайте отново</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Изберете цвят</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Редактиране на маршрут</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Не е инсталирано приложение, което може да отвори местоположението</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Автоматично в навигацията</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Като системата</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Споделяне на пистата</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Изтриване на %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Степен на трудност</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Лесно</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Умерен</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Трудно</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Актуализиране на</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Актуализиране на изтеглените карти</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Актуализирането на картите поддържа актуална информацията за обектите</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Актуализация (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Ръчно актуализиране по-късно</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Изтриване на песента</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Сигурни ли сте, че искате да изтриете този трак?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Име на песента</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Преместване</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Пътека</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Промяна на цвета</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Карта</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Искате ли да изпратите доклад за грешка на разработчиците?
+Разчитаме на нашите потребители, тъй като Organic Maps не събира информация за грешки автоматично. Благодарим ви предварително, че подкрепяте Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Активиране на синхронизацията с iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Синхронизацията в iCloud е експериментална функция в процес на разработка. Уверете се, че сте направили резервно копие на всичките си отметки и песни.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud е деактивиран</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>За да използвате тази функция, разрешете iCloud в настройките на устройството си.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Активиране на</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Резервно копие</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Неуспешна синхронизация на iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Грешка: Не успя да се синхронизира поради грешка при свързването</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Грешка: Неуспешно синхронизиране поради превишена квота на iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Грешка: iCloud не е наличен</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Наскоро изтрити списъци</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Изчистване</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Изтриване на всички</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Възстановяване</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Възстанови всички</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Допринесете към OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Добави място</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Актуализирайте картата, за да допринесете</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Трябва да актуализирате картата %1 до последната версия, преди да можете да допринесете с данни към OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>МБ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ГБ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Мое местоположение</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Мои места</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Вътрешно частно хранилище</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Вътрешно споделено хранилище</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Карта памет</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Външно споделено хранилище</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Пощенски код</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Точка на картата</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>м</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>км</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ми</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>фут</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>За да се показват маршрути, картите трябва да бъдат актуализирани.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Изход</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Вход</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Картата на метрото не е налична</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Вие</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Лилави изтеглени региони</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Маршрут</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Дефинирането на текущото местоположение във фонов режим е необходимо, за да се възползвате напълно от функционалността на приложението. То се използва при опциите за проследяване на маршрута и запазване на последния изминат такъв.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Определянето на местоположението ви е необходимо за навигацията и за запазване на последния изминат маршрут.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Влизане с парола</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Влизане чрез браузър</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Наскоро използван</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Цветът на отметките е променен</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Цветът на маршрутите е променен</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Спектър</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Плъзгачи</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ЧЕРВЕН</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ЗЕЛЕН</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Мрежа</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/bn/omim.ts
+++ b/qt/translations/bn/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="bn">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>পিছনে</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>বাতিল</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>মুছো</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>ডাউনলোডকৃত মানচিত্র</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>ডাউনলোড ব্যর্থ। আবার চেষ্টা করতে টিপ দাও।</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>ডাউনলোডরত…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>কিলোমিটার</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>মাইল</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>পরে</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>অনুসন্ধান</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>মানচিত্র অনুসন্ধান</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>অন্ধকারে নেভিগেট করার সময় নাইট স্টাইল</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>ভোর থেকে সন্ধ্যা পর্যন্ত হালকা</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>লক্ষ লক্ষ ব্যবহারকারীকে বিজ্ঞাপন ছাড়াই বিনামূল্যে মানচিত্র উপহার দিন!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org থেকে নিবন্ধ</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n বুকমার্ক</numerusform>
+<numerusform>%n বুকমার্ক</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n ফাইল পাওয়া গেছে। আপনি এটি রূপান্তরের পরে দেখতে পাবেন।</numerusform>
+<numerusform>%n ফাইল পাওয়া গেছে। আপনি সেগুলি রূপান্তরের পরে দেখতে পাবেন।</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ট্র্যাক</numerusform>
+<numerusform>%n ট্র্যাকগুলি</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>সিস্টেম অনুসরণ করুন</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>এমবি</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>জিবি</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>আমার অবস্থান</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>বেগুনি ডাউনলোড করা অঞ্চল</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>পাসওয়ার্ড দিয়ে লগইন</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ব্রাউজার ব্যবহার করে লগইন</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>সম্প্রতি ব্যবহৃত</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>স্পেকট্রাম</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>স্লাইডারসমূহ</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>লাল</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>সবুজ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>নীল</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB হেক্স রঙ #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>গ্রিড</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ca/omim.ts
+++ b/qt/translations/ca/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ca">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Enrere</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel·la</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Suprimeix</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Baixa mapes</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>La baixada ha fallat. Toqueu per a tornar-ho a intentar.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>S’està baixant…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Quilòmetres</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Més tard</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Cerca</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Cerca en el mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Tots els serveis de geolocalització d’aquest aparell o aplicació estan desactivats. Activeu-los a la configuració.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisió limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Per assegurar la navegació precisa, activeu la ubicació precisa en la configuració.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostra-ho al mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>La baixada ha fallat</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Torna-ho a intentar</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Quant a l’Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratuït per a tothom, fet amb amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sense publicitat, rastreig ni recopilació de dades</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Consum de bateria mínim, funciona fora de línia</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Ràpid, minimalista, desenvolupat per la comunitat</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicació de codi obert creada per entusiastes i voluntaris.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Paràmetres d’ubicació</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Tanca</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>L’aplicació requereix acceleració per maquinari OpenGL. Malauradament, el vostre aparell no ho admet.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Baixa</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Desconnecteu el cable USB o inseriu una targeta de memòria per a usar l’Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Allibereu espai en la targeta SD o emmagatzematge USB per a poder usar l’aplicació</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Abans d’usar l’aplicació, cal que baixeu el mapa del món general al vostre aparell.&#32;
+Usarà %1 d’emmagatzematge.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ves al mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>S’està baixant %1. Mentrestant, podeu
+anar al mapa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Voleu baixar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Voleu actualitzar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausa</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continua</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>La baixada de %1 ha fallat</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Afegeix una llista nova</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nom de la llista de marcadors</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadors</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Marcadors i recorreguts</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nom</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adreça</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Llista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Paràmetres</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Desa els mapes a</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Indiqueu la carpeta on s’han de baixar els mapes.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapes baixats</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 lliures de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Voleu moure els mapes?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>S&#x27;ha produït un error en moure els fitxers de mapes</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Això pot trigar uns minuts.
+Espereu…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unitats de mesura</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Trieu entre milles i quilòmetres</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel·la la baixada</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Deixa una opinió</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Baixa el mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Llistes de marcadors</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>On menjar</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Queviures</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzinera</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparcament</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compres</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Segona mà</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Turisme</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entreteniment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Caixer automàtic</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida nocturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Oci familiar</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banc</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmàcia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Lavabos</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Oficina postal</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclatge</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Aigua</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Caravanes</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>S’han compartit amb vós marcadors de l’Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hola!
+
+Adjunto els meus marcadors de l’Organic Maps. Obriu-los si teniu l’Organic Maps instal·lat. O, si no teniu l’aplicació, baixeu-la per al vostre aparell iOS o Android seguint aquest enllaç: https://omaps.app/get?kmz
+
+Gaudiu viatjant amb l’Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>S’estan carregant els marcadors</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Els marcadors s’han carregat correctament. Els trobareu al mapa i a la pantalla de gestió de marcadors.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>No s&#x27;ha pogut carregar els marcadors. El fitxer pot ser malmès o defectuós.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>L&#x27;aplicació no reconeix el tipus de fitxer:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>No s&#x27;ha pogut obrir el fitxer %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edita</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Encara no s’ha determinat la vostra ubicació</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>La configuració de l&#x27;emmagatzematge del mapes està desactivada.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>La baixada del mapa és en curs.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Mira la meva ubicació en l&#x27;Organic Maps! %1 o %2 No teniu mapes sense connexió? Baixeu-los aquí: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Ep, mireu el meu marcador a l&#x27;Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Ep, mireu la meva ubicació actual en el mapa de l&#x27;Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hola,
+
+Soc aquí: %1. Feu clic en aquest enllaç %2 o en aquest altre %3 per a veure el lloc en el mapa.
+
+Gràcies.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Comparteix</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Correu-e</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>S’ha copiat al porta-retalls: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Fet</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dades de l&#x27;OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Esteu segur que voleu tancar la sessió del vostre compte d&#x27;OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Recorreguts</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Longitud</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Comparteix la meva ubicació</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Configuració general</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informació</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegació</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botons «+» i «-» al mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Mostra&#x27;ls al mapa</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estil nocturn quan es navega en la foscor</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Mode nocturn</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desactivat</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activat</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automàtic</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vista en perspectiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edificis en 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Els edificis en 3D es desactiven en mode d’estalvi d’energia</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instruccions de veu</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anuncia els noms dels carrers</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Quan s&#x27;activa, el nom del carrer o la sortida per girar es pronunciarà en veu alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Llengua de la veu</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Per baixar una veu de més qualitat, obre l&#x27;app Configuració i ves a Accessibilitat → VoiceOver → Parla → Veu.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Prova les indicacions de veu (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Comproveu el volum o la configuració de text a veu del sistema si ara no escolteu la veu.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>No disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automàtic</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distància</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Visualitza al mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menú</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Lloc web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Notícies</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Comentaris</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Puntua l&#x27;aplicació</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ajuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Preguntes més freqüents</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donatiu</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ja he donat</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Recorda’m més tard</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Doneu suport a l’Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Doneu suport al projecte</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Drets d’autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Informa d’un error</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Milloreu la direcció de la fletxa movent el telèfon amb un moviment de vuit per a calibrar la brúixola.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Moveu el telèfon amb un moviment de vuit per a calibrar la brúixola i corregir la direcció de la fletxa al mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Toqueu llargament el mapa de nou per a veure la interfície</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Actualitza-ho tot</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel·la-ho tot</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Baixats</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En cua</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>A prop meu</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapes</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Baixa-ho tot</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Baixant:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Per a suprimir el mapa, atureu la navegació.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Només es poden crear rutes que pertanyin totalment al mapa d&#x27;una sola regió.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Baixeu el mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Torna-hi</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Suprimeix el mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Actualitza el mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Serveis d’ubicació de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determineu ràpidament la vostra ubicació aproximada mitjançant Bluetooth, WiFi o xarxa mòbil</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Baixeu tots els mapes de la ruta</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Per a crear una ruta, ens cal baixar i actualitzar tots els mapes des de la vostra ubicació a la destinació.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>No hi ha prou espai</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Activeu els serveis de geolocalització</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Desa</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crea</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Vermell</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Groc</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blau</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verd</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Porpra</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Taronja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marró</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Porpra fosc</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Blau clar</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cian</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Jade</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Llima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Taronja fosc</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris blavós</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informació</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versió de l’Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspecte</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Clar</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Fosc</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Clar de l&#x27;alba fins al capvespre</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Altre</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Regala mapes gratuïts sense anuncis a milions d&#x27;usuaris!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Informa o corregeix dades de mapa incorrectes</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Fer-se voluntari</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Segueix i contacta amb nosaltres:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>No s&#x27;ha configurat cap client de correu electrònic. Configureu-lo o useu un altra via per contactar amb nosaltres a %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>S&#x27;ha produït un error en enviar el correu</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibratge de la brúixola</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponibles</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Trobat</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Actualitza</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fallit</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>marcador</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Quan seguiu la ruta, tingueu present:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Les condicions de la carretera, les normes de trànsit i els senyals de circulació sempre tenen prioritat sobre les indicacions de navegació;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— El mapa pot ser imprecís, i la ruta suggerida potser no sempre és la via més òptima per a arribar a la destinació;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Les rutes suggerides només s’han d’entendre com a recomanacions;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Aneu am cura amb les rutes en zones frontereres: les rutes creades per la nostra aplicació de vegades creuen fronteres internacionals en zones no autoritzades.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Estigueu alerta i segur a la carretera!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Comprova el senyal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>No s&#x27;ha pogut crear la ruta. No s&#x27;ha pogut identificar les coordenades GPS atuals.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Comproveu el senyal GPS. L’activació del Wi-Fi millorarà la precisió de la ubicació.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activa els serveis de geolocalització</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>No s&#x27;han pogut trobar les coordenaes GPS actuals. Activeu els serveis de geolocalització per a calcular la ruta.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>No s&#x27;ha pogut trobar cap ruta</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>No s&#x27;ha pogut crear la ruta.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ajusteu el punt inicial o la destinació.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ajusta el punt inicial</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>La ruta no s&#x27;ha creat. No s&#x27;ha pogut trobar el punt inicial.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Indiqueu un punt inicial més proper a una via.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajusta la destinació</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>La ruta no s&#x27;ha creat. No s&#x27;ha pogut trobar la destinació.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Indiqueu un punt de destinació més proper a una via.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>No s&#x27;ha pogut trobar el punt intermig.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Ajusteu el punt intermig.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Error de sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>No s&#x27;ha pogut crear la ruta a causa d&#x27;un error de l&#x27;aplicació.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Torneu-ho a intentar</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ara no</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Voleu baixar el mapa i crar una ruta més òptima que travessi més d&#x27;un mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Baixeu mapes addicionals per a crear una ruta millor que creua els límits d&#x27;aquest mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Baixa els fitxers necessaris</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Baixeu i actualitzeu tots els mapes i informació de rutes del trajecte per a calcular-ne la ruta.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Per a començar a cercar i crear rutes, baixeu el mapa. Després ja no us caldrà connexio a Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Seleccioneu un mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostra</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Amaga</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historial</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>No s’ha trobat cap resultat.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Baixeu la regió on esteu cercant o proveu d&#x27;afegir un nom de ciutat o poble proper.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historial de cerca</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Mostra les cerques recents.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Neteja l’historial de cerques</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Viquipèdia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>La vostra ubicació</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Inicia</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>De</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>A</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navegació només és disponible des de la ubicació actual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Voleu que planifiquem una ruta des de la vostra ubicació actual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Següent</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>A</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Afegeix un horari</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Suprimeix l’horari</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Tot el dia (24 hores)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Obert</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Tancat</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Afegeix les hores de tancament</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horari d’obertura</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mode avançat</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mode senzill</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horari de tancament</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valors d’exemple</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corregeix un error</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Seleccioneu Ubicació</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Descriviu el problema detalladament perquè la comunitat d&#x27;OpenStreetMap pugui corregir l&#x27;error.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>O feu-ho vós mateix a https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Envia</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>El lloc no existeix</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Tancat per manteniment</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lloc duplicat</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Baixada automàtica</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diari</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Avui és tancat</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Tancat</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Avui</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Obre en %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Tanca en %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Tancat</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edita l’horari d’obertura</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>No teniu compte de l’OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registre a OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Inicia sessió</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>No heu iniciat sessió</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Inicia sessió a l’OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Contrasenya</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Heu oblidat la contrasenya?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Tanca la sessió</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edita el lloc</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Afegeix una llengua</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Carrer</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Número de la casa</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalls</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Mitjans Socials</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edifici</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Afegeix un carrer</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Introduïu un nom de carrer</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Trieu una llengua</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Trieu un carrer</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Trieu una cuina</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Adreça electrònica o nom d’usuari</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Afegeix un telèfon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Planta</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivell: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Totes les vostres edicions del mapa se suprimiran conjuntament amb aquest.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Actualitza els mapes</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Per a crear una ruta, cal que actualitzeu tots els mapes i després torneu a planificar la ruta.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Troba el mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Reviseu els paràmetres i assegureu-vos que l’aparell està connectat a Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>No hi ha prou espai</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Suprimiu les dades no necessàries</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Error en iniciar sessió.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Canvis verificats</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arrossegueu el mapa per col·locar la creu a la ubicació del lloc o de l&#x27;empresa.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Edició</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Addició</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nom del lloc</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Com està escrit en la llengua local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descripció detallada del problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Un altre problema</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Afegeix un negoci</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No s’ha trobat cap objecte aquí</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dades de l’OpenStreetMap creades per la comunitat a data de %1. Obteniu més informació sobre com editar i actualitzar el mapa a OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) és un projecte comunitari per construir un mapa lliure i obert. És la font principal de dades de mapes a Organic Maps i funciona de manera similar a la Viquipèdia. Pots afegir o editar llocs i estaran disponibles per a milions d&#x27;usuaris de tot el món.
+Uneix-te a la comunitat i ajuda a crear un mapa millor per a tothom!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Creeu un compte d&#x27;OpenStreetMap o inicieu sessió per publicar les vostres edicions de mapes al món.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Voleu baixar-ho a través d’una connexió de xarxa mòbil?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Podria ser força car amb algunes tarifes o amb itinerància de dades.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introduïu un número d’edifici vàlid</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Nombre de plantes (màxim %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>El nombre de plantes no pot excedir de %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Codi postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introduïu un codi postal vàlid</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota per als voluntaris d&#x27;OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Descriviu els errors al mapa o les coses que no es poden editar amb Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Les vostres edicions es pengen a la base de dades pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Ca:About&quot;&gt;OpenStreetMap&lt;/a&gt;. Si us plau, no afegiu informació personal o amb drets d&#x27;autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Més sobre l&#x27;OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>El vostre historial d’edicions</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Notes de les vostres dades del mapa</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>No trobeu una categoria adequada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps només permet afegir categories de punts simples, això vol dir que no hi ha ciutats, carreteres, llacs, contorns d&#x27;edificis, etc. Si us plau, afegiu aquestes categories directament a &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulteu la nostra &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guia&lt;/a&gt; per obtenir instruccions detallades pas a pas.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>No heu baixat cap mapa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Baixeu mapes per a cercar una ubicacio i usar la navegació sense connexió.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Es desconeix la ubicació actual.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Més</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edita el marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notes personals (text o html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentari…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Voleu descartar tots els canvis locals?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Descarta</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Voleu suprimir el lloc afegit?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Suprimeix</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>El lloc no existeix</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Indiqueu per què esborreu el lloc</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introduïu un número de telèfon vàlid</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Introduïu una adreça web vàlida</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Introduïu una adreça electrònica vàlida</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introduïu una adreça web de Facebook, un compte o un nom de pàgina vàlids</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introduïu una adreça web d&#x27;Instagram o un nom de compte vàlids</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introduïu una adreça web de Twitter o un nom d&#x27;usuari vàlids</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introduïu una adreça web de VK o un nom de compte vàlids</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introduïu una adreça web de LINE o un ID LINE vàlids</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Afegeix un lloc a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>O bé, deixeu una nota a la comunitat de l’OpenStreetMap perquè algú altre pugui afegir o arreglar un lloc.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>La nota s’enviarà a l’OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Voleu enviar-ho a tots els usuaris?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Assegureu-vos que no heu introduït cap dada personal.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Els editors de l’OpenStreetMap comprovaran els canvis i us contactaran si tenen qualsevol dubte.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Atura</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>S’està enregistrant el recorregut</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accepta</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Ho rebutjo</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Voleu usar Internet mòbil per a mostrar informació detallada?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usa’l sempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Només avui</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>No l’utilitzis avui</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mòbil</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Es necessita Internet mòbil per a les notifiacions d&#x27;actualitzacions del mapa i per a mostrar informació detallada dels llocs i marcadors.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Mai</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Demana-ho sempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Per a mostrar les dades de trànsit, s’han d’actualitzar els mapes.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Augmenta la mida de lletra del mapa</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Actualitzeu l’Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>No hi ha dades de trànsit disponibles</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activa el registre</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Opinió general</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Usem el sistema de síntesi de veu per a les instruccions de veu. Molts aparells Android use el motor de síntesi de veu de Google, podeu baixar o actualitzar-lo des del Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Per a algunes llengües, haureu d&#x27;instal·lar un sintetizador de veu o un paquet de llengua addicional des de la botiga d&#x27;apliacions (Google Play, Galazy Store, FDroid).
+Obriu la configuració de l&#x27;aparell → Idioma i entrada → Veu → Sortidda de text a veu.
+Aquí podeu gestionar la configuració de la síntesi de veu (per exemple, baixar un paquet de llengua per a ús sense connexió) i triar un altre motor de síntesi de veu.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Per a més informació, vegeu aquesta guia.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteració a l’alfabet llatí</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Més informació</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilitzeu la cerca o toqueu el mapa per afegir un punt de partida de la ruta</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utilitzeu la cerca o toqueu el mapa per afegir un punt de destinació</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gestionar la ruta</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifica</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Elimina parada</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Afegeix una parada</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Desat</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Inicieu sessió a l’OpenStreetMap per a pujar automàticament totes les edicions al mapa. Llegiu &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aquí&lt;/a&gt; més informació.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Hi ha un problema d’accés a l’emmagatzematge</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>L&#x27;emmagatzematge extern no és accessible. La targeta SD pot haver estat eliminada, danyada o sigui només de lectura. Si us plau, reviseu la targeta SD o contacta amb nosaltres a support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emula un emmagatzematge malmès</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Introduïu un nom correcte</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Llistes</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Amaga-ho tot</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Mostra-ho tot</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcador</numerusform>
+<numerusform>%n marcadors</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Crea una llista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importa marcadors i recorreguts</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>No s&#x27;ha pogut compartir a causa d&#x27;un error de l&#x27;aplicació</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Error al compartir</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>No es pot compartir una llista buida</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>El nom no pot ser buit</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Introduïu el nom de la llista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Llista nova</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Aquest nom ja és en ús</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Trieu-ne un altre</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Espereu…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de telèfon</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil de l’OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>S’ha trobat %n fitxer. Podreu veure’l després de la conversió.</numerusform>
+<numerusform>S’han trobat %n fitxers. Podreu veure’ls després de la conversió.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaura</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n recorregut</numerusform>
+<numerusform>%n recorreguts</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privadesa</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Política de privadesa</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Condicions del servei</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trànsit</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Camins</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclisme</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estils i capes del mapa</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Aquesta llista és buida</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Per a afegir un marcador, toqueu un lloc en el mapa i després toqueu la icona d&#x27;estrella</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Canvia el color de tots els marcadors</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Canvia el color de tots els recorreguts</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…més</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exporta KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exporta GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exporta GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Suprimeix la llista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radars</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descripció del lloc</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Baixada de mapes</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avisa en excedir el límit de velocitat</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Sempre avisa</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>No n’avisis mai</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mode d’estalvi d’energia</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Es provarà de reduir l’ús d’energia a costa d’algunes funcionalitats.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Mai</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automàtic</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Noms de marcadors al mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Si hi ha massa marcadors, mostrar-ne els noms al mapa pot alentir l&#x27;aplicació.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostra a la dreta</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostra a la part inferior</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Activeu aquesta opció temporalment per a registrar i enviar manualment registres de diagnòstic detallats sobre el vostre problema utilitzant «Informeu d’un error» al diàleg Ajuda. Els registres poden incloure informació d’ubicació.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opcions d’encaminament</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evita peatges</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evita vies sense pavimentar</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evita ferris</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evita autopistes</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>No s’ha pogut calcular la ruta</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Malauradament, no hem pogut trobar cap ruta. Probablement per les opcions que heu triat. Canvieu-les i torneu a intentar-ho.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definiu les vies a evitar</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Paràmetres d’encaminament activats</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Via de peatge</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Via sense pavimentar</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferris</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacitat: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Xarxa: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Heu arribat!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>D’acord</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordena…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordena els marcadors</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Per defecte</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Per tipus</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Per distància</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Per data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Per nom</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Fa una setmana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Fa un mes</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Fa més d’un mes</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Fa més d’un any</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Prop meu</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Altres</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>La planificació de la ruta ha fallat</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arribada: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Baixeu i actualitzeu tots els mapes del trajecte per a calcular-ne la ruta.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Heu canviat el mapa mundial. No ho guardeu en secret! Expliqueu-ho als amics, i editeu-lo junts.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Comparteix amb amics</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Ara és tancat</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Obre demà a les %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Obre el %1 a les %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Obre a les %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Tanca a les %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Afegeix horari d&#x27;obertura</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Contrasenya (mínim 8 caràcters)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nom d&#x27;usuari o contrasenya no vàlids.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Compte OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Última pujada</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Gràcies</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nom del lloc</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telèfon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Atenció</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Error de baixada</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Trieu una categoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Totes les categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Afegiu llocs al mapa, i editeu-ne els existents directament des de l’aplicació.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Canvia la ubicació</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Per a la baixada, us cal més espai. Suprimiu les dades no necessàries.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>He millorat els mapes de l’Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentari detallat</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Heu suggerit canvis en el mapa que s’enviaran a la comunitat de l’OpenStreetMap. Descriviu qualsevol detall addicional que no es pugui editar amb l’Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>S’ha produït un error en determinar la vostra ubicació. Comproveu que l’aparell funciona correctament i torneu-ho a provar.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Els serveis de geolocalització estan desactivats</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Activeu l&#x27;accés a la geolocalització en la configuració de l&#x27;aparell</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Obriu la configuració</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Toqueu «Ubicació»</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Trieu «Mentre s’usa l’aplicació»</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Trieu «Privadesa»</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Trieu «Serveis d’ubicació»</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Activeu els serveis d&#x27;ubicació</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>O continuar utilitzant Organic Maps sense ubicació</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reserva</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Truca-hi</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nom del marcador</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Suprimeix el marcador</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>La vostra nota s&#x27;enviarà a OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…més</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Actualitza</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Voleu desactivar l&#x27;enregistrament del recorregut recent?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desactiva</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Verifica</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>L’Organic Maps usa la vostra ubicació en segon pla per a enregistrar el recorregut que heu fet recentment.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Paràmetres generals</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Per a mostrar les dades de trànsit, cal que l&#x27;aplicació estigui actualitzada.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Mida del fitxer de registre: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arrossegueu-lo aquí per a eliminar-lo</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Substituir Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Comença des de</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Si us plau, inicieu sessió a OpenStreetMap per carregar automàticament totes les edicions de mapes. Més informació</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aquí</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Amaga la pantalla</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2/%3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>S’està baixant %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>S’està aplicant %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Aquest nom és massa llarg</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>S’han detectat fitxers nous</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Converteix</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Alguns fitxers no s&#x27;han convertit.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>S’ha produït un error</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Amaga-ho en el mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>S&#x27;ha produït un error en carregar les etiquetes, torneu-ho a intentar</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Dret</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Baix</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Som-hi</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinació</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centra</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultats de cerca</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Després</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Voleu tornar a calcular la ruta?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>El teclat no està disponible quan conduïu</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>No es pot calcular cap ruta des de la vostra ubicació actual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>No es pot calcular cap ruta a la vostra destinació. Trieu un altre punt</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No hi ha senyal GPS. Aneu a un àrea oberta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>No es pot calcular cap ruta. Indiqueu uns punts de ruta diferents</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Per a crear una ruta, baixeu les mapes que manquen en el vostre aparell</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>S’ha produït un error. Reinicieu l’aplicació</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Es tornarà a calcular la ruta des de la ubicació actual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>La ruta es convertira a una d&#x27;automòbil</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>No es mostren totes les adreces d&#x27;interès</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Canvia al telèfon per veure totes les adreces d&#x27;interès</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radars</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Avisos de radars</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Baixeu els mapes en l’aplicació de l’aparell mòbil</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 sortida</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenació predeterminada</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordena per tipus</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordena per distància</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordena per data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordena per nom</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Menjar</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Llocs d&#x27;interès</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museus</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parcs</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natació</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Muntanyes</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edificis</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Diners</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Botigues</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Aparcaments</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzineres</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Cerca en la llista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Llocs de culte</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Trieu una llista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navegació en metro en aquesta regió encara no és disponible</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No s’ha trobat cap ruta en metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Trieu un altre punt, inicial o final, més proper a una estació de metro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Corbes de nivell</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Per a activar i usar la capa topogràfica, actualitzeu o baixeu el mapa de l’àrea</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>La capa topogràfica encara no és disponible en aquesta àrea</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascens</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descens</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevació mín.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevació màx.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultat</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distància:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Temps:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Apropeu el mapa per a explorar les isolínies</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>S’està baixant</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Baixa el mapa general del món</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>No s&#x27;ha pogut crear la carpeta ni moure els fitxers a la memòria interna de l&#x27;aparell o targeta SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Error de disc</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Error de connexió</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desconnecteu el cable USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mantén la pantalla encesa</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Quan està activat, la pantalla sempre estarà encesa quan es mostri el mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostra en la pantalla de bloqueig</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Si està activa, no cal desblocar l&#x27;aparell cada vegada mentre l&#x27;aplicació està funcionant.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Llengua del mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dades cartogràfiques de l’OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/ca/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/ca/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Ca:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Gràcies per utilitzar els nostres mapes creats per la comunitat!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Amb les vostres donacions i suport, podem crear els millors mapes del món!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Us agrada la nostra aplicació? Feu una donació per donar suport al desenvolupament! Encara no us agrada? Si us plau, feu-nos-ho saber i ho solucionarem!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Si coneixeu un desenvolupador de programari, podeu demanar-li que implementi una funcionalitat que necessiteu.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Toqueu qualsevol lloc del mapa per seleccionar qualsevol cosa. Toqueu llargament per amagar i mostrar la interfície.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Sabíeu que podeu seleccionar la vostra ubicació actual al mapa?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Podeu ajudar a traduir la nostra aplicació a la vostra llengua.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>La nostra aplicació està desenvolupada per uns quants entusiastes i la comunitat.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Podeu corregir i millorar fàcilment les dades del mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>El nostre objectiu principal és crear mapes ràpids, centrats en la privadesa i fàcils d&#x27;utilitzar que us encantaran.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Ara esteu utilitzant Organic Maps a la pantalla del telèfon</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ara esteu utilitzant Organic Maps a la pantalla del cotxe</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Us heu connectat a Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Passa al telèfon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>A la pantalla del cotxe</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps necessita accés a la ubicació. Quan sigui segur, comproveu la notificació al telèfon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Aquesta aplicació necessita el vostre permís</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>L’Organic Maps a l’Android Auto necessita permisos d’ubicació per a funcionar eficaçment</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Concedeix permisos</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Senderisme</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>El navegador web no està disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volum</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exporta tots els marcadors i recorreguts</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Paràmetres de la síntesi de veu del sistema</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>No s’han trobat els paràmetres de la síntesi de veu. Esteu segur que el vostre dispositiu l’admet?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servei des del cotxe</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Elimina la cerca</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Apropa</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Allunya</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Enllaç del menú</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Visualitza el menú</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Obre en una altra aplicació</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoservei</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Seleccioneu l&#x27;opció</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Seients a l&#x27;aire lliure</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Per a una navegació més precisa, recomanem desactivar el mode d&#x27;estalvi d&#x27;energia a la configuració de la bateria del telèfon.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Enregistra el recorregut</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Atura l’enregistrament del recorregut</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Enregistrament de trajecte</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Atura sense desar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuar enregistrant</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Voleu desar l’enregistrament a Marcadors i recorreguts?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>El recorregut està buit; no hi ha res a desar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>No es pot mostrar el diàleg de selecció de carpetes perquè no hi ha cap aplicació adequada instal·lada al vostre dispositiu. Instal·leu una aplicació de gestió de fitxers i torneu-ho a provar.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Tria el color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edita el recorregut</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No hi ha cap aplicació instal·lada que pugui obrir la ubicació</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto a la navegació</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Segueix el sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Comparteix la pista</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Esborrar %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivell de dificultat</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fàcil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderat</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>S’està actualitzant</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Actualitzeu els mapes baixats</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>L&#x27;actualització dels mapes manté la informació sobre els objectes al dia</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Actualitza (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Actualitza manualment després</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Suprimeix el recorregut</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Segur que voleu suprimir aquest recorregut?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nom del recorregut</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mou</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Recorregut</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Canvia de color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Voleu enviar un informe d’error als desenvolupadors?
+Ens refiem dels nostres usuaris, ja que l’Organic Maps no recull cap informació d’errors automàticament. Gràcies per avançat per donar suport a Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activa la sincronització amb l’iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La sincronització de l’iCloud és una funcionalitat experimental en desenvolupament. Assegureu-vos que heu fet una còpia de seguretat de tots els vostres marcadors i recorreguts.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>L’iCloud està desactivat</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Activeu l’iCloud a la configuració del dispositiu per utilitzar aquesta funció.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activa</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Còpia de seguretat</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Error de sincronització de l’iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: no s’ha pogut sincronitzar a causa d’un error de connexió</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: no s’ha pogut sincronitzar perquè s’ha superat la quota de l’iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: l’iCloud no està disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Llistes suprimides recentment</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Neteja</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Suprimeix-ho tot</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar-ho tot</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribueix a OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Afegeix un lloc</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Actualitza el mapa per contribuir</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Heu d’actualitzar el mapa de %1 a l’última versió abans de poder contribuir a les dades d’OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>La meva posició</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Els meus llocs</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Emmagatzematge privat intern</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Emmagatzematge compartit intern</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Targeta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Emmagatzematge compartit extern</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Codi postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punt del mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Per mostrar els itineraris, cal actualitzar els mapes.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Sortida</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>El mapa del metro no està disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Tu</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regions descarregades en lila</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ruta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>La detecció de la ubicació en segon pla és necessària per gaudir plenament de la funcionalitat de l&#x27;aplicació. S&#x27;utilitza per a la navegació i desar la ruta feta recentment.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determinar la vostra ubicació és necessari per a la navegació i per desar el vostre recorregut recentment.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Inicieu la sessió amb contrasenya</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Inicieu la sessió mitjançant el navegador</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Usats recentment</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>El color dels marcadors ha canviat</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>El color dels recorreguts ha canviat</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectre</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Desplaçadors</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROIG</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERD</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLAV</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Color Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Graella</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/cs/omim.ts
+++ b/qt/translations/cs/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="cs">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Zpět</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Zrušit</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Smazat</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Stáhnout mapy</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Stahování selhalo, zkuste to znovu.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Stahování…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometry</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Míle</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Později</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Hledat</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Prohledat mapu</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Aktuálně máte všechny možnosti pro určování polohy vypnuté. Prosím, povolte je v Nastavení.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Omezená přesnost</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Chcete-li zajistit přesnou navigaci, povolte v nastavení možnost Přesná poloha.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Ukázat na mapě</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Stahování selhalo</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Zkusit znovu</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>O aplikaci Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Zdarma pro všechny, vyrobené s láskou</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Žádné reklamy, žádné sledování, žádný sběr dat</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Žádné vybíjení baterie, funguje offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rychlé, minimalistické, vyvinuté komunitou</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Otevřená aplikace vytvořená nadšenci a dobrovolníky.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Nastavení polohy</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zavřít</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Je vyžadována hardwarová akcelerace OpenGL. Bohužel, vaše zařízení není podporováno.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Stáhnout</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Prosím, odpojte USB kabel nebo vložte paměťovou kartu pro použití s Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Prosím, uvolněte nejprve místo na SD kartě/USB uložišti</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Ještě než začnete, bude třeba stáhnout obecnou mapu světa.
+Zabere to %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Přejít na mapu</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Stahování oblasti %1. Nyní můžete
+přejít na mapu.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Stáhnout %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Aktualizovat %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pozastavit</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Pokračovat</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Stahování selhalo: %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Přidat novou skupinu záložek</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Název záložky</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Záložky</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Záložky a stopy</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Název</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresa</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Seznam</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Nastavení</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Ukládat mapy do</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Vyberte místo, kam mají být stahovány mapy.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 z %2 volných</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Přesunout mapy?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Chyba při přesouvání souborů mapy</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Tato akce může trvat několik minut.
+Prosím čekejte…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Měřicí jednotky</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Vyberte si míle nebo kilometry</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Zrušit stahování</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Zpětná vazba</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ano</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Stáhnout mapu</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Skupiny záložek</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Kde se najíst</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Potraviny</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Doprava</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Čerpací stanice</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkoviště</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Nákupy</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second-hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Památky</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Zábava</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Noční život</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Dovolená s dětmi</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Lékárna</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Nemocnice</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Záchody</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pošta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policie</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recyklace</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Voda</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Pro RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Poznámky</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Sdílené záložky Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Ahoj!
+
+V příloze najdeš mé záložky; otevři je v aplikaci Organic Maps. Pokud ji nemáš nainstalovanou, můžeš si ji stáhnout zde: https://omaps.app/get?kmz&#32;
+
+Užij si cestování s Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Nahrávání záložek</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Záložky byly úspěšně nahrány! Naleznete je na mapě nebo ve správci záložek.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Nahrávání záložek se nezdařilo. Soubor může být poškozený nebo vadný.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Typ souboru není aplikací rozpoznán:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nepodařilo se otevřít soubor %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Upravit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Vaše poloha zatím nebyla určena</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Omlouváme se, nastavení uložení map je dočasně nedostupné.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Právě probíhá stahování země.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Podívej se na mojí polohu v Organic Maps! %1 nebo %2 Nemáš offline mapy? Stáhni si je zde: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Koukni na mojí značku na mapě v Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Podívej se na mou aktuální polohu na mapě v Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Ahoj,
+
+Právě jsem tady: %1. Klepni na jeden z těchto odkazů %2, %3 a uvidíš toto místo na mapě.
+
+Díky.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Sdílet</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Zkopírováno do schránky: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Hotovo</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Data OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Opravdu se chcete odhlásit ze svého účtu OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Stopy</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Délka</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Sdílet mé umístění</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Obecná nastavení</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informace</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigace</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Tlačítka „+“ a „-“ na mapě</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Zobrazit na obrazovce</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Noční styl při navigaci ve tmě</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Noční režim</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Vypnuto</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Zapnuto</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automaticky</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Zobrazení perspektivy</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D budovy</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D budovy jsou vypnuty v úsporném režimu</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Hlasové instrukce</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Oznamovat názvy ulic</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Je-li povoleno, bude nahlas vyslovován název ulice nebo výjezdu, na který máte odbočit.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Jazyk hlasu</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Chcete-li stáhnout hlas ve vyšší kvalitě, otevřete aplikaci Nastavení a přejděte do Zpřístupnění → VoiceOver → Řeč → Hlas.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Otestovat hlasové pokyny (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Pokud nyní hlas neslyšíte, zkontrolujte nastavení hlasitosti nebo převodu textu na řeč v systému.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Není dostupná</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatické zvětšení</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Vzdálenost</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Zobrazit na mapě</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Nabídka</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webové stránky</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Novinky</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Zpětná vazba</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Ohodnotit aplikaci</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Nápověda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Otázky a odpovědi</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Darovat</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Již darováno</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Připomeň později</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Podpořit Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Podpořte projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autorská práva</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Nahlásit chybu</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Zlepšete směr šipky pohybem telefonu do osmičky a zkalibrujte kompas.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Pohybem telefonu do osmičky zkalibrujte kompas a zafixujte směr šipky na mapě.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Dlouhým klepnutím na mapu znovu zobrazíte rozhraní</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aktualizovat vše</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Zrušit vše</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Staženo</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Ve frontě</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Poblíž mě</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Stáhnout vše</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Probíhá stahování:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Chcete-li odstranit mapu, pak prosím zastavte navigaci.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Lze vytvářet jen takové trasy, které se nachází na území jediné mapy.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Stáhnout mapu</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Opakovat</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Smazat mapu</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aktualizovat mapu</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Služby určování polohy Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Rychlé určení přibližné polohy pomocí sítě Bluetooth, Wi-Fi nebo mobilní sítě</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Stahovat mapy podél cesty</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Naplánování trasy vyžaduje stažení a aktualizaci všech map z vašeho umístění do cílového umístění.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nedostatek místa</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Prosím, povolte Služby určování polohy</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Uložit</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>vytvořit</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Červená</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Žlutá</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Modrá</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zelená</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purpurová</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranžová</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Hnědá</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Růžová</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tmavě fialová</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Světle modrá</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Azurová</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Čajová</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limeta</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tmavě oranžová</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Šedá</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Modrošedá</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Více informací</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Verze Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Vzhled</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Světlý</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tmavý</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Světlý od svítání do soumraku</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Ostatní</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Darujte bezplatné mapy bez reklam milionům uživatelů!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Nahlášení nebo oprava nesprávných mapových dat</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Dobrovolnictví</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Sledujte nás a kontaktujte nás:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Emailový klient nebyl ještě nakonfigurován. Nastavte ho, prosím, nebo použijte jiný způsob k našemu kontaktování na %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Chyba při odesílání emailu</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrace kompasu</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Dostupné</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Nalezeno</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aktualizace</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Selhalo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>uložit</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Při navigaci podle trasy mějte na paměti následující:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Situace na silnici, dopravní předpisy a dopravní značení mají vždy prioritu před pokyny navigace;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Mapa může být nepřesná a navrhovaná trasa nemusí být vždy optimální cestou, jak dojet do cíle;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Navrhované trasy je třeba brát pouze jako doporučení;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— U stop v hraničních zónách buďte opatrní: trasy vytvořené naší aplikací občas překračují hranice zemí na nepovolených místech.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Na silnici buďte pozorní a chovejte se bezpečně!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Zkontrolovat signál GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Trasu se nepodařilo vytvořit. Nelze zjistit aktuální souřadnice GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Zkontrolujte signál GPS. Povolením připojení WiFi zpřesníte určení vaší polohy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Povolit služby určování polohy</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Aktuální souřadnice GPS se nepodařilo zjistit. Pro výpočet trasy povolte služby určování polohy.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Trasu se nepodařilo zjistit</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Trasu se nepodařilo vytvořit.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Upravte výchozí nebo cílový bod.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Upravte výchozí bod</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Trasa nebyla vytvořena. Výchozí bod se nepodařilo najít.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Zvolte výchozí bod blíže k silnici.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Upravit cíl</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Trasa nebyla vytvořena. Cíl se nepodařilo najít.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Vyberte cílový bod blíže k silnici.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nelze najít mezilehlý bod.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Upravte mezilehlý bod.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systémová chyba</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Trasu se nepodařilo vytvořit z důvodu chyby aplikace.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Prosím, zkuste to znovu</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nyní ne</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Chcete mapu stáhnout a vytvořit optimálnější trasu, která vede přes více než jednu mapu?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Stáhnout mapu a vytvořit optimálnější trasu, která překračuje hranice této mapy.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Stáhnout požadované soubory</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Stáhnout a aktualizovat všechny mapy a data tras pro výpočet trasy podél navrhované cesty.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Chcete-li začít hledat a vytvářet trasy, pak si prosím stáhněte mapu a nebudete již potřebovat připojení.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Vybrat mapu</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Ukázat</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Skrýt</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorie</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historie</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Omlouváme se, nic nebylo nalezeno.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Stáhněte si oblast, ve které hledáte, nebo zkuste přidat název blízkého města/obce.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historie vyhledávání</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Získejte rychlý přístup k hledaným výrazům.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Vymazat historii vyhledávání</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedie</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Článek z wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Vaše umístění</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Trasa z</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Trasa do</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigovat lze pouze z současného umístění.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Máme naplánovat trasu z vašeho současného umístění?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Další</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Od</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Do</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Přidat rozvrh</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Smazat rozvrh</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Celý den (24 hodin)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Otevřeno</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zavřeno</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Přidat dobu, kdy je zavřeno</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Otevírací doba</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Pokročilý režim</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Jednoduchý režim</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Pauza</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Vzorové hodnoty</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Opravit chybu</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Zvolte umístění</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Popište prosím detailně problém, aby vám komunita OpenStreetMap mohla pomoct opravit chybu.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Nebo to udělejte sami na https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Odeslat</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problém</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Místo neexistuje</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Zavřeno kvůli údržbě</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicitní místo</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automaticky stahovat mapy</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Denně</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Nonstop</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Dnes zavřeno</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Zavřeno</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Dnes</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Otevírá za %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Zavírá za %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zavřeno</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Upravit otevírací dobu</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nemáte účet u OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrace</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Přihlásit se</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nejste přihlášeni</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Přihlásit se do OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Heslo</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Zapomenuté heslo?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Odhlášení</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Upravit místo</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Přidat jazyk</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Ulice</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Číslo domu</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Podrobnosti</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociální média</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Budova</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Přidat ulici</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Zadejte název ulice</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Zvolit jazyk</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Zvolit ulici</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuchyně</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Vybrat kuchyni</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mail nebo uživatelské jméno</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Přidat telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Podlaží</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Podlaží: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Zároveň s touto mapou budou odstraněny také všechny změny na této mapě.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Aktualizujte mapy</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Chcete-li vytvořit trasu, pak musíte aktualizovat všechny mapy a poté trasu naplánovat znovu.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Najít mapu</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Zkontrolujte prosím své nastavení a ujistěte se, že je vaše zařízení připojeno k internetu.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nedostatek místa</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Odstraňte prosím nepotřebná data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Chyba při přihlašování.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Oveřené změny</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Přetažením mapy umístěte křížek na místo, kde se nachází místo nebo podnik.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Probíhají úpravy</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Probíhá přidávání</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Název místa</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Jak je napsáno v místním jazyce</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailní popis problému</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Jiný problém</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Přidat organizaci</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Objekt zde nemůže být umístěn</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Data OpenStreetMap vytvořená komunitou ke dni %1. Další informace o tom, jak upravovat a aktualizovat mapu, najdete na stránkách OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) je komunitní projekt, jehož cílem je vytvořit svobodnou a otevřenou mapu. Je hlavním zdrojem mapových dat v aplikaci Organic Maps a funguje podobně jako Wikipedie. Můžete přidávat nebo upravovat místa a ta se pak stanou dostupná milionům uživatelů po celém světě.
+Připojte se ke komunitě a pomozte vytvořit lepší mapu pro všechny!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Vytvořte si účet OpenStreetMap nebo se přihlaste a zveřejněte své úpravy mapy celému světu.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 z %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Stáhnout pomocí připojení přes mobilní síť?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Toto by mohlo být s některými tarify nebo roamingem výrazně dražší.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Zadejte správné číslo domu</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Počet poschodí (max. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Opravte počet poschodí, max. %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>PSČ</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Zadejte správné PSČ</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Poznámka pro dobrovolníky OpenStreetMap (nepovinné)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Popište chyby na mapě nebo věci, které nelze upravit pomocí aplikace Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vaše úpravy se nahrají do veřejné databáze &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Nepřidávejte prosím osobní informace nebo informace chráněné autorskými právy.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Další informace o projektu OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Vaše historie úprav</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vaše poznámky k mapovým datům</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Provozovatel</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operátor: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nemůžete najít vhodnou kategorii?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps umožňuje přidávat pouze jednoduché bodové kategorie, to znamená žádná města, silnice, jezera, obrysy budov atd. Tyto kategorie prosím přidávejte přímo na &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Podrobný návod krok za krokem najdete v našem &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;průvodci&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Nemáte stažené žádné mapy</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Současná poloha nezjištěna.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mil/h</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>hod</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Více</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Upravit záložku</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Vlastní poznámka (text nebo HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Poznámka…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Vymazat všechny místní změny?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Zahodit</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Odstranit přidané místo?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Odstranit</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Místo neexistuje</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Uveďte prosím důvod odstranění místa</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Zadejte platné telefonní číslo</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Zadat platnou webovou adresu</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Zadejte platný e-mail</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Zadejte platnou webovou adresu, účet nebo název stránky na Facebooku</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Zadejte platné uživatelské jméno nebo webovou adresu Instagramu</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Zadejte platné uživatelské jméno nebo webovou adresu Twitteru</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Zadejte platné uživatelské jméno nebo webovou adresu VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Zadejte platné ID nebo webovou adresu LINE</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Přidat místo do OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Nebo můžete zanechat zprávu komunitě OpenStreetMap, aby někdo jiný mohl místo přidat nebo opravit.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Poznámka bude odeslána do OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Chcete změnu odeslat všem uživatelům?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Ujistěte se, že jste nezadali žádná osobní data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Editoři OpenStreetMap zkontrolují změny a budou vás kontaktovat, pokud budou mít nějaké dotazy.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Zastavit</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Záznam trasy</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Přijmout</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Odmítnout</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Použít mobilní data k zobrazení podrobnějších informací?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Vždy použít</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Jen dnes</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Nepoužívat dnes</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilní data</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Pro zobrazení oznámení o aktualizacích map a nahrávání úprav je potřeba internet.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nikdy nepoužívat</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Vždy se zeptat</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Pro zobrazení údajů o provozu je nutné aktualizovat mapy.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Zvětšit velikost písma na mapě</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Aktualizujte Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Data o provozu nejsou k dispozici</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Povolit protokolování</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Všeobecné připomínky</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Pro hlasové pokyny používáme systémovou službu TTS. Mnoho zařízení se systémem Android používá Google TTS, můžete si jej stáhnout nebo aktualizovat na Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>U některých jazyků je třeba nainstalovat jiný hlasový syntetizátor nebo další jazykové sady z obchodu s aplikacemi (Google Play, Galaxy Store, App Gallery, FDroid).
+Otevřete nastavení vašeho zařízení → Jazyky a zadávání → Hlasové zadávání → Převod textu na řeč.&#32;
+Zde můžete spravovat nastavení pro syntézu řeči (například stáhnout jazykový balíček pro použití offline) a vybrat jiný modul převodu textu na řeč.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Více informací najdete v tomto návodu.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Přepis do latinky</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Zjistit více</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Pomocí vyhledávání, vybráním záložky nebo klepnutím na mapu přidejte výchozí bod trasy</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Pomocí vyhledávání, vybráním záložky nebo klepnutím na mapu přidejte cílový bod</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Spravovat trasu</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Naplánovat</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Odstranit zastávku</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Přidat zastávku</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Uloženo</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Přihlaste se do OpenStreetMap, abyste mohli automaticky nahrávat všechny své úpravy mapy. Více informací &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;zde&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problém s přístupem k úložišti</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Externí úložiště není k dispozici, pravděpodobně byla vyjmuta nebo poškozena SD karta, nebo je systém souborů pouze pro čtení. Zkontrolujte to prosím a kontaktujte nás na support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulovat špatné úložiště</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Zadejte prosím správný název</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Seznamy</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Skrýt vše</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Zobrazit vše</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n záložka</numerusform>
+<numerusform>%n záložky</numerusform>
+<numerusform>%n záložek</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Vytvořit nový seznam</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import záložek a stop</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nelze sdílet kvůli chybě aplikace</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Chyba sdílení</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Nelze sdílet s prázdným seznamem</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Jméno nemůže být prázdné</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Zadejte název seznamu</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nový seznam</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Toto jméno již bylo provedeno</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Zvolte jiný název</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Prosím, čekejte…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonní číslo</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Byl nalezen %n soubor. Uvidíte jej po konverzi.</numerusform>
+<numerusform>Byly nalezeny %n soubory. Uvidíte je po konverzi.</numerusform>
+<numerusform>Bylo nalezeno %n souborů. Uvidíte je po konverzi.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Obnovit</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n stopa</numerusform>
+<numerusform>%n stopy</numerusform>
+<numerusform>%n stop</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Soukromí</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Zásady ochrany osobních údajů</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Podmínky užívání</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Zácpy</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Turistika</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cyklistika</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Styly a vrstvy mapy</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Seznam je prázdný</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Pro přidání nové značky klikněte na symbol hvězdičky na obrázku objektu</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Změnit barvu všech značek</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Změnit barvu všech tras</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…ještě</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportovat KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportovat GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Smazat seznam</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radary</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Popis místa</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Nahrávání map</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Varovat při překročení rychlosti</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Vždy upozorňovat</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nikdy neupozorňovat</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Režim spořiče baterie</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Pokusit se snížit spotřebu energie na úkor některých funkcí.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nikdy</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Při vybité baterii</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Vždy</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Názvy záložek na mapě</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Pokud máte příliš mnoho záložek, může zobrazení jejich názvů na mapě zpomalit aplikaci.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Zobrazit napravo</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Zobrazit dole</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Dočasně zapněte, abyste mohli zaznamenat a ručně nám poslat podrobná diagnostická data o vašem problému pomocí tlačítka „Nahlásit chybu“ v okně nápovědy. Protokoly mohou zahrnovat informace o poloze.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Možnosti trasy</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vyhnout se mýtnému</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vyhnout se nezpevněným silnicím</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vyhnout se trajektům</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vyhnout se dálnicím</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nelze vypočítat trasu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Bohužel jsme nemohli nalézt trasu. Mohlo se tak stát kvůli vámi definovaným možnostem trasy nebo nekompletním datům OpenStreetMap. Změňte prosím nastavenímožnosti trasy a zkuste to znovu.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definovat silnice, kterým se vyhnout</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Možnosti trasy aktivní</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Silnice s mýtným</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Nezpevněná silnice</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Přejezd trajektů</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ano</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ano</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapacita: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Síť: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Přijeli jste!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Třídit…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Třídit záložky</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Podle výchozího stavu</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Podle typu</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Podle vzdálenosti</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Podle data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Podle jména</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Před týdnem</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Před měsícem</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Více než před měsícem</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Více než před rokem</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Blízko mě</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Ostatní</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Naplánování trasy se nezdařilo</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Příjezd: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Změnili jste světovou mapu. Neskrývejte to! Řekněte o tom svým kamarádům a upravujte ji společně.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Sdílejte s kamarády</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Nyní je zavřeno</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Otevírá zítra v %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Otevírá %1 v %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Otevírá v %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Zavírá v %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Přidat otevírací dobu</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Heslo (minimálně 8 znaků)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Neplatné uživatelské jméno nebo heslo.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Účet OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Poslední nahrání</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Děkujeme Vám</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Název místa</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Vezměte prosím na vědomí</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Chyba při stahování</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Vyberte kategorii</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populární</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Všechny kategorie</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Přidejte na mapu nová místa a upravte existující místa přímo z aplikace.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Změnit umístění</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Ke stažení potřebujete více volného místa. Odstraňte prosím nepotřebná data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Vylepšil jsem mapy Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Podrobný komentář</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vámi navržené změny odešleme do komunity OpenStreetMap. Popište podrobnosti, které nelze upravit v Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Při zjišťování současné polohy došlo k chybě. Zkontrolujte, že nedošlo k chybě zařízení a pokus prosím opakujte později.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Určení polohy je zakázáno</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Povolte přístup ke geolokaci v nastavení přístroje</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Otevřete Nastavení</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Klepněte na položku Poloha</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Vyberte při používání aplikace</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Vyberte možnost Soukromí</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Vyberte možnost Služby určování polohy</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Zapnutí služeb určování polohy</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Nebo pokračujte v používání aplikace Organic Maps bez polohy</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervace</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Volat</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Název záložky</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Smazat záložku</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Vaše poznámka bude odeslána do OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…dále</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aktualizovat</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Zakázat zaznamenávání vaší nedávno ujeté trasy?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Zakázat</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Odjezd</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps používají geopozici na pozadí, aby se zaznamenala vaše nedávno ujetá trasa.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Obecná nastavení</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Ke zobrazení dat o provozu je nutné aplikaci aktualizovat.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Velikost souboru protokolu: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Pro odebrání přetáhněte sem</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Nahradit zastávku</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Začít z</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Přihlaste se do OpenStreetMap, abyste mohli automaticky nahrávat všechny své úpravy mapy. Více informací</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>zde</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Skrýt obrazovku</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 z %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Stahování %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Aplikuji %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Tento název je příliš dlouhý</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Byly zjištěny nové soubory</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertovat</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Chyba</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Některé soubory nebyly převedeny.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Někde se stala chyba</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populární</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Neukazovat na mapě</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Během nahrávání tagů se stala chyba, zkuste to prosím ještě jednou</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Vpravo</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Dole</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Pojďme</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinace</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Znovu vystředit</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Prohledat výsledky</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Poté</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Chcete přestavět trasu?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Při řízení není klávesnice dostupná</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Od vaší aktuální polohy nelze vystavět trasu</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nelze vystavět trasu k vaší destinaci. Zvolte prosím další bod</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Signál GPS neexistuje. Přesuňte se prosím do otevřeného prostoru</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nelze sestavit trasu. Specifikujte prosím další body trasy</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>K vytvoření trasy si stáhněte chybějící mapy do vašeho zařízení</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Vyskytla se chyba. Restartujte prosím aplikaci</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Trasa bude přestavěna od vaší aktuální polohy</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Trasa bude upravena k autu jedna</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nezobrazují se všechny záložky</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Přepnutí do telefonu pro zobrazení všech záložek</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Rych. kam.</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Rych. varování</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Stáhněte si prosím mapy do aplikace Organic Maps ve vašem zařízení</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 výjezd</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Třídit ve výchozím nastavení</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Třídit dle typu</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Třídit dle vzdálenosti</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Třídit dle data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Řazení podle názvu</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Jídlo</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Památky</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzea</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parky</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Plavat</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Hory</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Zvířata</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotely</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Budovy</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Peníze</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Obchody</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkoviště</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Čerpací stanice</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicína</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Vyhledat v seznamu</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Posvátná místa</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Vybrat seznam</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigace metra v této oblasti zatím není k dispozici</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Trasa metra nebyla nalezena</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Zvolte prosím počáteční nebo koncový bod blíže k stanici metra</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terén</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Chcete-li aktivovat a používat topografickou vrstvu, prosím aktualizujte nebo si stáhněte mapu oblasti</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Topografická vrstva není v této oblasti ještě dostupná</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stoupání</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Klesání</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. výška</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. výška</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Obtížnost</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Vzdál.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Čas:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Přiblížit pro prozkoumání izolinií</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Probíhá stahování</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Stáhnout mapu světa</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nepodařilo se vytvořit složku a přesunout soubory v interní paměti zařízení nebo na SD kartě</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Chyba disku</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Chyba připojení</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Odpojte kabel USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Nechat obrazovku zapnutou</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Je-li povoleno, bude obrazovka při zobrazení mapy vždy zapnutá.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Zobrazit na uzamčené obrazovce</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Je-li povoleno, bude aplikace fungovat na zamykací obrazovce, i když je zařízení uzamčeno.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Jazyk mapy</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Mapová data z OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/cs/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/cs/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Děkujeme, že používáte naše komunitní mapy!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>S vašimi dary a podporou můžeme vytvořit ty nejlepší mapy na světě!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Líbí se vám naše aplikace? Přispějte prosím na podporu rozvoje! Ještě se ti to nelíbí? Dejte nám prosím vědět a my to napravíme!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Pokud znáte vývojáře softwaru, můžete ho požádat, aby implementoval funkci, kterou potřebujete.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Klepnutím na libovolné místo na mapě můžete cokoli vybrat. Dlouhým klepnutím skryjete a znovu zobrazíte rozhraní.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Víte, že si na mapě můžete vybrat svou aktuální polohu?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Můžete pomoci přeložit naši aplikaci do vašeho jazyka.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Naše aplikace je vyvinuta několika nadšenci a komunitou.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Mapová data můžete snadno opravit a vylepšit.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Naším hlavním cílem je vytvářet rychlé, na soukromí zaměřené a snadno použitelné mapy, které si zamilujete.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Na obrazovce telefonu nyní používáte aplikaci Organic Maps</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Na obrazovce auta nyní používáte aplikaci Organic Maps</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Jste připojeni ke službě Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Pokračujte v telefonu</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Na obrazovku auta</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Služba Organic Maps potřebuje přístup k poloze. Když je to bezpečné, zkontrolujte oznámení v telefonu.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Tato aplikace potřebuje vaše povolení</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps v systému Android Auto potřebují k efektivní práci povolení k poloze</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Udělení oprávnění</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Pěší turistika</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webový prohlížeč není k dispozici</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Hlasitost</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export všech záložek a stop</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Systémové nastavení syntézy řeči</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nastavení syntézy řeči nebylo nalezeno, jste si jisti, že jej vaše zařízení podporuje?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Průjezd</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Vymazat vyhledávání</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Přiblížení</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zvětšení</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Odkaz na menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Zobrazit menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Otevřít v jiné aplikaci</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Samoobsluha</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Vyberte možnost</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Venkovní posezení</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Pro co nejpřesnější navigaci doporučujeme vypnout úsporný režim v nastavení baterie telefonu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Zaznamenat trasu</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Zastavit nahrávání trasy</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Záznam trasy</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Zastavit bez uložení</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Pokračovat v nahrávání</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Uložit do záložek a stop?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Trasa je prázdná - není co ukládat</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nelze zobrazit dialogové okno pro výběr složky, protože v zařízení není nainstalována žádná vhodná aplikace. Nainstalujte si prosím aplikaci pro správu souborů a zkuste to znovu.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Vyberte barvu</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Upravit trasu</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Není nainstalována žádná aplikace, která by mohla otevřít umístění</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automaticky v navigaci</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Podle systému</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Sdílet trasu</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Smazat %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Stupeň obtížnosti</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Snadný</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mírný</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Těžký</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Probíhá aktualizace</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Aktualizujte své stažené mapy</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Aktualizace map zajišťuje aktuální informace o objektech</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Aktualizace (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Aktualizovat ručně později</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Odstranit stopu</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Opravdu chcete tuto stopu odstranit?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Název stopy</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Přesunout</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Dráha</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Změna barvy</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Chcete poslat vývojářům hlášení o chybě?
+Spoléháme na naše uživatele, protože společnost Organic Maps neshromažďuje žádné informace o chybách automaticky. Předem vám děkujeme za podporu Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Povolení synchronizace s iCloudem</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Synchronizace iCloudu je experimentální funkce, která se vyvíjí. Ujistěte se, že jste si vytvořili zálohu všech svých záložek a skladeb.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>Služba iCloud je vypnutá</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Chcete-li tuto funkci používat, povolte v nastavení zařízení službu iCloud.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Povolit</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Záloha</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Selhání synchronizace iCloudu</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Chyba: Nepodařilo se synchronizovat z důvodu chyby připojení</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Chyba: Nepodařilo se synchronizovat z důvodu překročení kvóty iCloudu</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Chyba: iCloud není k dispozici</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nedávno odstraněné seznamy</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Vymazat</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Smazat vše</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Obnovit</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Obnovit vše</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Přispět do OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Přidat místo</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Aktualizujte mapu pro příspěvek</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Musíte aktualizovat mapu %1 na nejnovější verzi, než budete moci přispět do dat OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Moje poloha</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Moje místa</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Interní soukromé úložiště</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interní sdílené úložiště</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD karta</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Externí sdílené úložiště</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wi-Fi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>PSČ</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Bod na mapě</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mil</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>stopa</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Pro zobrazení tras je nutné aktualizovat mapy.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Ukončit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Vstup</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Mapa metra není dostupná</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Vy</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Fialové stažené regiony</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Trasa</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Chcete-li si užívat plnou funkčnost aplikace, pak musíte určit aktuální polohu na pozadí. Používá se k sledování trasy a ukládání vaší nedávno uskutečněné cesty.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Stanovení současného umístění se používá v možnostech sledování trasy a uložení vaší nedávno uskutečněné cesty.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Přihlášení pomocí hesla</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Přihlášení pomocí prohlížeče</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nedávno použité</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Barva značek byla změněna</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Barva tras byla změněna</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Posuvníky</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ČERVENÁ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZELENÁ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex barva #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Mřížka</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/cy/omim.ts
+++ b/qt/translations/cy/omim.ts
@@ -1,0 +1,3943 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="cy">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Golau o wawr hyd fachlud</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Erthygl o wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n tracks</numerusform>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+<numerusform>%n tracks</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/cy/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Defnyddiwyd yn ddiweddar</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Sbectrwm</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sleidwyr</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>COCH</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GWYRDD</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>GLAS</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Lliw Heics sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/da/omim.ts
+++ b/qt/translations/da/omim.ts
@@ -1,0 +1,3935 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="da">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Tilbage</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Slet</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Hent kort</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Hentning af kort mislykkedes. Tryk for at prøve igen.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Henter…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mil</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Senere</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Søg</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Søg på kort</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Du har deaktiveret alle placeringstjenester for denne enhed eller applikation. Slå dem venligst til i Indstillinger.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Begrænset nøjagtighed</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>For at sikre nøjagtig navigation skal du aktivere præcis placering i indstillinger.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Vis på kortet</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Hentning mislykket</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Prøv igen</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Om Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis for alle, lavet med kærlighed</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Ingen annoncer, ingen sporing, ingen dataindsamling</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Intet batteridræn, fungerer offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Hurtig, minimalistisk, udviklet i fællesskab</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open source-applikation skabt af entusiaster og frivillige.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Indstillinger for placering</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Luk</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Appen kræver hardwareaccelereret OpenGL. Din enhed er desværre ikke understøttet.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Hent</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Frakobl venligst USB-kabel, eller indsæt et hukommelseskort for at bruge Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Frigør først noget plads på dit SD-kort/USB lager for at bruge denne app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Før du begynder at bruge appen, skal du hente oversigtskortet over verden til din enhed.
+Det vil bruge %1 lagerplads.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Gå til kortet</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Henter %1. Du kan nu
+fortsætte til kortet.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Hent %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Opdater %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Fortsæt</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 hentning mislykkedes</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Tilføj en ny liste</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Indstil navn for bogmærkeliste</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bogmærker</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bogmærker og spor</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Navn</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresse</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Indstillinger</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Gem kort på</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Vælg den mappe, der skal downloades kort til.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloadede kort</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 fri af %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Flyt kort?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Fejl ved flytning af kortfiler</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Dette kan tage flere minutter.
+Vent venligst…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Måleenheder</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Vælg mellem mil eller kilometer</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Annuller download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Lav en bedømmelse</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download kort</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bogmærkelister</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Spisesteder</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Dagligvarer</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzin</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkering</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Indkøb</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Genbrugsbutikker</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Seværdigheder</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Underholdning</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Hæveautomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Natteliv</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Familieferie</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Politi</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recirkulering</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vand</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Til RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Noter</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bogmærker er blevet delt med dig</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hej!
+
+Vedhæftet er mine bogmærker; åbn dem venligst i Organic Maps. Hvis du ikke har den installeret, kan du downloade den her: https://omaps.app/get?kmz
+&#32;
+God rejse med Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Indlæser bogmærker</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bogmærker er indlæst! Du kan finde dem på kortet eller på skærmen for bogmærkehåndtering.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Bogmærkerne kunne ikke indlæses. Filen kan være skadet eller defekt.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Filtypen genkendes ikke af appen:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Kunne ikke åbne filen %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Rediger</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Din placering er ikke blevet bestemt endnu</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Beklager, indstillingerne for kortlagring er i øjeblikket deaktiveret.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Download af kort er i gang nu.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hey, tjek min nuværende placering på Organic Maps! %1 eller %2. Har du ikke offline kort? Download her: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, tjek min knappenål på Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, tjek min nuværende placering på Organic Maps-kortet!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hej,
+
+Jeg er her nu: %1. Tryk på dette link %2 eller dette %3 for at se stedet på kortet.&#32;
+
+Tak.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Del</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopieret til udklipsholderen: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Færdig</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Er du sikker på, at du vil logge ud af din OpenStreetMap-konto?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Spor</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Længde</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Del min placering</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Generelle indstillinger</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Knapperne + og - på kortet</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Vis på skærmen</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nat-stil, når du navigerer i mørke</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nattilstand</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Fra</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Til</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivvisning</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-bygninger</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-bygninger er deaktiveret i strømbesparende tilstand</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Stemmeinstruktioner</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Annoncer gadenavne</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Når det er aktiveret, bliver navnet på den gade eller frakørsel, man skal dreje ind på, sagt højt.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Stemmesprog</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>For at hente en stemme i højere kvalitet skal du åbne appen Indstillinger og gå til Tilgængelighed → VoiceOver → Tale → Stemme.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test stemmeanvisninger (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Tjek lydstyrken eller systemets tekst-til-tale-indstillinger, hvis du ikke kan høre stemmen nu.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ikke til rådighed</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto-zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Afstand</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Vis på kort</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Hjemmeside</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nyheder</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Bedøm appen</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hjælp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Spørgsmål og svar</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doner</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Allerede doneret</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Påmind mig senere</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Støt Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Støt projektet</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Ophavsret</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Rapportér fejl</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Forbedre pilens retning ved at bevæge telefonen i en ottetalsbevægelse for at kalibrere kompasset.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Bevæg telefonen i en ottetalsbevægelse for at kalibrere kompasset og rette pilens retning på kortet.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Tryk længe på kortet igen for at se grænsefladen</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Opdatér alle</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Annuller alt</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloadet</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>I kø</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>I nærheden</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kort</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download alle</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloader:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>For at slette kortet skal du stoppe navigeringen.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Der kan kun oprettes ruter, der er fuldt ud indeholdt i et kort over en enkelt region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download kortet</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Prøv igen</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Slet kort</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Opdater kort</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Placeringstjenester</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Find hurtigt din omtrentlige position via Bluetooth, WiFi eller mobilnetværk</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download alle kort langs din rute</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>For at kunne oprette en rute skal vi downloade og opdatere alle kort fra din placering til din destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ikke nok plads</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Aktiver venligst placeringstjenester</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Gem</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>opret</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rød</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Gul</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blå</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Grøn</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Lilla</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brun</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Lyserød</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Mørkelilla</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Lyseblå</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Blågrøn</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Kalk</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Dyb orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grå</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blågrå</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Udseende</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Lys</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Mørk</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Lys fra daggry til skumring</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Andet</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Giv gratis kort uden reklamer til millioner af brugere!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Rapporter eller ret forkerte kortdata</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>At melde sig som frivillig</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Følg og kontakt os:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Emailklienten er ikke blevet sat op. Venligst konfigurér den eller brug en anden måde til at kontakte os på %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Mailforsendelsesfejl</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrering af kompas</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Tilgængelige</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Fundet</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Opdater</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Mislykkedes</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bogmærke</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Når du følger ruten, skal du være opmærksom på følgende:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Vejforhold, færdselsregler og skiltning skal altid prioriteres højere end navigationsanvisninger;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Kortet kan være unøjagtigt, og den foreslåede rute er ikke nødvendigvis altid den bedste måde at nå destinationen på;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— De foreslåede ruter skal kun betragtes som anbefalinger;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Vær forsigtig med ruter i grænseområder: de ruter, vores app har skabt, kan nogle gange krydse landegrænser på uautoriserede steder.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Vær altid opmærksom og årvågen på vejene!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Tjek GPS-signalet</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Det lykkedes ikke at oprette rute. GPS-koordinaterne kunne ikke identificeres korrekt.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Tjek dit GPS-signal. Din placering registreres mere præcist, hvis wi-fi er slået til.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktiver placeringstjenester</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Det lykkedes ikke at finde de aktuelle GPS-koordinater. Slå placeringstjenester til for at beregne rute.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Kan ikke finde rute</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Kan ikke oprette rute.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Prøv at angive et andet startpunkt eller en anden destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Vælg et andet startpunkt</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Rute blev ikke oprettet. Kunne ikke finde startpunktet.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Angiv et startpunkt, der ligger tættere på en vej.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Vælg en anden destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Rute blev ikke oprettet. Kunne ikke finde destinationen.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Angiv en destination, der ligger tættere på en vej.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Kunne ikke lokalisere mellemliggende punkt.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Rediger det mellemliggende punkt.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systemfejl</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Kan ikke oprette rute på grund af en applikationsfejl.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Prøv venligst igen</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ikke nu</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Ønsker du at downloade kortet og planlægge en mere optimal rute, der strækker sig over mere end ét kort?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download yderligere kort for at planlægge en mere optimal rute, der strækker sig ud over dette korts grænser.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download de nødvendige filer</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download og opdatér alle kort og ruteoplysninger for at beregne en rute.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>For at komme i gang med at søge og oprette ruter skal du downloade kortet. Derefter har du ikke længere brug for en internetforbindelse.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Vælg kort</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Vis</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Skjul</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorier</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historik</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ups, ingen resultater fundet.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download den region, hvor du søger i, eller prøv at tilføje et nærliggende bynavn.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Søgehistorik</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Se dine seneste søgninger.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Ryd søgehistorik</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel fra wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Din placering</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Rute fra</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rute til</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation er kun tilgængelig fra din nuværende placering.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Ønsker du at planlægge en rute fra din nuværende placering?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Næste</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Fra</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Til</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Tilføj tidsplan</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Slet tidsplan</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Alle dage (24 timer)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Åbent</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Lukket</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Tilføj Lukket-timer</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Åbningstider</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Avanceret tilstand</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Enkel tilstand</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Lukket-timer</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Eksempelværdier</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Ret fejl</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Vælg placering</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Beskriv problemet i detaljer, så OpenStreetMap-fællesskabet kan løse fejlen.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Eller gør det selv på https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Stedet findes ikke</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Lukket for vedligeholdelse</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplikeret sted</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Download kort automatisk</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daglig</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Døgnet rundt</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Lukket i dag</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Lukket</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>I dag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Åbner om %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Lukker om %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Lukket</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Rediger åbningstid</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Har du ikke OpenStreetMap-konto?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Tilmeld dig OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Log ind</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Ikke logget ind</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Log ind på OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Adgangskode</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Glemt adgangskode?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log ud</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Redigér stedet</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Tilføj et sprog</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Gade</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Husnummer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detaljer</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociale medier</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bygning</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Tilføj en gade</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Indtast et gadenavn</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Vælg et sprog</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Vælg en gade</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Køkken</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Vælg køkken</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mail eller brugernavn</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Tilføj telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Etage</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Etage: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alle dine kortændringer vil blive slettet sammen med kortet.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Opdatér kort</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>For at oprette en rute skal du opdatere alle kort og så planlægge ruten igen.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find kort</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Tjek dine indstillinger og sørg for, din enhed er forbundet til internettet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ikke nok plads</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Slet unødvendig data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login-fejl.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Bekræftede ændringer</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Træk i kortet for at placere korset på stedet eller virksomheden.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Redigerer</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Tilføjer</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Stedets navn</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Som det står skrevet på det lokale sprog</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategori</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detaljeret beskrivelse af problemet</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Et andet problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Tilføj virksomhed</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Et objekt kan ikke placeres her</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Fællesskabsskabte OpenStreetMap-data fra %1. Få mere at vide om, hvordan du redigerer og opdaterer kortet på OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) er et fællesskabsprojekt til opbygning af et gratis og åbent kort. Det er hovedkilden til kortdata i Organic Maps og fungerer på samme måde som Wikipedia. Du kan tilføje eller redigere steder, og de bliver tilgængelige for millioner af brugere over hele verden.
+Slut dig til fællesskabet og vær med til at skabe et bedre kort for alle!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Opret en OpenStreetMap-konto eller log ind for at offentliggøre dine kortredigeringer til hele verden.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 af %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download ved brug af mobilnetværksforbindelse?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Dette kan være meget dyrt med nogle abonnementer eller ved roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Indtast et gyldigt bygningsnummer</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Antal etager (maks %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Antallet af etager må ikke overstige %1 etager</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postnummer</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Indtast et gyldigt postnummer</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note til OpenStreetMap-frivillige (valgfrit)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beskriv fejl på kortet eller ting, der ikke kan redigeres med Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Dine ændringer uploades til den offentlige &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Da:Om_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-database. Tilføj venligst ikke personlige eller ophavsretligt beskyttede oplysninger.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mere om OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Din redigeringshistorik</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Dine noter til kortdata</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatør</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatør: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Kan du ikke finde en passende kategori?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps giver kun mulighed for at tilføje simple punktkategorier, dvs. ingen byer, veje, søer, bygningsomrids osv. Tilføj sådanne kategorier direkte til &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Se vores &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detaljerede trin for trin-instruktioner.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Du har ikke downloadet nogen kort</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download kort for at søge og navigere offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Aktuel placering er ukendt.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/t</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>time</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mere</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Rediger bogmærke</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personlige notater (tekst eller html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Kassér alle lokale ændringer?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Kassér</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Slet tilføjet sted?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Slet</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Stedet eksisterer ikke</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Angiv begrundelsen for at slette stedet</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Indtast et gyldigt telefonnummer</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Indtast en gyldig webadresse</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Indtast en gyldig e-mailadresse</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Indtast en gyldig Facebook-webadresse, -konto eller -sidenavn</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Indtast et gyldigt Instagram-brugernavn eller en webadresse</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Indtast et gyldigt Twitter-brugernavn eller en webadresse</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Indtast et gyldigt VK-brugernavn eller en webadresse</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Indtast et gyldigt LINE ID eller en webadresse</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Tilføj sted til OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Du kan også efterlade en note til OpenStreetMap-fællesskabet, så en anden kan tilføje eller rette et sted her.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note vil blive send til OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Ønsker du at sende det til alle brugere?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Sørg for at du ikke indtastede personlige oplysninger.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-redaktører vil tjekke ændringerne og kontakte dig, hvis de har spørgsmål.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Optager sporet</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accepter</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Afvis</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Brug mobilt internet til at vise detaljeret information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Brug altid</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Kun i dag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Brug ikke i dag</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilt internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobilt internet er nødvendigt for at få besked om kortopdateringer og uploade ændringer.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Brug aldrig</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Spørg altid</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Kort skal opdateres for at vise trafikdata.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Forøg størrelsen på kortetiketter</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Opdater Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Trafikdata er ikke tilgængelige</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Aktiver logføring</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Generel feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Vi bruger systemets TTS til stemmevejledning. Mange Android-enheder bruger Google TTS, du kan hente eller opdatere det via Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For nogle sprog skal du installere en anden talesyntese eller en yderligere sprogpakke fra appbutiken (Google Play, Galaxy Store, App Gallery, FDroid).&#32;
+
+Åbn din enheds indstillinger → Sprog og input → Tale → Tekst til tale.
+Her kan du administrere indstillingerne for talesyntese (f.eks. downloade en sprogpakke til brug offline) og vælge et andet tekst-til-tale program.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Se denne vejledning for flere oplysninger.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translitterer til det latinske alfabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Flere oplysninger</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Brug søgning, vælg et bogmærke eller tryk på kortet for at tilføje et startpunkt for en rute</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Brug søgning, vælge et bogmærke eller tryk på kortet for at tilføje et destinationspunkt</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Administrer rute</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planlæg</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Fjern stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Tilføj stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Gemt</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Log ind på OpenStreetMap for automatisk at uploade alle dine kortredigeringer. Få mere at vide &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;her&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problem med lageradgang</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Eksternt lager er ikke tilgængeligt. SD-kortet kan være blevet fjernet eller beskadiget, eller filsystemet er skrivebeskyttet. Kontroller dit SD-kort eller kontakt os på support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulér beskadiget lager</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Angiv et korrekt navn</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lister</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Skjul alle</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Vis alle</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bogmærke</numerusform>
+<numerusform>%n bogmærker</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Opret ny liste</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importer bogmærker og spor</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Ikke i stand til at dele på grund af en applikationsfejl</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Delingsfejl</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Kan ikke dele en tom liste</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Navnet kan ikke være tomt</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Indtast venligst listenavnet</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Ny liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Dette navn er allerede taget</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Vælg venligst et andet navn</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Vent venligst…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonnummer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fil blev fundet. Du vil se det efter konvertering.</numerusform>
+<numerusform>%n filer blev fundet. Du vil se dem efter konvertering.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Gendan</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n spor</numerusform>
+<numerusform>%n spor</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatliv</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privatlivspolitik</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Vilkår for bruger</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafik</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Vandring</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cykling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Undergrundsbane</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kortstile og -lag</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Listen er tom</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>For at tilføje et bogmærke, så tryk et sted på kort og så på stjerneikonet</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Skift farve på alle bogmærker</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Skift farve på alle spor</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mere</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Eksporter KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Eksporter GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Eksporter GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Slet liste</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Fartkameraer</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Beskrivelse af sted</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kort-downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Advar om for høj hastighed</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Advar altid</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Advar aldrig</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Strømsparetilstand</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Prøv at reducere strømforbruget på bekostning af nogle funktioner.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Aldrig</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Når batteriniveauet er lavt</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Altid</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bogmærk navne på kortet</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Hvis der er for mange bogmærker, kan visning af deres navne på kortet gøre appen langsommere.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Vis til højre</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Vis i bunden</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aktivér denne mulighed midlertidigt for at registrere og manuelt sende detaljerede diagnostiske logfiler om dit problem til os ved hjælp af &quot;Rapportér en fejl&quot; i Hjælp-dialogen. Logfiler kan indeholde placeringsoplysninger.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Indstillinger for ruteberegning</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Undgå betalingsveje</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Undgå ikke-asfalterede veje</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Undgå færger</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Undgå motorveje</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Kan ikke beregne rute</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Der kunne ikke findes en rute. Dette kan skyldes dine ruteindstillinger eller ufuldstændige OpenStreetMap-data. Ændr dine ruteindstillinger, og prøv igen.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definer veje du vil undgå</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Indstillinger for ruteberegning aktiveret</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Betalingsvej</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Ikke-asfalteret vej</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Færgeoverfart</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapacitet: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netværk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Du er ankommet!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sorter…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sorter bogmærker</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Som standard</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Efter type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Efter afstand</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Efter dato</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Efter navn</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>En uge siden</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>En måned siden</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Mere end en måned siden</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Mere end et år siden</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>I nærheden</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Andre</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Ruteplanlægning mislykkedes</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ankomst: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>For at oprette en rute skal du hente og opdatere alle kort langs ruten.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Du har ændret verdenskortet. Lad andre det vide! Fortæl dine venner og redigér det sammen.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Del med venner</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Lukket nu</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Åbner i morgen kl. %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Åbner %1 kl. %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Åbner kl. %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Lukker kl. %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Tilføj arbejdstid</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Adgangskode (mindst 8 tegn)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Ugyldigt brugernavn eller adgangskode.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-konto</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Sidste overførsel</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Mange tak</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Navn på sted</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Bemærk venligst</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Fejl ved download</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Vælg kategori</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populær</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Alle kategorier</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Tilføj nye steder til kortet og redigér eksisterende direkte fra app&#x27;en.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Skift lokation</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>For at opdatere app&#x27;en skal du bruge mere plads. Slet unødvendig data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Jeg forbedrede Organic Maps kortene</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detaljerede bemærkninger</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Dine foreslåede ændringer vil blive sendt til OpenStreetMap fællesskabet. Beskrive detaljer, som ikke kan redigeres i Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Der opstod en fejl under søgning efter din position. Kontrollér at din enhed fungerer korrekt, og prøv igen senere.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Placeringsservices er slået fra</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Slå adgang til geoposition til i enhedens indstillinger</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Åbn Indstillinger</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tryk på Placering</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Vælg Mens app&#x27;en bruges</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Vælg Privatliv</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Vælg Placeringstjenester</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Slå placeringstjenester til</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Eller fortsæt med at bruge Organic Maps uden placering</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Bog</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Ring</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bogmærke</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Slet bogmærke</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Din note vil blive sendt til OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mere</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Opdater</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Deaktiver optagelse af din nyligt tilbagelagte rute?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Deaktiver</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Tjek</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps anvender din placering i baggrunden til at gemme din nyligt tilbagelagte rute.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Generelle indstillinger</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Appen skal opdateres for at kunne vise trafikdata.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Logfilens størrelse: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Træk herhen for at fjerne</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Erstat stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start fra</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Log ind på OpenStreetMap for automatisk at uploade alle dine kortredigeringer. Få mere at vide</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>her</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Skjul skærm</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 af %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloader %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Anvender %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Dette navn er for langt</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nye filer registreret</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertere</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Fejl</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Nogle filer blev ikke konverteret.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Der er opstået en fejl</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populær</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Skjul på kort</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Der skete en fejl under hentning af tags, prøv igen</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Højre</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bund</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Lad os komme i gang</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrer igen</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Søgeresultater</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Derefter</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vil du genopbygge ruten igen?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard er ikke tilgængelig under kørsel</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Det er ikke muligt at beregne rute fra din nuværende placering</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Det er ikke muligt at beregne rute til din destination. Vælg en anden destination</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Intet GPS signal. Flyt til et område med dækning</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Kan ikke oprette en rute. Angiv andre rutepunkter</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>For at oprette en rute skal du downloade manglende kort på din enhed</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Der opstod en fejl. Genstart programmet</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Ruten vil blive beregnet igen, ud fra din nuværende placering</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Ruten vil blive ændret til en bilrute</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ikke alle bogmærker vises</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Skift til telefonen for at se alle bogmærker</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radarkontrol</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Radar advarsel</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Download kort i Organic Maps appen, på din enhed</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 afkørsel</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortér (std)</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort (type)</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort (Afs)</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort (dato)</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sorter efter navn</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Mad</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Seværdigheder</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museer</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parker</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Svøm</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Bjerge</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Dyr</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteller</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Bygninger</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Penge</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Butikker</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkering</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzintankstationer</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicin</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Søg i listen</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religiøse steder</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Væg liste</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro-navigation er endnu ikke tilgængelig i denne region</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Ingen undergrundsrute fundet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Vælg venligst et start- eller stoppunkt tættere på en metrostation</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Konturlinjer</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Aktivering af konturlinjer kræver download af kortdata for dette område</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Konturlinjer er endnu ikke tilgængelige i dette område</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stigning</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Nedstigning</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. højde</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. højde</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Sværhedsgrad</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Afs.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tid:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom ind for at udforske isolinjer</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloader</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download oversigtskortet over verden</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Kan ikke oprette mapper og flytte filer på enhedens interne hukommelse eller sd-kort</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Diskfejl</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Forbindelsesfejl</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Frakobl USB-kabel</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Hold skærmen tændt</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Når den er aktiveret, vil skærmen altid være tændt, når kortet vises.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Vis på låseskærmen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Når den er aktiveret, fungerer appen på låseskærmen, selv når enheden er låst.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Sprog på kort</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kortdata fra OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Da:Om_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Tak, fordi du bruger vores fællesskabsskabte kort!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Med dine donationer og støtte kan vi skabe de bedste kort i verden!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Kan du lide vores app? Donér venligst for at støtte udviklingen! Kan du ikke lide det endnu? Fortæl os det, så ordner vi det!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Hvis du kender en softwareudvikler, kan du bede ham eller hende om at implementere en funktion, som du har brug for.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tryk hvor som helst på kortet for at vælge noget. Tryk længe for at skjule og vise grænsefladen igen.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Ved du, at du kan vælge din nuværende placering på kortet?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Du kan hjælpe med at oversætte vores app til dit sprog.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Vores app er udviklet af nogle få entusiaster og fællesskabet.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Du kan nemt rette og forbedre kortdataene.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Vores hovedmål er at bygge hurtige, privatlivsfokuserede, brugervenlige kort, som du vil elske.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Du bruger nu Organic Maps på telefonens skærm</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Du bruger nu Organic Maps på bilens skærm</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Du er forbundet til Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Fortsæt på telefonen</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Til bilens skærm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps har brug for placeringsadgang. Når det er sikkert, kan du tjekke notifikationen på din telefon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Denne app har brug for din tilladelse</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps i Android Auto har brug for placeringstilladelse for at fungere effektivt</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Giv tilladelser</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Friluft</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webbrowser er ikke tilgængelig</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Lydstyrke</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksporter alle bogmærker og spor</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Indstillinger for talesyntese-system</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Indstillingerne for talesyntese blev ikke fundet, er du sikker på, at din enhed understøtter det?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Gennemkørsel</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Ryd søgningen</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom ind</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom ud</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link til menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Vis menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Åbn i en anden app</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Selvbetjening</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Vælg mulighed</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Udendørs siddepladser</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For at få den mest nøjagtige navigation anbefaler vi at deaktivere strømbesparende tilstand i telefonens batteriindstillinger.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Optag spor</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop optagelse af spor</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Optagelse af rute</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop uden at gemme</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Fortsæt optagelse</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Gem i bogmærker og spor?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Sporet er tomt - der er ikke noget at gemme</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kan ikke vise dialogboksen til valg af mappe, fordi der ikke er installeret en passende app på din enhed. Installer venligst en filhåndteringsapp, og prøv igen.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Vælg farve</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Rediger spor</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ingen app installeret, der kan åbne stedet</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto ved navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Følg systemet</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Del spor</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Slet %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Sværhedsgrad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Let</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Middel</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Svær</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Opdaterer</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Opdater dine downloadede kort</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Opdatering af kort sikrer, at oplysningerne om objekter er aktuel</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Opdater (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Opdater manuelt senere</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Slet spor</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Er du sikker på, at du vil slette dette spor?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Spornavn</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Flyt</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Spor</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Skift farve</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kort</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Vil du gerne sende en fejlrapport til udviklerne?
+Vi er afhængige af vores brugere, da Organic Maps ikke indsamler nogen fejloplysninger automatisk. Tak på forhånd for at støtte Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktivér iCloud-synkronisering</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-synkronisering er en eksperimentel funktion under udvikling. Sørg for, at du har lavet en backup af alle dine bogmærker og spor.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud er deaktiveret</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aktivér iCloud i din enheds indstillinger for at bruge denne funktion.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktivér</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sikkerhedskopiering</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Fejl i iCloud-synkronisering</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Fejl: Kunne ikke synkronisere på grund af forbindelsesfejl</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Fejl: Kunne ikke synkronisere på grund af overskredet iCloud-kvote</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Fejl: iCloud er ikke tilgængelig</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nyligt slettede lister</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Ryd</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Slet alle</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Gendan</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Gendan alle</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Bidrag til OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Tilføj sted</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Opdater kortet for at bidrage</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Du skal opdatere %1-kortet til den nyeste version, før du kan bidrage til OpenStreetMap-dataene</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Min position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mine steder</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Intern privat lagerplads</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Intern delt lagerplads</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kort</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ekstern delt lagerplads</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postnummer</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kortpunkt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mil</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>fod</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>For at vise ruter, skal kortene være opdateret.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Udgang</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Indgang</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Kort over undergrundsbaner er ikke tilgængeligt</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Du</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Lilla downloadede regioner</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rute</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Det er nødvendigt at fastslå den gældende placering i baggrunden for at udnytte appens funktionalitet fuldt ud. Dette anvendes når en rute skal følges, og når din sidste rejserute skal gemmes.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Definition af aktuel placering bruges i indstillingerne for at følge ruten og lagring af din seneste rejserute.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login med adgangskode</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login ved hjælp af browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nyligt brugt</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bogmærkefarve er ændret</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Sporfarve er ændret</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Skydere</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RØD</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GRØN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLÅ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB hex-farve #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Gitter</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/de/omim.ts
+++ b/qt/translations/de/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="de">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Zurück</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Löschen</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Karten herunterladen</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Herunterladen fehlgeschlagen. Antippen für einen neuen Versuch.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Wird heruntergeladen…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Meilen</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Später</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Suche</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Auf der Karte suchen</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Standortdienste sind für dieses Gerät oder App deaktiviert. Bitte aktiviere sie in den Einstellungen.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Begrenzte Genauigkeit</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Um eine genaue Navigation zu gewährleisten, aktiviere in den Einstellungen die Option Genauen Standort verwenden.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Auf der Karte anzeigen</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Herunterladen fehlgeschlagen</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Erneut versuchen</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Über Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Kostenlos für alle, mit Liebe gemacht</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Keine Werbung, kein Tracking, keine Datenerfassung</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Minimaler Batterieverbrauch, funktioniert offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Schnell, minimalistisch, von der Community entwickelt</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-Source-Anwendung, entwickelt von Enthusiasten und Freiwilligen.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Standorteinstellungen</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Schließen</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Das Programm benötigt OpenGL, um zu funktionieren. Leider wird dein Gerät nicht unterstützt.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Herunterladen</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Bitte USB-Kabel entfernen oder Speicherkarte einsetzen, um Organic Maps zu verwenden</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Bitte zuerst Speicherplatz auf SD-Karte/USB-Speicher freigeben, um die App zu nutzen</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Bevor du die App verwendest, lade bitte die weltweite Übersichtskarte herunter.
+Es werden %1 Speicherplatz benötigt.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Zur Karte</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 wird heruntergeladen. Du kannst jetzt
+zur Karte weitergehen.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 herunterladen?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 aktualisieren?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Fortfahren</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 Download fehlgeschlagen</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Neue Liste hinzufügen</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Name der Lesezeichenliste</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Lesezeichen</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Lesezeichen und Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresse</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Einstellungen</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Karten speichern auf</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Speicherort für heruntergelandene Karten wählen.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Heruntergeladene Karten</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 frei von %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Karten verschieben?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Fehler beim Verschieben der Karten</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Dies kann einige Minuten in Anspruch nehmen.
+Bitte warten…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Maßeinheiten</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Wähle zwischen Kilometern und Meilen</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Herunterladen abbrechen</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Bewertung abgeben</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Karte herunterladen</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Lesezeichenliste</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Essmöglichkeiten</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Lebensmittel</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Verkehr</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Tankstelle</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkplatz</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Einkaufen</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second-hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sehenswürdigkeit</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Unterhaltung</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Geldautomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nachtleben</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Freizeit mit Kindern</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotheke</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Krankenhaus</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilette</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polizeistation</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Wasser</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Einrichtungen für Wohnmobile</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notizen</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps Lesezeichen wurden mit dir geteilt</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hallo!
+
+Im Anhang sind meine Lesezeichen der Organic Maps App. Du kannst sie mit Organic Maps öffnen. Wenn du die App nicht installiert hast, kannst du sie von https://omaps.app/get?kmz herunterladen.
+
+Viel Spaß beim Reisen mit Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Lesezeichen werden geladen</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Lesezeichen erfolgreich geladen! Du kannst diese nun auf deiner Karte oder im Lesezeichen-Manager anzeigen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Laden der Lesezeichen fehlgeschlagen. Die Datei könnte beschädigt oder defekt sein.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Der Dateityp wird von der App nicht erkannt:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Datei konnte nicht geöffnet werden %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Bearbeiten</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Dein Standort konnte noch nicht ermittelt werden</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Leider sind die Einstellungen für die Kartenspeicherung deaktiviert.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Die Karte wird heruntergeladen.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hey, sieh dir meinen aktuellen Standort auf Organic Maps an! %1 oder %2 Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, sieh dir meine Stecknadel auf der Organic Maps-Karte an!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, sieh dir meinen aktuellen Standort auf der Organic Maps-Karte an!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+ich bin gerade hier: %1. Klicke den Link %2 oder %3, um den Ort auf der Karte anzuzeigen.
+
+Vielen Dank.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Teilen</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-Mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>In die Zwischenablage kopiert: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Fertig</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-Daten: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Bist du sicher, dass du dich von deinem OpenStreetMap-Konto abmelden möchtest?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Länge</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Meinen Standort teilen</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Allgemeine Einstellungen</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>„+“ und „-“ Knöpfe auf der Karte</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Auf der Karte anzeigen</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nacht-Stil beim Navigieren im Dunkeln</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nachtmodus</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Aus</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>An</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivische Ansicht</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-Gebäude</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-Gebäude werden im Energiesparmodus ausgeschaltet</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Sprachanweisungen</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Straßennamen ankündigen</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Wenn aktiviert, wird der Name der Straße oder Ausfahrt, in die abgebogen werden soll, laut angekündigt.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Sprache für Sprachanweisungen</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Um eine Stimme mit höherer Qualität zu laden, öffne die App Einstellungen und gehe zu Bedienungshilfen → VoiceOver → Sprachausgabe → Stimme.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Sprachanweisungen testen (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Überprüfe die Lautstärke oder die Text-To-Speech-Einstellungen des Systems, wenn du die Stimme jetzt nicht hörst.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nicht verfügbar</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto-Zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Entfernung</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Auf der Karte ansehen</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menü</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webseite</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Neuigkeiten</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Rückmeldung</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Bewerte die App</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hilfe</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Häufige Fragen und Antworten</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Spenden</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Bereits gespendet</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Später erinnern</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Unterstütze Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Unterstütze das Projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Urheberrecht</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>App-Fehler melden</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Bewege das Telefon in Form einer Acht, um den Kompass zu kalibrieren und die Pfeilrichtung zu verbessern.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Bewege das Telefon in Form einer Acht, um den Kompass zu kalibrieren und die Pfeilrichtung auf der Karte zu fixieren.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Tippe erneut lange auf die Karte, um das Interface zu sehen</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Alle aktualisieren</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Alle abbrechen</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Heruntergeladen</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>In der Warteschlange</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>In meiner Nähe</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Karten</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Alle herunterladen</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Wird heruntergeladen:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Zum Löschen der Karte bitte die Navigation unterbrechen.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Es können nur Routen erstellt werden, die vollständig in einer einzigen Karte enthalten sind.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Karte herunterladen</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Wiederholen</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Karte löschen</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Karte aktualisieren</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Standortdienste</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Ermittel schnell deinen ungefähren Standort über Bluetooth, WLAN oder das Mobilfunknetz</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Karten entlang der Route herunterladen</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Zum Erstellen einer Route müssen alle Karten von deinem Standort bis zum Ziel heruntergeladen und aktualisiert worden sein.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nicht genügend Speicherplatz</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Bitte aktiviere die Standortdienste</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Speichern</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>erstellen</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rot</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Gelb</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blau</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Grün</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violett</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Braun</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Dunkelpurpur</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Hellblau</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Blaugrün</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smaragdgrün</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limette</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Dunkelorange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grau</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Graublau</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Infos</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps Version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Erscheinungsbild</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Hell</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dunkel</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Hell von der Morgendämmerung bis zur Abenddämmerung</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Weitere</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Schenke Millionen von Nutzern kostenlose und werbefreie Karten!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Falsche Kartendaten melden oder korrigieren</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Freiwillig helfen</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Folge und kontaktiere uns:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Der E-Mail-Client ist noch nicht eingerichtet worden. Konfiguriere ihn bitte oder kontaktiere uns unter %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Fehler beim E-Mail-Versand</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompass-Kalibrierung</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Verfügbar</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Gefunden</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aktualisieren</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fehlgeschlagen</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>Lesezeichen</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Wenn du der Route folgst, beachte bitte:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Zustand der Straßen, die Verkehrsordnung und Straßenschilder haben stets Vorrang vor Navigationsanweisungen;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Die Karte kann ungenau sein, und die vorgeschlagene Route ist möglicherweise nicht der optimale Weg, um das Ziel zu erreichen;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Die vorgeschlagenen Routen sind als Empfehlungen zu verstehen;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Bitte sei vorsichtig bei Routen in Grenzgebieten: die Routen, die unsere App erstellt, können manchmal Landesgrenzen in gesperrten Gebieten überschreiten.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Bitte fahre aufmerksam und sicher!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS-Signal prüfen</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Route kann nicht erstellt werden. Aktuelle GPS-Koordinaten konnten nicht ermittelt werden.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Bitte prüfe dein GPS-Signal. Das Aktivieren von WLAN verbessert die Genauigkeit deiner Standortbestimmung.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Standortdienste aktivieren</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Aktuelle GPS-Koordinaten können nicht ermittelt werden. Aktiviere Standortdienste, um die Route zu berechnen.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Route kann nicht ermittelt werden</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Route kann nicht erstellt werden.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Bitte passe deinen Startpunkt oder dein Ziel an.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Startpunkt anpassen</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route wurde nicht erstellt. Startpunkt kann nicht gefunden werden.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Bitte wähle einen Startpunkt, der näher an einer Straße liegt.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ziel anpassen</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route wurde nicht erstellt. Ziel kann nicht gefunden werden.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Bitte wähle einen Zielort, der näher an einer Straße liegt.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Zwischenstopp kann nicht gefunden werden.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Bitte passe deinen Zwischenstopp an.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systemfehler</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Route kann wegen eines Anwendungsfehlers nicht erstellt werden.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Bitte versuche es erneut</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nicht jetzt</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Möchtest du die Karte herunterladen und eine bessere Route erstellen, die mehr als eine Karte umfasst?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Lade zusätzliche Karten herunter, um eine bessere Route zu erstellen, die die Grenzen dieser Karte überschreitet.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Erforderliche Dateien herunterladen</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Lade alle Karten entlang der geplanten Route herunter oder aktualisiere sie, um eine Route zu berechnen.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Um mit der Suche und dem Erstellen von Routen zu beginnen, lade bitte die Karte herunter. Du benötigst danach keine Internetverbindung mehr.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Karte auswählen</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Anzeigen</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ausblenden</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorien</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Verlauf</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Leider wurde nichts gefunden.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Lade die Region herunter, in der du suchst, oder füge den Namen einer nahe gelegenen Stadt oder eines Dorfes hinzu.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Suchverlauf</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Hier werden deine letzten Suchanfragen angezeigt.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Suchverlauf löschen</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel von wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Dein Standort</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Von</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Nach</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Die Navigation ist nur von deinem aktuellen Standort verfügbar.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Soll eine Route von deinem aktuellen Standort aus berechnet werden?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Weiter</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Von</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Bis</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Zeitplan hinzufügen</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Zeitplan löschen</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Ganztägig (24 Stunden)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Geöffnet</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Geschlossen</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Schließzeiten hinzufügen</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Öffnungszeiten</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Erweiterter Modus</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Einfachmodus</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Schließzeiten</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Beispiele</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Fehler korrigieren</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Standort auswählen</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Bitte beschreibe das Problem detailliert, damit die OpenStreetMap-Community den Fehler korrigieren kann.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Oder kümmere dich selbst darum auf https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Senden</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Der Ort existiert nicht</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Wegen Wartung geschlossen</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Doppelter Ort</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Karten automatisch herunterladen</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Täglich</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Heute geschlossen</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Geschlossen</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Heute</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Öffnet in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Schließt in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Geschlossen</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Geschäftszeiten bearbeiten</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Kein Konto bei OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Bei OpenStreetMap registrieren</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Anmelden</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nicht angemeldet</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Bei OpenStreetMap anmelden</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Passwort</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Passwort vergessen?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Abmelden</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Eintrag bearbeiten</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Eine Sprache hinzufügen</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Straße</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Hausnummer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Einzelheiten</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Soziale Medien</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Gebäude</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Eine Straße hinzufügen</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Bitte einen Straßennamen eingeben</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Eine Sprache wählen</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Eine Straße wählen</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Küche</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Küche auswählen</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-Mail oder Benutzername</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Telefon hinzufügen</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Stockwerk</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Stock: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alle Kartenänderungen werden zusammen mit der Karte gelöscht.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Karten aktualisieren</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Um eine Route zu erstellen, musst du alle Karten aktualisieren und dann die Route erneut planen.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Karte finden</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Bitte überprüfe deine Einstellungen und stelle sicher, dass dein Gerät mit dem Internet verbunden ist.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nicht genug Speicherplatz</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Bitte entferne unnötige Daten</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login-Fehler.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Bestätigte Änderungen</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Verschiebe die Karte, um das Kreuz an der Stelle zu platzieren, an der sich der Ort oder das Geschäft befindet.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Wird bearbeitet</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Wird hinzugefügt</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name des Ortes</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Wie in der lokalen Sprache geschrieben</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detaillierte Beschreibung eines Problems</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Ein anderes Problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Organisation hinzufügen</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ein Objekt kann hier nicht positioniert werden</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Von der Community erstellte OpenStreetMap-Daten (Stand: %1). Erfahre mehr darüber, wie du die Karte bearbeiten und aktualisieren kannst unter OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) ist ein Gemeinschaftsprojekt zum Erstellen einer freien und offenen Karte. Es ist die Hauptquelle für Kartendaten in Organic Maps und funktioniert ähnlich wie Wikipedia. Du kannst Orte hinzufügen oder bearbeiten, die dann Millionen von Nutzern auf der ganzen Welt zur Verfügung stehen.
+Tritt der Gemeinschaft bei und helfe mit, die Karte für alle besser zu machen!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Erstelle ein OpenStreetMap-Konto oder melde dich an, um deine Kartenbearbeitungen weltweit zu veröffentlichen.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 von %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Über eine Mobilfunkverbindung herunterladen?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Das könnte mit einigen Tarifen oder beim Roaming sehr teuer werden.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Gib eine gültige Hausnummer ein</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Anzahl der Etagen (maximal %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Das Gebäude kann nicht mehr als %1 Etagen haben</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postleitzahl</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Gib eine gültige Postleitzahl ein</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Hinweis an Freiwillige von OpenStreetMap (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beschreibe Kartenfehler oder Dinge, die mit Organic Maps nicht bearbeitet werden können</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Deine Bearbeitungen werden in die öffentliche &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/DE:Über_OSM&quot;&gt;OpenStreetMap&lt;/a&gt; Datenbank hochgeladen. Bitte trage keine privaten oder urheberrechtlich geschützten Informationen ein.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mehr Informationen über OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Dein Bearbeitungsverlauf</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Deine Hinweise zu den Kartendaten</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Betreiber</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Betreiber: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Keine passende Kategorie gefunden?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Mit Organic Maps kann man nur einfache Punktkategorien hinzufügen, daher keine Städte, Straßen, Seen, Gebäudeumrisse, etc. Bitte füge solche Kategorien direkt bei &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; hinzu. In unserem &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;Leitfaden&lt;/a&gt; findest du eine detaillierte Schritt-für-Schritt-Anleitung.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Keine Karten heruntergeladen</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Lade Karten für die Offline-Suche und Navigation herunter.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Aktueller Standort ist unbekannt.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mehr</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Lesezeichen bearbeiten</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Persönliche Notizen (Text oder HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Alle lokalen Korrekturen verwerfen?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Verwerfen</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Hinzugefügtes Objekt löschen?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Löschen</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Dieser Ort existiert nicht</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Gib bitte den Grund für die Löschung an</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Gib eine gültige Telefonnummer ein</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Gib eine gültige Internetadresse ein</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Gib eine gültige E-Mail-Adresse ein</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Gib eine gültige Facebook-Webadresse, ein Konto oder einen Seitennamen ein</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Gib eine gültige Instagram-Webadresse oder einen Kontonamen ein</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Gib eine gültige Twitter-Webadresse oder einen Benutzernamen ein</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Gib eine gültige VK-Webadresse oder einen Kontonamen ein</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Gib eine gültige LINE-Webadresse oder LINE ID ein</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Ort zu OpenStreetMap hinzufügen</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Oder hinterlasse einfach eine Nachricht an die OpenStreetMap-Community, damit jemand anderes den Ort hier hinzufügen oder korrigieren kann.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Eine Notiz wird an OpenStreetMap geschickt</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>An alle Benutzer senden?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Stelle sicher, dass du keine persönlichen oder privaten Daten eingegeben hast.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Freiwillige von OpenStreetMap werden die Änderungen prüfen und sich bei Fragen mit dir in Verbindung setzen.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Beenden</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Aufnahme der Strecke</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Annehmen</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Ablehnen</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Mobiles Internet verwenden, um genauere Informationen anzuzeigen?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Immer verwenden</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Nur heute</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Heute nicht verwenden</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiles Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Für Benachrichtigungen über Kartenaktualisierungen und das Hochladen von Änderungen ist eine mobile Internetverbindung erforderlich.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nie verwenden</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Immer fragen</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Um Verkehrsdaten anzuzeigen, müssen die Karten aktualisiert werden.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Schrift auf der Karte vergrößern</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Bitte aktualisiere Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Verkehrsdaten sind nicht verfügbar</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Protokollierung aktivieren</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Allgemeines Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Wir verwenden Text-to-Speech-Systeme für Sprachanweisungen. Viele Android-Geräte nutzen Google-TTS, das du bei Google Play herunterladen oder aktualisieren kannst</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Für einige Sprachen musst einen anderen Sprachgenerator oder ein zusätzliches Sprachpaket aus dem App Store installieren (Google Play, Galaxy Store, App Gallery, F-Droid).
+Öffne die Einstellungen deines Gerätes → Sprache und Eingabe → Sprache → Text-to-Speech-Ausgabe.
+Hier kannst du die Einstellungen für Sprachsynthese verwalten (beispielsweise ein Sprachpaket für die Offline-Verwendung herunterladen) und ein anderes Sprachausgabeprogramm auswählen.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Weitere Informationen findest du in dieser Anleitung.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteration ins Lateinische</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Weitere Informationen</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Verwende die Suche, wähle ein Lesezeichen aus oder tippe auf die Karte, um einen Routenstartpunkt hinzuzufügen</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Verwende die Suche, wähle ein Lesezeichen aus oder tippe auf die Karte, um einen Zielpunkt hinzuzufügen</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Route verwalten</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planen</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Stopp entfernen</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Stopp einfügen</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Gespeichert</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Bitte melde dich bei OpenStreetMap an, um alle deine Kartenbearbeitungen automatisch hochzuladen. Erfahre mehr &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hier&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problem mit dem Zugreifen auf den Speicher</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Der externe Speicher ist nicht verfügbar, möglicherweise wurde die SD-Karte entfernt oder sie ist beschädigt oder das Dateisystem ist schreibgeschützt. Überprüfe das bitte oder kontaktiere uns unter support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Fehlerhaften Speicher emulieren</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Bitte gib einen korrekten Namen ein</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listen</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Alle ausblenden</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Alle anzeigen</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n Lesezeichen</numerusform>
+<numerusform>%n Lesezeichen</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Neue Liste erstellen</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Lesezeichen und Tracks importieren</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Teilen wegen eines Anwendungsfehlers nicht möglich</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Fehler beim Teilen</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Eine leere Liste kann nicht geteilt werden</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Der Name darf nicht leer sein</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Bitte gib den Listennamen ein</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Neue Liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Dieser Name ist bereits vergeben</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Bitte wähle einen anderen Namen</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Bitte warten…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonnummer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap-Profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n Datei wurde gefunden. Du kannst sie nach der Konvertierung sehen.</numerusform>
+<numerusform>%n Dateien wurden gefunden. Du kannst sie nach der Konvertierung sehen.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Wiederherstellen</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n Track</numerusform>
+<numerusform>%n Tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatsphäre</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Datenschutzerklärung</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Nutzungsbedingungen</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Verkehr</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Wanderrouten</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Fahrradrouten</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>U-Bahn</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kartenstile und Ebenen</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Die Liste ist leer</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Zum Hinzufügen eine Lesezeichens tippe in der Karte auf den Ort und dann unten auf das Sternchen</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Farbe aller Lesezeichen ändern</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Farbe aller Tracks ändern</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mehr</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZ exportieren</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPX exportieren</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSON exportieren</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Liste löschen</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Blitzer</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Ortsbeschreibung</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Karten werden geladen</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warnen, wenn zu schnell</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Immer warnen</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Niemals warnen</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Stromsparmodus</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Versucht den Stromverbrauch auf Kosten einiger Funktionen zu reduzieren.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Niemals</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Auto</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Immer</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Lesezeichenname auf der Karte mit anzeigen</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Wenn du zu viele Lesezeichen hast, kann es sein, dass die App langsamer wird, wenn die Namen auf der Karte angezeigt werden.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Rechts anzeigen</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Unten anzeigen</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aktivieren, um Diagnoseprotokolle aufzuzeichnen. Sollte ein App-Fehler auftreten, reproduziere das Problem und sende uns die Protokolle über die Schaltfläche &quot;App-Fehler melden&quot; unter &quot;Hilfe&quot;. Protokolle können Standortformationen enthalten.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routenbeschränkungen</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Mautstraßen vermeiden</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Unbefest. Straßen vermeiden</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Fähren vermeiden</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Autobahnen vermeiden</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Route kann nicht berechnet werden</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Eine Route konnte nicht gefunden werden. Dies kann an deinen Routenbeschränkungen oder an unvollständigen OpenStreetMap-Daten liegen. Bitte ändere deine Routenbeschränkungen und versuche es erneut.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Routenbeschränkung einstellen</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routenbeschränkungen aktiv</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Mautstraße</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unbefestigte Straße</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Fährstelle</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nein</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nein</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapazität: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netzwerk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Du bist angekommen!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sortieren…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Lesezeichen sortieren</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Nach Voreinstellung</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Nach Typ</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Nach Entfernung</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Nach Datum</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Nach Name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Vor einer Woche</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Vor einem Monat</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Vor über einem Monat</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Vor über einem Jahr</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>In meiner Nähe</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Sonstiges</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Routenplanung fehlgeschlagen</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ankunft: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Lade alle Karten entlang der geplanten Route herunter und aktualisiere sie, um die Route zu berechnen.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Du hast die Weltkarte geändert. Behalte das nicht für dich! Erzähle deine Freunden davon und bearbeitet sie zusammen.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Mit Freunden teilen</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Jetzt geschlossen</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Öffnet morgen um %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Öffnet %1 um %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Öffnet um %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Schließt um %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Öffnungszeiten hinzufügen</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Passwort (mindestens 8 Zeichen)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Ungültiger Benutzername oder Passwort.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Konto</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Zuletzt hochgeladen</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Danke</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Name des Ortes</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Bitte beachten</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Fehler beim Herunterladen</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Kategorie auswählen</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Beliebt</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Alle Kategorien</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Füge auf der Karte einen neuen Ort hinzu und bearbeite existierende Orte direkt in der App.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Standort wechseln</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Zum Herunterladen benötigst du mehr Speicherplatz. Bitte lösche unnötige Daten.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ich habe die Organic Maps-Karten verbessert</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Ausführlicher Kommentar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Dein Änderungsvorschläge für die Karte werden an OpenStreetMap gesendet: Beschreibe die Details der Objekte, die du in Organic Maps nicht bearbeiten kannst.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Bei der Standortsuche ist ein unbekannter Fehler aufgetreten. Prüfe die Funktionstüchtigkeit deines Geräts und versuche es etwas später erneut.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Standortdienste sind deaktiviert</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aktiviere den Zugriff zur Standortbestimmung in den Geräteeinstellungen</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Einstellungen öffnen</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Auf Standort tippen</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. „Beim Verwenden der App“ auswählen</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Datenschutz auswählen</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Standortdienste auswählen</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Standortdienste einschalten</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Oder verwende Organic Maps weiterhin ohne Standort</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Buchen</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Anrufen</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Name des Lesezeichens</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Lesezeichen löschen</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Deine Notiz wird an OpenStreetMap gesendet</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mehr</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aktualisieren</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Aufzeichnung deiner kürzlich gefahrenen Route deaktivieren?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Deaktivieren</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Nachsehen</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps verwendet deinen Standort im Hintergrund, um deine kürzlich gefahrene Route aufzunehmen.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Allgemeine Einstellungen</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Zum Anzeigen von Verkehrsdaten muss die Anwendung aktualisiert werden.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Größe der Protokolldatei: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Hierher ziehen zum Entfernen</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Stopp ersetzen</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Starten von</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Bitte melde dich bei OpenStreetMap an, um alle deine Kartenbearbeitungen automatisch hochzuladen. Erfahre mehr</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hier</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Bildschirm ausblenden</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 von %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 heruntergeladen…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 anwenden…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Dieser Name ist zu lang</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Neue Dateien erkannt</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertieren</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Fehler</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Einige Dateien wurden nicht konvertiert.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Es ist ein Fehler aufgetreten</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Beliebt</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Auf der Karte ausblenden</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Während dem Laden der Tags ist ein Fehler aufgetreten, bitte versuche es erneut</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Rechts</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Unten</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Losfahren</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Ziel</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Zentrieren</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Suchergebnisse</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Danach</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Möchtest du die Route neu erstellen?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Die Tastatur ist während der Fahrt nicht verfügbar</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Vom aktuellen Standort aus kann keine Route erstellt werden</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Zu diesem Ziel kann keine Route erstellt werden. Bitte wähle einen anderes Ziel</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Kein GPS-Signal. Gehe in das offene Gelände</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Es kann keine Route erstellt werden. Bitte wähle andere Routenpunkte</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Lade die fehlenden Karten herunter, um die Route zu erstellen</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Es ist ein Fehler aufgetreten. Bitte starte die App neu</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Die Route wird von deinem derzeitigen Standort aus neu erstellt</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Die Route wird zu einer Route für Fahrzeuge geändert</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Es werden nicht alle Lesezeichen angezeigt</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Wechsle aufs Telefon, um alle Lesezeichen zu sehen</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Blitzer</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Blitzerwarnung</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Lade Karten in der App auf deinem Gerät herunter</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 Ausfahrt</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Nach Voreinstellung sortieren</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Nach Kategorien sortieren</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Nach Entfernung sortieren</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Nach Datum sortieren</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Nach Name sortieren</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Essen</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sehenswürdigkeiten</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museen</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Schwimmmöglichkeiten</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Berge</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Tiere</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Gebäude</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Geld</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Ladengeschäfte</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkplätze</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Tankstellen</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medizin</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>In der Liste suchen</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religiöse Orte</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Liste auswählen</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Die U-Bahn-Navigation ist in dieser Region noch nicht verfügbar</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Keine U-Bahn-Route gefunden</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Bitte wähle einen Start- oder Zielpunkt, der näher an einer U-Bahn-Station liegt</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Höhenlinien</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Um die Höhenlinien nutzen zu können, aktualisiere die Karte des betreffenden Gebiets oder lade diese herunter</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Höhenlinien sind für dieses Gebiet noch nicht verfügbar</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Bergauf</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Bergab</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. Höhe</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. Höhe</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Schwierigkeitsgrad</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Entf.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Dauer:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Karte vergrößern, um Höhenlinien sichtbar zu machen</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Herunterladen</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Lade die weltweite Übersichtskarte herunter</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Ordner kann nicht erstellt und Dateien können nicht auf den Gerätespeicher oder die SD-Karte verschoben werden</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Speicherfehler</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Verbindungsfehler</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB-Kabel trennen</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Bildschirm anlassen</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Wenn diese Option aktiviert ist, bleibt der Bildschirm bei der Anzeige der Karte immer eingeschaltet.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Auf dem Sperrbildschirm anzeigen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Wenn aktiviert, funktioniert die App auf dem Sperrbildschirm auch wenn das Gerät gesperrt ist.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kartensprache</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kartendaten von OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/de/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/de/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/DE:Über_OSM</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Danke, dass du unsere von der Community erstellten Karten benutzt!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Mit deinen Spenden und deiner Unterstützung können wir die besten Karten der Welt erstellen!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Gefällt dir unsere App? Bitte spende, um die Entwicklung zu unterstützen! Gefällt sie dir noch nicht? Bitte lass uns wissen warum und wir werden das Problem beheben!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Wenn du einen Softwareentwickler kennst, kannst du ihn oder sie bitten, eine Funktion zu implementieren, die du benötigst.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tippe irgendwo auf die Karte, um etwas auszuwählen. Tipp lange, um die Oberfläche aus- und wieder einzublenden.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Wusstest du, dass du deinen aktuellen Standort auf der Karte auswählen kannst?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Du kannst dabei helfen, unsere App in deine Sprache zu übersetzen.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Unsere App wird von einigen Enthusiasten und der Community entwickelt.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Du kannst die Kartendaten einfach korrigieren und verbessern.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Unser Hauptziel ist es, schnelle, datenschutzorientierte und benutzerfreundliche Karten zu erstellen, die du liebst.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Du verwendest jetzt Organic Maps auf dem Telefondisplay</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Du verwendest jetzt Organic Maps auf dem Bildschirm des Autos</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Du bist mit Android Auto verbunden</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Weiter am Telefon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Zum Autobildschirm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps benötigt Zugriff auf den Standort. Wenn es sicher ist, überprüfe die Benachrichtigung auf deinem Telefon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Diese App braucht deine Erlaubnis</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto benötigt Standortberechtigungen, um effektiv zu funktionieren</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Erlaubnis erteilen</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Wandern</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webbrowser ist nicht verfügbar</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Lautstärke</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Alle Lesezeichen und Tracks exportieren</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Einstellungen des Sprachsynthesesystems</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Die Einstellungen für die Sprachsynthese wurden nicht gefunden. Bist du sicher, dass dein Gerät sie unterstützt?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Lösche die Suche</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Vergrößern</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Herauszoomen</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link zur Speisekarte</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Speisekarte anzeigen</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>In einer anderen App öffnen</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Selbstbedienung</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Option auswählen</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sitzplätze im Freien</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Für eine möglichst genaue Navigation empfehlen wir, den Energiesparmodus in den Akku-Einstellungen des Telefons zu deaktivieren.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Track aufnehmen</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Aufnahme des Tracks stoppen</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track-Aufzeichnung</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Ohne Speichern beenden</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Aufnahme fortsetzen</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>In Lesezeichen und Tracks speichern?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track ist leer - nichts zu speichern</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Das Dialogfeld zur Ordnerauswahl kann nicht angezeigt werden, da keine geeignete App auf deinem Gerät installiert ist. Bitte installiere eine Dateimanager-App und versuche es erneut.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Farbe auswählen</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Track bearbeiten</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Keine App installiert, die den Speicherort öffnen kann</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in der Navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Systemeinstellung</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Track teilen</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>%1 löschen?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Anspruchsniveau</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Leicht</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mittel</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Schwer</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Aktualisierung</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Aktualisiere deine heruntergeladenen Karten</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Das Aktualisieren der Karten sorgt dafür, dass die Objektinformationen stets auf dem neuesten Stand sind</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Aktualisieren (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Später manuell aktualisieren</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Track löschen</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Willst du diesen Track wirklich löschen?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Name des Tracks</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Verschieben</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Spur</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Farbe ändern</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Karte</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Willst du einen Fehlerbericht an die Entwickler schicken?
+Wir sind auf unsere Nutzer angewiesen, da Organic Maps keine Fehlerinformationen automatisch sammelt. Wir danken dir im Voraus für deine Unterstützung von Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktiviere die iCloud-Syncronisierung</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Die iCloud-Synchronisierung ist eine experimentelle Funktion, die noch entwickelt wird. Vergewissere dich, dass du eine Sicherungskopie all deiner Lesezeichen und Tracks erstellt hast.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud ist deaktiviert</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Bitte aktiviere iCloud in den Einstellungen deines Geräts, um diese Funktion zu nutzen.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktivieren</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sicherung</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-Synchronisierung fehlgeschlagen</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Fehler: Synchronisierung aufgrund eines Verbindungsfehlers fehlgeschlagen</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Fehler: Synchronisierung fehlgeschlagen, da iCloud-Kontingent überschritten</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Fehler: iCloud ist nicht verfügbar</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Kürzlich gelöschte Listen</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Löschen</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Alle löschen</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Wiederherstellen</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Alles wiederherstellen</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Zu OpenStreetMap beitragen</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Ort hinzufügen</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Aktualisiere die Karte, um beizutragen</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Du musst die %1-Karte auf die neueste Version aktualisieren, bevor du zu OpenStreetMap-Daten beitragen kannst</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mein Standort</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Meine Orte</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Interner persönlicher Speicher</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interner gemeinsamer Speicher</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-Karte</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Externer gemeinsamer Speicher</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WLAN</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postleitzahl</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kartenpunkt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Um Routen anzuzeigen, muss die Karte aktualisiert werden.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Ausgang</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Eingang</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Die U-Bahnkarte steht nicht zur Verfügung</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Sie</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Heruntergeladene Regionen farblich markieren</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Das Bestimmen des aktuellen Standortes im Hintergrund ist erforderlich, um den vollen Funktionsumfang der App zu genießen. Dies wird dafür genutzt, der Route zu folgen und, um Ihren bereits bestrittenen Weg zu speichern.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Die Angabe des aktuellen Standortes wird in den Optionen bei der Verfolgung der Route und beim Speichern Ihres zuletzt zurückgelegten Weges verwendet.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Anmeldung mit Passwort</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Anmeldung über den Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Zuletzt verwendet</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Lesezeichenfarbe geändert</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Trackfarbe geändert</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Schieberegler</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROT</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GRÜN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLAU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex-Farbe #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Raster</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/el/omim.ts
+++ b/qt/translations/el/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="el">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Πίσω</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Άκυρο</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Διαγραφή</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Λήψη χαρτών</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Η λήψη απέτυχε. Πατήστε για να προσπαθήσετε ξανά.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Λήψη…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Χιλιόμετρα</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Μίλια</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Αργότερα</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Αναζήτηση</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Αναζήτηση στο χάρτη</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Οι υπηρεσίες εντοπισμού τοποθεσίας είναι προς το παρόν απενεργοποιημένες σε αυτή τη συσκευή ή για αυτή την εφαρμογή. Ενεργοποιήστε τες από τις Ρυθμίσεις.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Περιορισμένη ακρίβεια</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Για να εξασφαλίσετε ακριβή πλοήγηση, ενεργοποιήστε την Ακριβής τοποθεσία στις ρυθμίσεις.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Εμφάνιση στο χάρτη</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Η λήψη απέτυχε</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Δοκιμάστε ξανά</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Σχετικά με το Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Δωρεάν για όλους, φτιαγμένα με αγάπη</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Χωρίς διαφημίσεις, χωρίς tracking, χωρίς συλλογή δεδομένων</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Δεν εξαντλεί τη μπαταρία, λειτουργεί εκτός σύνδεσης</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Γρήγορο, μινιμαλιστικό, αναπτυγμένο από την κοινότητα</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Εφαρμογή ανοιχτού κώδικα που δημιουργήθηκε από θιασώτες και εθελοντές.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Ρυθμίσεις τοποθεσίας</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Κλείσιμο</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Η εφαρμογή απαιτεί OpenGL με επιτάχυνση υλικού. Δυστυχώς, η συσκευή σας δεν το υποστηρίζει.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Λήψη</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Αποσυνδέστε το καλώδιο USB ή τοποθετήστε την κάρτα μνήμης για να χρησιμοποιήσετε το Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Ελευθερώσετε χώρο αποθήκευσης στην SD κάρτα/USB πρώτα προκειμένου να χρησιμοποιήσετε την εφαρμογή</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Πριν ξεκινήσετε τη χρήση της εφαρμογής, επιτρέψτε μας να κατεβάσουμε το γενικό παγκόσμιο χάρτη στη συσκευή σας.
+Θα χρησιμοποιήσει %1 αποθηκευτικού χώρου.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Μετάβαση στο χάρτη</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Λήψη %1. Μπορείτε τώρα να
+μεταβείτε στο χάρτη.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Να γίνει λήψη %1;</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Να γίνει ενημέρωση %1;</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Παύση</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Συνέχεια</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>η λήψη %1 απέτυχε</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Δημιουργία νέας λίστας</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Όνομα λίστας αγαπημένων</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Αγαπημένα</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Αγαπημένα και διαδρομές</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Όνομα</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Διεύθυνση</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Λίστα</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Ρυθμίσεις</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Αποθήκευση χαρτών σε</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Επιλέξτε την τοποθεσία λήψης των χαρτών.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Κατεβασμένοι Χάρτες</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 ελεύθερα από τα %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Να γίνει μετακίνηση των χαρτών;</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Σφάλμα κατά τη μετακίνηση των αρχείων</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Αυτό μπορεί να κρατήσει αρκετά λεπτά.
+Παρακαλώ περιμένετε…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Μονάδες μέτρησης</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Επιλέξετε ανάμεσα σε μίλια και χιλιόμετρα</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Ακύρωση λήψης</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Αφήστε μια κριτική</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ναι</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Λήψη χάρτη</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Λίστα αγαπημένων</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Μέρη για φαγητό</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Παντοπωλεία</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Συγκοινωνία</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Βενζινάδικο</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Χώρος στάθμευσης</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Ψώνια</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Μεταχειρισμένα</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Ξενοδοχείο</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Αξιοθέατα</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Ψυχαγωγία</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ΑΤΜ</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Νυχτερινή ζωή</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Οικογενειακές διακοπές</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Τράπεζα</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Φαρμακείο</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Νοσοκομείο</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Τουαλέτα</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Ταχυδρομείο</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Αστυνομία</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Ανακύκλωση</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Νερό</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Για RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Σημειώσεις</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Κοινοποιήθηκαν τα αγαπημένα από το Organic Maps σε εσάς</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Γειa!
+
+Σου επισυνάπτω τα αγαπημένα μου. Παρακαλώ άνοιξέ τα με το Organic Maps. Αν δεν το έχεις εγκαταστήσει, μπορείς να το κατεβάσεις από εδώ: https://omaps.app/get?kmz
+
+Καλή διασκέδαση ταξιδεύοντας με το Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Φορτώνονται τα αγαπημένα</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Τα αγαπημένα φορτώθηκαν με επιτυχία! Μπορείτε να τα βρείτε στο χάρτη ή στην οθόνη Διαχείρισης αγαπημένων.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Η φόρτωση των αγαπημένων απέτυχε. Το αρχείο μπορεί να είναι κατεστραμμένο ή ελαττωματικό.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Ο τύπος αρχείου δεν αναγνωρίζεται από την εφαρμογή:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Αποτυχία ανοίγματος του αρχείου %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Επεξεργασία</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Η τοποθεσία σας δεν έχει προσδιοριστεί ακόμη</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Λυπούμαστε, οι ρυθμίσεις αποθήκευσης χαρτών είναι προς το παρόν απενεργοποιημένες.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Λήψη χάρτη βρίσκεται σε εξέλιξη.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Δες την τρέχουσα τοποθεσία μου στο Organic Maps! %1 ή %2 Αν δεν έχεις τους χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Γεια, δες τις τοποθεσίες που έχω καρφιτσώσει στο Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Γεια, δες την τρέχουσα τοποθεσία μου στο χάρτη του Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Γεια,
+
+Αυτή τη στιγμή είμαι εδώ: %1. Κάνε κλικ σε αυτό το σύνδεσμο %2 ή σε αυτόν %3 για να δεις την τοποθεσία στο χάρτη.
+
+Ευχαριστώ.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Κοινοποίηση</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Ηλεκτρονικό ταχυδρομείο</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Αντιγράφηκε στο Πρόχειρο: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Ολοκλήρωση</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Δεδομένα OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Είστε σίγουροι ότι θέλετε να αποσυνδεθείτε από το λογαριασμό σας στο OpenStreetMap;</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Διαδρομές</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Μήκος</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Κοινοποίηση της τοποθεσίας μου</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Γενικές Ρυθμίσεις</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Πληροφορίες</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Πλοήγηση</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Πλήκτρα «+» και «-» στον χάρτη</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Εμφάνιση στο χάρτη</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Νυχτερινό στυλ κατά την πλοήγηση στο σκοτάδι</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Νυχτερινή λειτουργία</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Απενεργ.</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Ενεργ.</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Αυτόματα</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Οπτική γωνία</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Τρισδιάστατα κτίρια</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Τα τρισδιάστατα κτίρια είναι απενεργοποιημένα σε λειτουργία εξοικονόμησης ενέργειας</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Φωνητικές οδηγίες</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Ανακοινώστε ονόματα οδών</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Όταν είναι ενεργοποιημένο, το όνομα της οδού ή της εξόδου στην οποία θα μεταβείτε θα εκφωνείται δυνατά.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Γλώσσα φωνής</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Για να κατεβάσετε μια φωνή υψηλότερης ποιότητας, ανοίξτε την εφαρμογή Ρυθμίσεις και μεταβείτε στην Προσβασιμότητα → VoiceOver → Ομιλία → Φωνή.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Δοκιμή φωνητικών οδηγιών (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Ελέγξτε την ένταση ήχου ή τις ρυθμίσεις του συστήματος text-to-speech αν δεν ακούτε τη φωνή τώρα.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Δεν είναι διαθέσιμη</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Αυτόματη μεγέθυνση</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Απόσταση</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Προβολή στο χάρτη</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Μενού</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Ιστότοπος</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Νέα</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Σχόλια</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Βαθμολογήστε την εφαρμογή</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Βοήθεια</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Συχνές ερωτήσεις</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Δωρεά</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ήδη δωρεά</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Υπενθύμισε αργότερα</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Υποστήριξε το Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Στηρίξτε αυτό το πρότζεκτ</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Πνευματικά δικαιώματα</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Αναφορά σφάλματος</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Βελτιώστε την κατεύθυνση των βελών μετακινώντας το τηλέφωνο με μια κίνηση σχήματος οκτώ για να καλιμπράρετε την πυξίδα.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Μετακινήστε το τηλέφωνο με μια κίνηση σχήματος οκτώ για να καλιμπράρετε την πυξίδα και να καθορίσετε την κατεύθυνση του βέλους στο χάρτη.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Πατήστε ξανά παρατεταμένα στο χάρτη για να δείτε το περιβάλλον εργασίας</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Ενημέρωση όλων</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Ακύρωση όλων</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Κατεβασμένα</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Στην ουρά</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Κοντά μου</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Χάρτες</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Λήψη όλων</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Γίνεται λήψη:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Για να διαγράψετε το χάρτη, σταματήστε την πλοήγηση.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Μπορούν να δημιουργηθούν μόνο διαδρομές που περιέχονται πλήρως μέσα σε ένα χάρτη σε μια ενιαία περιοχή.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Λήψη χάρτη</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Επανάληψη</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Διαγραφή χάρτη</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Ενημέρωση χάρτη</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Υπηρεσίες τοποθεσίας Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Προσδιορίστε γρήγορα την κατά προσέγγιση τοποθεσία σας μέσω Bluetooth, WiFi ή δικτύου κινητής τηλεφωνίας</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Κατέβασμα όλων των χαρτών για ολόκληρο το μήκος της διαδρομής σας</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Για να φτιάξετε μια διαδρομή, πρέπει πρώτα να γίνει λήψη και ενημέρωση όλων των χαρτών από τη θέση σας μέχρι τον προορισμό σας.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Δεν υπάρχει αρκετός χώρος</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Αποθήκευση</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>δημιουργήστε</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Κόκκινο</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Κίτρινο</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Μπλε</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Πράσινο</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Μωβ</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Πορτοκαλί</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Καφέ</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Ροζ</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Βαθύ μωβ</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Γαλάζιο</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Κυανό</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Σμαραγδένιο</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Λάιμ</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Βαθύ πορτοκαλί</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Γκρι</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Γκρίζο μπλε</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Πληροφορίες</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Έκδοση Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Εμφάνιση</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Ανοιχτόχρωμη</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Σκουρόχρωμη</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Ανοιχτόχρωμο από την αυγή μέχρι το σούρουπο</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Άλλo</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Χαρίστε δωρεάν χάρτες χωρίς διαφημίσεις σε εκατομμύρια χρήστες!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Αναφορά ή διόρθωση λανθασμένων δεδομένων χάρτη</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Γίνετε εθελοντής</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Ακολουθήστε και επικοινωνήστε μαζί μας:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Το πρόγραμμα ηλεκτρονικού ταχυδρομείου δεν έχει ρυθμιστεί. Ρυθμίστε το ή χρησιμοποιήστε άλλο τρόπο να επικοινωνήσετε μαζί μας στη διεύθυνση %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Σφάλμα κατά την αποστολή του e-mail</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Καλιμπράρισμα πυξίδας</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Διαθέσιμα</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Βρέθηκαν</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Ενημέρωση</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Απέτυχε</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>αγαπημένο</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Όταν ακολουθείτε την διαδρομή, να θυμάστε:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>- Οι οδικές συνθήκες, οι κανόνες οδικής κυκλοφορίας και οι πινακίδες έχουν πάντα προτεραιότητα έναντι των συμβουλών πλοήγησης;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Ο Χάρτης μπορεί να είναι ανακριβής, και η προτεινόμενη διαδρομή μπορεί να μην είναι πάντα ο βέλτιστος τρόπος να φτάσετε στον προορισμό;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Οι προτεινόμενες διαδρομές πρέπει να ερμηνεύονται μόνο ως συστάσεις;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Προσέξτε τις διαδρομές στις παραμεθόριες περιοχές: οι διαδρομές που δημιουργούνται από την εφαρμογή μας μπορεί μερικές φορές να διαπερνούν τα εθνικά σύνορα σε απαγορευμένες περιοχές.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Να είστε πάντα σε εγρήγορση και να οδηγείτε με ασφάλεια στους δρόμους!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Ελέγξτε το σήμα GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Δεν είναι δυνατή η δημιουργία της διαδρομής. Δεν μπορούν να προσδιοριστούν οι τρέχουσες συντεταγμένες GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Ελέγξτε το σήμα GPS. Η ενεργοποίηση του Wi-Fi θα βελτιώσει την ακρίβεια της τοποθεσίας σας.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Δεν είναι δυνατός ο εντοπισμός των τρεχουσών συντεταγμένων GPS. Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας για τον υπολογισμό της διαδρομής.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Δε μπορεί να εντοπιστεί η διαδρομή</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Δε μπορεί να δημιουργηθεί η διαδρομή.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ρυθμίστε το σημείο εκκίνησης ή τον προορισμό σας.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ρυθμίστε το σημείο εκκίνησης</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Η διαδρομή δεν δημιουργήθηκε. Δεν είναι δυνατός ο εντοπισμός του σημείου εκκίνησης.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Επιλέξτε σημείο εκκίνησης πιο κοντά σε κάποιο δρόμο.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ρύθμιση προορισμού</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Η διαδρομή δεν δημιουργήθηκε. Δεν είναι δυνατός ο εντοπισμός του προορισμού.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Επιλέξτε ένα σημείο προορισμού πιο κοντά σε κάποιο δρόμο.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Δεν είναι δυνατός ο εντοπισμός ενδιάμεσου σημείου.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Ρυθμίστε το ενδιάμεσο σημείο.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Σφάλμα συστήματος</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Δεν είναι δυνατή η δημιουργία διαδρομής λόγω σφάλματος της εφαρμογής.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Προσπαθήστε ξανά</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Όχι τώρα</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Θέλετε να κατεβάσετε το χάρτη και να δημιουργήσετε μια πιο βέλτιστη διαδρομή που εκτείνεται σε περισσότερους από έναν χάρτες;</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Κατεβάστε επιπλέον χάρτες για να δημιουργηθεί μια καλύτερη διαδρομή που διασχίζει τα όρια αυτού του χάρτη.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Κατεβάστε τα απαιτούμενα αρχεία</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Κατεβάσετε ή ενημερώστε όλους τους χάρτες για όλο το μήκος της προβαλλόμενης διαδρομής ώστε να γίνει ο υπολογισμός της.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Για να ξεκινήσετε την αναζήτηση και τη δημιουργία διαδρομών, κατεβάστε το χάρτη. Μετά από αυτό δεν θα χρειάζεστε πλέον σύνδεση στο Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Επιλογή χάρτη</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Εμφάνιση</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Απόκρυψη</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Κατηγορίες</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Ιστορικό</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ωχ, δε βρέθηκαν αποτελέσματα.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Κατεβάστε την περιοχή στην οποία ψάχνετε ή δοκιμάστε να προσθέσετε το όνομα μιας κοντινής πόλης/χωριού.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Ιστορικό αναζητήσεων</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Προβολή πρόσφατων αναζητήσεων.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Εκκαθάριση ιστορικού αναζητήσεων</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Βικιπέδια</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Άρθρο από wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Κοινά της Wikimedia</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Η τοποθεσία σας</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Έναρξη</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Διαδρομή από</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Διαδρομή προς</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Η πλοήγηση είναι διαθέσιμη μόνο από την τρέχουσα τοποθεσία σας.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Θέλετε να σχεδιαστεί μια διαδρομή από την τρέχουσα τοποθεσία σας;</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Επόμενο</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Από</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Έως</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Προσθέσετε χρονοδιάγραμμα</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Διαγραφή χρονοδιαγράμματος</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Όλη την ημέρα (24 ώρες)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Ανοικτό</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Κλειστό</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Προσθήκη μη-εργάσιμων ωρών</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Εργάσιμες ώρες</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Αναλυτική Προβολή</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Απλή προβολή</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Μη-εργάσιμες ώρες</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Παραδείγματα</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Διόρθωση λάθους</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Επιλέξτε τοποθεσία</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Περιγράψτε το πρόβλημα αναλυτικά ώστε η κοινότητα του OpenStreetMap να το διορθώσει.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ή κάντε το μόνοι σας στη διεύθυνση https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Αποστολή</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Πρόβλημα</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Η τοποθεσία δεν υπάρχει</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Κλειστό για συντήρηση</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Διπλότυπη τοποθεσία</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Αυτόματη λήψη</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Καθημερινά</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Κλειστό σήμερα</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Κλειστό</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Σήμερα</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Ανοίγει σε %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Κλείνει σε %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Κλειστό</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Επεξεργαστείτε τις ώρες λειτουργίας</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Δεν έχετε λογαριασμό OpenStreetMap;</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Εγγραφή στο OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Σύνδεση</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Δεν έχετε συνδεθεί</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Συνδεθείτε στο OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Κωδικός πρόσβασης</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Ξαχάσατε τον κωδικό πρόσβασης;</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Αποσύνδεση</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Επεξεργασία τοποθεσίας</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Προσθήκη γλώσσας</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Οδός</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Αριθμός κτιρίου</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Λεπτομέρειες</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Μέσα κοινωνικής δικτύωσης</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Κτίριο</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Προσθέστε οδό</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Εισαγάγετε όνομα οδού</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Επιλέξτε μια γλώσσα</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Επιλέξτε μια οδό</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Κουζίνα</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Επιλέξτε κουζίνα</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ή όνομα χρήστη</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Προσθήκη Τηλεφώνου</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Όροφος</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Όροφος: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Όλες οι αλλαγές που έχετε κάνει στο χάρτη θα διαγραφούν μαζί με το χάρτη.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Ενημέρωση χαρτών</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Για να δημιουργήσετε μια διαδρομή, πρέπει να ενημερώσετε όλους τους χάρτες και στη συνέχεια να σχεδιάσετε τη διαδρομή ξανά.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Εύρεση χάρτη</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Βεβαιωθείτε ότι η συσκευή σας είναι συνδεδεμένη στο Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Δεν υπάρχει αρκετός χώρος</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Διαγράψτε μη απαραίτητα δεδομένα</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Σφάλμα σύνδεσης.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Επαληθευμένες αλλαγές</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Σύρετε το χάρτη για να τοποθετήσετε το σταυρό στη θέση του τόπου ή της επιχείρησης.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Επεξεργασία</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Προσθήκη</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Όνομα τοποθεσίας</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Όπως είναι γραμμένο στην τοπική γλώσσα</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Κατηγορία</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Λεπτομερής περιγραφή του θέματος</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Διαφορετικό πρόβλημα</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Προσθήκη επιχείρησης</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Δε μπορεί να τοποθετηθεί αντικείμενο εδώ</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Δεδομένα OpenStreetMap που δημιουργήθηκαν από την κοινότητα στις %1. Μάθετε περισσότερα για τον τρόπο επεξεργασίας και ενημέρωσης του χάρτη στο OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>Το OpenStreetMap.org (OSM) είναι ένα κοινοτικό έργο με στόχο τη δημιουργία ενός δωρεάν και ανοιχτού χάρτη. Αποτελεί την κύρια πηγή δεδομένων χαρτών στο Organic Maps και λειτουργεί παρόμοια με τη Wikipedia. Μπορείτε να προσθέσετε ή να επεξεργαστείτε τοποθεσίες, οι οποίες θα γίνουν διαθέσιμες σε εκατομμύρια χρήστες σε όλο τον κόσμο.
+Γίνετε μέλος της κοινότητας και βοηθήστε στη δημιουργία ενός καλύτερου χάρτη για όλους!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Δημιουργήστε έναν λογαριασμό OpenStreetMap ή συνδεθείτε για να δημοσιεύσετε τις επεξεργασίες του χάρτη σας στον κόσμο.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Να γίνει λήψη μέσω δικτύου κινητής τηλεφωνίας;</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Αυτό μπορεί να είναι πολύ ακριβό για μερικά πακέτα ή στην περίπτωση roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Εισαγάγετε έναν έγκυρο αριθμό κτιρίου</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Αριθμός ορόφων (μέγιστο %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Ο αριθμός των ορόφων δεν πρέπει να υπερβαίνει τους %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Ταχυδρομικός κώδικας</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Εισάγετε έναν έγκυρο ταχυδρομικό κώδικα</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Σημείωση για τους εθελοντές του OpenStreetMap (προαιρετική)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Περιγράψτε λάθη στο χάρτη ή πράγματα που δεν μπορούν να επεξεργαστούν με τους Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Οι επεξεργασίες σας μεταφορτώνονται στη δημόσια βάση δεδομένων &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Παρακαλούμε μην προσθέτετε προσωπικές πληροφορίες ή πληροφορίες που προστατεύονται από πνευματικά δικαιώματα.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Περισσότερα σχετικά με το OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Το ιστορικό επεξεργασίας σας</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Σημειώσεις δεδομένων του χάρτη σας</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Χειριστής</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Χειριστής: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Δεν μπορείτε να βρείτε την κατάλληλη κατηγορία;</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps επιτρέπει την προσθήκη μόνο απλών κατηγοριών σημείων, δηλαδή όχι πόλεων, δρόμων, λιμνών, περιγραμμάτων κτιρίων κ.λπ. Παρακαλούμε προσθέστε τέτοιες κατηγορίες απευθείας στο &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Ανατρέξτε &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;στον οδηγό&lt;/a&gt; μας για λεπτομερείς οδηγίες βήμα προς βήμα.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Δεν έχετε κατεβάσει χάρτες</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Η τρέχουσα τοποθεσία είναι άγνωστη.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>χμ/ω</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>Ωρα</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>λπτ</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>Μέρα</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>δ</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Περισσότερα</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Επεξεργασία αγαπημένου</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Προσωπικές σημειώσεις (κείμενο ή html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Σχόλιο…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Απόρριψη όλων των τοπικών αλλαγών;</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Απόρριψη</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Διαγραφή της τοποθεσίας που προστέθηκε;</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Διαγραφή</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Η τοποθεσία δεν υπάρχει</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Παρακαλώ εξηγήστε τον λόγο που διαγράφετε αυτή την τοποθεσία</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Εισάγετε έναν έγκυρο αριθμό τηλεφώνου</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Εισάγετε μια έγκυρη ηλεκτρονική διεύθυνση</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Εισάγετε ένα έγκυρο email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Εισάγετε μία έγκυρη διεύθυνση Facebook, λογαριασμού ή σελίδας</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Εισάγεται μια έγκυρη διεύθυνση Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Εισάγεται μια έγκυρη διεύθυνση X (δηλαδή Twitter)</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Εισάγεται μια έγκυρη διεύθυνση VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Εισάγεται μια έκγυρη διεύθυνση LIME</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Προσθήκη τοποθεσίας στο OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ή, εναλλακτικά, αφήστε μια σημείωση προς την κοινότητα του OpenStreetMap ώστε κάποιος άλλος να μπορεί να προσθέσει ή να διορθώσει ένα μέρος εδώ.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Η σημείωση θα αποσταλεί στο OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Θέλετε να το στείλετε σε όλους τους χρήστες;</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Βεβαιωθείτε ότι δεν έχετε εισάγει προσωπικά δεδομένα.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Οι συντάκτες του OpenStreetMap θα ελέγξουν τις αλλαγές και θα επικοινωνήσουν μαζί σας εάν έχουν απορίες.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>τέλος</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Καταγραφή της διαδρομής</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Συμφωνώ</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Διαφωνώ</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Θέλετε να χρησιμοποιήσετε το δίκτυο κινητής τηλεφωνίας για να εμφανίσετε αναλυτικές πληροφορίες;</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Να χρησιμοποιείται πάντα</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Μόνο σήμερα</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Να Μην χρησιμοποιηθεί σήμερα</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Ίντερνετ μέσω δικτύου κινητής</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Απαιτείται πρόσβαση στο ίντερνετ μέσω δικτύου κινητής για την εμφάνιση αναλυτικών πληροφοριών για τις τοποθεσίες, όπως φωτογραφίες, τιμές και κριτικές.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Να μην χρησιμοποιείται ποτέ</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Να γίνεται πάντα ερώτηση</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Για να εμφανιστούν πληροφορίες για την κίνηση, πρέπει να ενημερωθούν οι χάρτες.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Αύξηση μεγέθους γραμματοσειράς στο χάρτη</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Κάντε ενημέρωση του Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Ενεργοποίηση δυνατότητας καταγραφής</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Αποστολή γνώμης</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Χρησιμοποιούμε το σύστημα TTS για τις φωνητικές οδηγίες. Αρκετές συσκευές Android χρησιμοποιούν το Google TTS, μπορείτε να το κατεβάσετε ή να το ενημερώσετε από το Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Για μερικές γλώσσες θα χρειαστεί να εγκαταστήσετε συνθεσάιζερ ομιλίας ή κάποιο συμπληρωματικό πακέτο γλώσσας από το app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Ανοίξτε τις Ρυθμίσεις της συσκευής σας → Γλώσσα και εισαγωγή → Ομιλία → Μετατροπή κειμένου σε ομιλία.
+Εδώ μπορείτε να διαχειριστείτε τις ρυθμίσεις της σύνθεσης ομιλίας (για παράδειγμα, μπορείτε να κατεβάσετε πακέτο γλώσσας για χρήση εκτός σύνδεσης) και να επιλέξετε άλλη μηχανή μετατροπής κειμένου σε ομιλία.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Για περισσότερες πληροφορίες δείτε αυτό τον οδηγό.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Μεταγραφή στο λατινικό αλφάβητο</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Μάθετε περισσότερα</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Χρησιμοποιήστε την αναζήτηση, επιλέξτε έναν σελιδοδείκτη ή πατήστε στο χάρτη για να προσθέσετε ένα σημείο εκκίνησης της διαδρομής</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Χρησιμοποιήστε την αναζήτηση, επιλέξτε έναν σελιδοδείκτη ή πατήστε στο χάρτη για να προσθέσετε ένα σημείο προορισμού</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Διαχείριση διαδρομής</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Σχεδιασμός</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Αφαίρεση στάσης</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Προσθήκη στάσης</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Αποθηκεύτηκε</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Παρακαλούμε συνδεθείτε στο OpenStreetMap για να ανεβάσετε αυτόματα όλες τις επεξεργασίες του χάρτη σας. Μάθετε περισσότερα &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;εδώ&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Πρόβλημα πρόσβασης στον αποθηκευτικό χώρο</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Η εξωτερική αποθήκευση δεν είναι προσβάσιμη. Η κάρτα SD μπορεί να έχει αφαιρεθεί, να έχει υποστεί ζημιά ή το σύστημα αρχείων να είναι μόνο για ανάγνωση. Ελέγξτε την κάρτα SD ή επικοινωνήστε μαζί μας στο support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Εξομείωση κακού αποθηκευτικού χώρου</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Εισάγετε ένα σωστό όνομα</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Λίστες</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Απόκρυψη όλων</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Εμφάνιση όλων</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n σελιδοδείκτης</numerusform>
+<numerusform>%n σελιδοδείκτες</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Δημιουργία νέας λίστας</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Εισαγωγή σελιδοδεικτών και διαδρομών</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Αδυναμία κοινοποίησης λόγω σφάλματος εφαρμογής</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Σφάλμα κατά την κοινοποίηση</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Δεν είναι δυνατή η κοινή χρήση μιας κενής λίστας</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Το όνομα δεν μπορεί να είναι άδειο</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Εισαγάγετε το όνομα της λίστας</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Νέα λίστα</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Αυτό το όνομα χρησιμοποιείται ήδη</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Επιλέξτε άλλο όνομα</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Παρακαλώ περιμένετε…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Αριθμός τηλεφώνου</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Προφίλ OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Βρέθηκε %n αρχείο. Μπορείτε να το δείτε μετά τη μετατροπή.</numerusform>
+<numerusform>Βρέθηκαν %n αρχεία. Μπορείτε να τα δείτε μετά τη μετατροπή.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Επαναφορά</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ίχνος</numerusform>
+<numerusform>%n ίχνη</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Απόρρητο</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Πολιτική απορρήτου</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Όροι χρήσης</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Κίνηση</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Πεζοπορία</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ποδηλασία</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Μετρό</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Στυλ χάρτη και επίπεδα</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Η λίστα είναι άδεια</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Για να προσθέσετε σελιδοδείκτη, πατήστε ένα μέρος στο χάρτη και μετά πατήστε το αστεράκι</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Αλλαγή χρώματος όλων των σελιδοδεικτών</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Αλλαγή χρώματος όλων των διαδρομών</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…περισσότερα</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Εξαγωγή KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Εξαγωγή GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Εξαγωγή GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Διαγραφή λίστας</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Κάμερες Ταχύτητας</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Περιγραφή μέρους</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Κατέβασμα χαρτών</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Προειδοποιήσεις για υπερβολική ταχύτητα</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Να ειδοποιούμαι πάντα</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Να μην ειδοποιούμαι ποτέ</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Λειτουργία εξοικονόμησης ενέργειας</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Θα γίνεται προσπάθεια εξοικονόμησης ενέργειας εις βάρος κάποιον λειτουργιών.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Ποτέ</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Αυτόματα</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Πάντα</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Ονόματα σελιδοδεικτών στο χάρτη</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Εάν έχετε πάρα πολλούς σελιδοδείκτες, η προβολή των ονομάτων τους στο χάρτη θα κάνει αργή την εφαρμογή.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Εμφάνισε στα δεξιά</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Εμφάνισε στο κάτω μέρος</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Ρυθμίσεις δρομολόγησης</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Αποφυγή διοδίων</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Αποφυγή χωματόδρομων</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Αποφυγή πορθμείων</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Αποφυγή αυτοκινητόδρομων</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Δεν ήταν δυνατός ο υπολογισμός διαδρομής</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Δυστυχώς, δεν μπορούσαμε να δημιουργήσουμε μια διαδρομή με τις καθορισμένες επιλογές. Αλλάξτε τις ρυθμίσεις και δοκιμάστε πάλι.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Ορισμός δρόμων προς αποφυγή</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Ρυθμίσεις δρομολόγησης ενεργοποιημένες</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Δρόμος με διόδια</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Χωματόδρομος</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Πέρασμα πορθμείου</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ναι</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Όχι</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ενεργ.</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Απενεργ.</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Χωρητικότητα: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Δίκτυο: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Μόλις φτάσατε!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Οκ</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ταξινόμηση…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ταξινόμηση σελιδ/κτών</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Προεπιλογή</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Κατά τύπο</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Κατά απόσταση</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Κατά ημερομηνία</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Με όνομα</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Μια βδομάδα πριν</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Ένα μήνα πριν</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Περισσότερο από έναν μήνα πριν</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Περισσότερο από ένα χρόνο πριν</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Δίπλα μου</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Άλλα</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Ο σχεδιασμός διαδρομής απέτυχε</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Άφιξη στις %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Κάντε λήψη και ενημέρωση όλων των χαρτών κατά μήκος της προβαλλόμενης διαδρομής για τον υπολογισμό της.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Έχετε αλλάξει τον παγκόσμιο χάρτη. Μην το κρατάτε για τον εαυτό σας! Πείτε το στους φίλους σας και κάντε αλλαγές μαζί.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Μοιραστείτε το με φίλους</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Κλειστό τώρα</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Ανοίγει αύριο στις %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Ανοίγει %1 στις %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Ανοίγει στις %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Κλείνει στις %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Προσθέστε ώρες λειτουργίας</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Κωδικός πρόσβασης (τουλάχιστον 8 χαρακτήρες)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Μη έγκυρο όνομα χρήστη ή κωδικός πρόσβασης.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Λογαριασμός OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Τελευταία μεταφόρτωση</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Σας ευχαριστούμε</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Όνομα τοποθεσίας</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Τηλέφωνο</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Λάβετε υπόψη</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Σφάλμα λήψης</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Επιλέξτε κατηγορία</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Δημοφιλή</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Όλες οι κατηγορίες</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Προσθέστε νέες τοποθεσίες στο χάρτη, και επεξεργαστείτε τις υπάρχουσες απευθείας από την εφαρμογή.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Αλλαγή τοποθεσίας</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Για να το κατεβάσετε, χρειάζεστε περισσότερο χώρο. Διαγράψτε μη απαραίτητα δεδομένα.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Βελτίωσα τους χάρτες Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Λεπτομερές σχόλιο</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Οι προτεινόμενες αλλαγές θα σταλούν στην Κοινότητα του OpenStreetMap. Περιγράψτε τυχόν πρόσθετα στοιχεία που δεν μπορείτε να επεξεργαστείτε στο Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Παρουσιάστηκε σφάλμα κατά την αναζήτηση της τοποθεσίας σας. Ελέγξτε αν η συσκευή σας λειτουργεί κανονικά και δοκιμάστε ξανά αργότερα.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Οι υπηρεσίες εντοπισμού τοποθεσίας είναι απενεργοποιημένες</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Ενεργοποιήστε την υπηρεσία γεωεντοπισμού στις ρυθμίσεις της συσκευής</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ανοίξτε τις ρυθμίσεις</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Πατήστε τοποθεσία</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Επιλέξτε «Ενώ χρησιμοποιείτε η εφαρμογή»</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Επιλέξτε Απόρρητο</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Επιλέξτε Υπηρεσίες τοποθεσίας</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ενεργοποιήστε τις Υπηρεσίες τοποθεσίας</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ή συνεχίστε να χρησιμοποιείτε το Organic Maps χωρίς Τοποθεσία</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Κράτηση</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Κλήση</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Όνομα αγαπημένου</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Διαγραφή αγαπημένου</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Η σημείωσή σας θα σταλεί στο OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…περισσότερα</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Ενημέρωση</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Θέλετε να απενεργοποιήσετε την καταγραφή της πρόσφατης διαδρομής σας;</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Απενεργοποίηση</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Τσέκαρε</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Το Organic Maps χρησιμοποιεί την τοποθεσία σας στο παρασκήνιο για την καταγραφή των πρόσφατων διαδρομών σας.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Γενικές ρυθμίσεις</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Για να εμφανιστούν πληροφορίες για την κίνηση, πρέπει να γίνει ενημέρωση της εφαρμογής.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Μέγεθος αρχείου καταγραφής: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Σύρετε εδώ για αφαίρεση</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Αντικατάσταση Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Έναρξη από</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Παρακαλούμε συνδεθείτε στο OpenStreetMap για να ανεβάσετε αυτόματα όλες τις επεξεργασίες του χάρτη σας. Μάθετε περισσότερα</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>εδώ</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Απόκρυψη οθόνης</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 από %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Λήψη %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Εφαρμογή %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Αυτό το όνομα είναι πολύ μεγάλο</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Εντοπίστηκαν νέα αρχεία</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Μετατροπή</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Σφάλμα</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Ορισμένα αρχεία δεν μετατράπηκαν.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Συνέβη κάποιο σφάλμα</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Δημοφιλή</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Απόκρυψη από τον χάρτη</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Ένα σφάλμα συνέβη κατά το φόρτωμα των ετικετών, παρακαλώ ξαναπροσπαθήστε</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Δεξιά</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Κάτω μέρος</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Φύγαμε</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Προορισμός</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Κεντράρισμα</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Αποτελέσματα αναζήτησης</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Μετά</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Θα θέλατε να επανυπολογιστεί η διαδρομή;</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Το πληκτρολόγιο δεν είναι διαθέσιμο κατά τη διάρκεια της οδήγησης</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Δεν είναι δυνατή η δημιουργία διαδρομής από την τρέχουσα τοποθεσία σας</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Δεν είναι δυνατή η δημιουργία διαδρομής μέχρι τον προορισμό σας. Επιλέξτε ένα άλλο σημείο</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Δεν υπάρχει σήμα GPS. Μετακινηθείτε σε μια ανοικτή τοποθεσία</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Δεν είναι δυνατή η δημιουργία διαδρομής. Επιλέξτε άλλα σημεία διαδρομής</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Για να δημιουργήσετε μια διαδρομή, κατεβάστε τους χάρτες που λείπουν</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Παρουσιάστηκε σφάλμα. Κάντε επανεκκίνηση της εφαρμογής</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Η διαδρομή θα ξαναδημιουργηθεί από την τρέχουσα τοποθεσία σας</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Η διαδρομή θα μετατραπεί σε διαδρομή με αυτοκίνητο</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Δεν εμφανίζονται όλοι οι σελιδοδείκτες</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Μεταβείτε στο τηλέφωνο για να δείτε όλους τους σελιδοδείκτες</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Κάμερες Ταχύτητας</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Ειδοποιήσεις ταχύτητας</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Κάντε λήψη χαρτών στην εφαρμογή, στη συσκευή σας</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 έξοδος</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ταξινόμηση κατά προεπιλογή</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ταξινόμηση ανά τύπο</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ταξινόμηση κατά απόσταση</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ταξινόμηση κατά ημερομηνία</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ταξινόμηση με βάση το όνομα</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Φαγητό</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Αξιοθέατα</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Μουσεία</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Πάρκα</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Κολύμβηση</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Βουνά</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Ζώα</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Διαμονή</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Κτήρια</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Χρήματα</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Καταστήματα</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Χώροι στάθμευσης</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Πρατήρια βενζίνης</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Φαρμακεία</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Αναζήτηση στη λίστα</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Χώροι Λατρείας</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Επιλογή λίστας</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Η πλοήγηση με μετρό γι&#x27; αυτή την περιοχή δεν είναι ακόμα διαθέσιμη</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Δεν βρέθηκε διαδρομή του μετρό</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Επιλέξτε το σημείο εκκίνησης ή τέλους διαδρομής πιο κοντά στο σταθμό του μετρό</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Υψομετρικά</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Για να χρησιμοποιήσετε υψομετρικές γραμμές, ενημερώστε ή κατεβάστε τον χάρτη της επιθυμητής περιοχής</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Οι υψομετρικές γραμμές δεν είναι ακόμα διαθέσιμες σε αυτή την περιοχή</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ανάβαση</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Κατάβαση</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Ελάχ. υψόμετρο</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Μέγ. υψόμετρο</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Δυσκολία</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Απόστ.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Διάρκ:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Μεγεθύνετε για να δείτε περιγράμματα</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Κατέβασμα</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Κατεβάστε τον παγκόσμιο χάρτη επισκόπησης</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Δεν μπόρεσε να δημιουργηθεί φάκελος και να μεταφερθούν τα αρχεία στην εσωτερική ή εξωτερική μνήμη</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Σφάλμα δίσκου</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Σφάλμα σύνδεσης</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Αποσυνδέστε το καλώδιο USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Να παραμένει η οθόνη ανοιχτή</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Αν ενεργοποιηθεί, η οθόνη θα είναι πάντα αναμμένη όσο εμφανίζεται ο χάρτης.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Εμφάνιση στην Οθόνη Κλειδώματος</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Αν ενεργοποιηθεί, η εφαρμογή θα λειτουργεί και στην Οθόνη Κλειδώματος ακόμα και αν η συσκευή είναι κλειδωμένη.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Γλώσσα χάρτη</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Δεδομένα χάρτη από το OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/el/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/el/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Σας ευχαριστούμε που χρησιμοποιείτε τους χάρτες μας που δημιουργήθηκαν από την κοινότητα!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Με τις δωρεές και την υποστήριξή σας, μπορούμε να δημιουργήσουμε τους καλύτερους χάρτες στον κόσμο!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Σας αρέσει η εφαρμογή μας; Παρακαλούμε κάντε μια δωρεά για να στηρίξετε την ανάπτυξη! Ακόμα δεν σας αρέσει; Ενημερώστε μας και θα το διορθώσουμε!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Εάν γνωρίζετε έναν προγραμματιστή λογισμικού, μπορείτε να του ζητήσετε να υλοποιήσει μια λειτουργία που χρειάζεστε.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Πατήστε οπουδήποτε στο χάρτη για να επιλέξετε οτιδήποτε. Πατήστε παρατεταμένα για να αποκρύψετε και να εμφανίσετε ξανά το περιβάλλον εργασίας.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Γνωρίζετε ότι μπορείτε να επιλέξετε την τρέχουσα τοποθεσία σας στο χάρτη;</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Μπορείτε να βοηθήσετε στη μετάφραση της εφαρμογής μας στη γλώσσα σας.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Η εφαρμογή μας έχει αναπτυχθεί από λίγους θιασώτες και την κοινότητα.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Μπορείτε εύκολα να διορθώσετε και να βελτιώσετε τα δεδομένα χάρτη.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Ο κύριος στόχος μας είναι να δημιουργήσουμε γρήγορους, εύχρηστους και με σεβασμό στην ιδιωτικότητα χάρτες που θα λατρέψετε.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Αυτή τη στιγμή το Organic Maps βρίσκεται στην οθόνη του κινητού</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Αυτή τη στιγμή το Organic Maps βρίσκεται στην οθόνη του αυτοκινήτου</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Είστε συνδεδεμένοι στο Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Συνέχεια στο κινητό</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Στην οθόνη του αυτοκινήτου</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Η εφαρμογή Organic Maps χρειάζεται πρόσβαση στην τοποθεσία. Όταν είναι ασφαλές, ελέγξτε την ειδοποίηση στο τηλέφωνό σας.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Αυτή η εφαρμογή χρειάζεται την άδειά σας</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps στο Android Auto απαιτεί δικαιώματα πρόσβασης στην τοποθεσία για να λειτουργεί αποτελεσματικά</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Να επιτραπεί</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Πεζοπορία</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Δεν είναι διαθέσιμος ο περιηγητής</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Ένταση ήχου</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Εξαγωγή όλων των σελιδοδεικτών και των διαδρομών</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Ρυθμίσεις συστήματος σύνθεσης ομιλίας</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Δεν βρέθηκαν οι ρυθμίσεις σύνθεσης ομιλίας, είστε σίγουροι ότι η συσκευή σας την υποστηρίζει;</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Οδηγώ μέσα από</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Καθαρίστε την αναζήτηση</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Μεγέθυνση</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Σμίκρυνση</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Σύνδεσμος μενού</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Προβολή μενού</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Άνοιγμα σε άλλη εφαρμογή</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Αυτοεξυπηρέτηση</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Επιλέξτε επιλογή</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Εξωτερικά καθίσματα</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Για την πιο ακριβή πλοήγηση, συνιστούμε να απενεργοποιήσετε τη λειτουργία εξοικονόμησης ενέργειας στις ρυθμίσεις μπαταρίας του τηλεφώνου.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Εγγραφή διαδρομής</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Σταματήστε την εγγραφή διαδρομής</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Καταγραφή διαδρομής</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Σταματήστε χωρίς αποθήκευση</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Συνέχεια εγγραφής</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Αποθήκευση στα Αγαπημένα και Διαδρομές;</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Η διαδρομή είναι άδεια - δεν υπάρχει τίποτα να αποθηκεύσετε</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Δεν είναι δυνατή η εμφάνιση του διαλόγου επιλογής φακέλου επειδή δεν είναι εγκατεστημένη η κατάλληλη εφαρμογή στη συσκευή σας. Εγκαταστήστε μια εφαρμογή διαχείρισης αρχείων και δοκιμάστε ξανά.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Επιλέξτε χρώμα</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Επεξεργασία διαδρομής</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Δεν υπάρχει εγκατεστημένη εφαρμογή που να μπορεί να ανοίξει την τοποθεσία</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Αυτόματη πλοήγηση</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Ακολούθησε το σύστημα</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Κοινοποίηση ίχνους</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Διαγραφή %1;</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Επίπεδο δυσκολίας</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Εύκολο</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Μέτριο</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Δύσκολο</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Γίνεται ενημέρωση</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Ενημέρωση κατεβασμένων χαρτών</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Η ενημέρωση των χαρτών διατηρεί τις πληροφορίες των στοιχείων επικαιροποιημένες</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Ενημέρωση (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Χειροκίνητη ενημέρωση αργότερα</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Διαγραφή διαδρομής</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Είστε σίγουροι ότι θέλετε να διαγράψετε αυτό το κομμάτι;</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Όνομα διαδρομής</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Μετακίνηση</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Ίχνος</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Αλλαγή χρώματος</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Χάρτης</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Θα θέλατε να στείλετε μια αναφορά σφάλματος στους προγραμματιστές;
+Βασιζόμαστε στους χρήστες μας, καθώς οι Organic Maps δεν συλλέγουν αυτόματα καμία πληροφορία σφάλματος. Σας ευχαριστούμε εκ των προτέρων για την υποστήριξη των Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Ενεργοποίηση συγχρονισμού iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Ο συγχρονισμός iCloud είναι μια πειραματική λειτουργία υπό ανάπτυξη. Βεβαιωθείτε ότι έχετε δημιουργήσει αντίγραφο ασφαλείας όλων των σελιδοδεικτών και των κομματιών σας.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>Το iCloud είναι απενεργοποιημένο</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ενεργοποιήστε το iCloud στις ρυθμίσεις της συσκευής σας για να χρησιμοποιήσετε αυτή τη λειτουργία.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Ενεργοποίηση</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Δημιουργία αντιγράφων ασφαλείας</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Αποτυχία συγχρονισμού iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Σφάλμα: Αποτυχία συγχρονισμού λόγω σφάλματος σύνδεσης</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Σφάλμα: iCloud: Απέτυχε ο συγχρονισμός λόγω υπέρβασης της ποσόστωσης iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Σφάλμα: Το iCloud δεν είναι διαθέσιμο</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Πρόσφατα διαγραμμένες λίστες</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Εκκαθάριση</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Διαγραφή όλων</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Ανάκτηση</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Ανάκτηση όλων</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Συνεισφέρετε στο OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Προσθήκη τοποθεσίας</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Ενημερώστε τον χάρτη για να συνεισφέρετε</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Πρέπει να ενημερώσετε τον χάρτη %1 στην πιο πρόσφατη έκδοση πριν μπορέσετε να συνεισφέρετε στα δεδομένα του OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Η θέση μου</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Οι τοποθεσίες μου</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Εσωτερικός κρυφός αποθηκευτικός χώρος</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Εσωτερικός κοινός αποθηκευτικός χώρος</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Κάρτα SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Εξωτερικός κοινός αποθηκευτικός χώρος</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Ταχυδρομικός Κώδικας</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Σημείο χάρτη</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>μ</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>χμ</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>μι</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>πόδια</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Για την προβολή των διαδρομών, οι χάρτες πρέπει να είναι ενημερωμένοι.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Έξοδος</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Είσοδος</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Ο χάρτης μετρό δεν είναι διαθέσιμος</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Εσείς</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Μωβ ληφθείσες περιοχές</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Διαδρομή</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Ο εντοπισμός τοποθεσίας στο παρασκήνιο είναι απαραίτητος για να απολαύσετε πλήρως τη λειτουργικότητα της εφαρμογής. Χρησιμοποιείται για πλοήγηση και αποθήκευση του κομματιού που ταξιδέψατε πρόσφατα.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Ο προσδιορισμός της θέσης σας είναι απαραίτητος για την πλοήγηση και για την αποθήκευση της διαδρομής που διανύσατε πρόσφατα.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Σύνδεση με κωδικό πρόσβασης</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Σύνδεση μέσω προγράμματος περιήγησης</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Πρόσφατα χρησιμοποιημένα</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Το χρώμα των σελιδοδεικτών άλλαξε</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Το χρώμα των διαδρομών άλλαξε</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Φάσμα</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Ολισθητήρες</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ΚΟΚΚΙΝΟ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ΠΡΑΣΙΝΟ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Εξάγωνο χρώμα sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Πλέγμα</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/en-GB/omim.ts
+++ b/qt/translations/en-GB/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="en-GB">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometres</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometres</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Petrol</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grey</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Grey</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Light from dawn till dusk</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorised places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article from wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postcode</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid postcode</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows adding simple point categories only, which means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step-by-step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid motorways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-centre</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Petrol Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No metro route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a metro station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postcode</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metro map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently travelled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently travelled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recently Used</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sliders</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RED</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GREEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/en/omim.ts
+++ b/qt/translations/en/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="en">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Light from dawn till dusk</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article from wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recently Used</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sliders</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RED</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GREEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/es-MX/omim.ts
+++ b/qt/translations/es-MX/omim.ts
@@ -1,0 +1,3925 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="es-MX">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Volver</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Borrar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Descargar mapas</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>La descarga ha fallado. Pulse para volver a intentarlo.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Descargando…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilómetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Millas</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Más tarde</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Buscar en</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Mapa de búsqueda</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Actualmente tienes desactivados todos los servicios de localización para este dispositivo o aplicación. Actívalos en Ajustes.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisión limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Para garantizar una navegación precisa, activa Localización precisa en los ajustes.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostrar en el mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>La descarga ha fallado</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Inténtelo de nuevo</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Acerca de Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis para todos, hecho con amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sin anuncios, sin seguimiento, sin recopilación de datos</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No consume batería, funciona sin conexión</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rápido, minimalista, desarrollado por la comunidad</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicación de código abierto creada por entusiastas y voluntarios.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Ajustes de ubicación</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Cerrar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>La aplicación requiere OpenGL acelerado por hardware. Lamentablemente, tu dispositivo no es compatible.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Descargar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Desconecta el cable USB o inserta la tarjeta de memoria para utilizar Organic Maps.</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Por favor, libera espacio en la tarjeta SD/USB para poder utilizar la aplicación.</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Antes de empezar a utilizar la aplicación, descarga el mapa general del mundo en tu dispositivo.&#32;
+Usará %1 de almacenamiento.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ir al mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Descargando %1. Ahora puede proceder al mapa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Descargar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>¿Actualizar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausar</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuar</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 la descarga ha fallado</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Añadir una nueva lista</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nombre de la lista de favoritos</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadores</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Marcadores y pistas</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nombre</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Dirección</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Ajustes</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Guardar mapas en</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Seleccione la carpeta en la que desea descargar los mapas.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapas descargados</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 libre de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>¿Mover mapas?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error al mover archivos de mapas</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Esto puede tardar varios minutos. Por favor, espere…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidades de medida</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Elige entre millas y kilómetros</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancelar descarga</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Deja tu opinión</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Descargar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Listas de favoritos</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Dónde comer</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Comestibles</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gasolinera</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparcamiento</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compras</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Segunda mano</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Visores</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretenimiento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Cajero automático</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida nocturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Vacaciones en familia</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banco</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Aseo</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Oficina de correos</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policía</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclado</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Agua</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Instalaciones para autocaravanas</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notas</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Los favoritos de Organic Maps se han compartido contigo</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hola!
+\Adjunto mis marcadores de la aplicación Organic Maps. Por favor, ábralos si tiene instalado Organic Maps. O, si no lo tiene, descargue la aplicación para su dispositivo iOS o Android siguiendo este enlace: https://omaps.app/get?kmz
+¡Disfrute viajando con Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Cargando favoritos</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>¡Marcadores cargados correctamente! Puedes encontrarlos en el mapa o en la pantalla del Gestor de favoritos.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>La carga de marcadores ha fallado. El archivo puede estar corrupto o ser defectuoso.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>La aplicación no reconoce el tipo de archivo:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Fallo al abrir el archivo %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Su ubicación aún no ha sido determinada</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Lo sentimos, los ajustes de Almacenamiento de Mapas están actualmente desactivados.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>La descarga del mapa está en curso.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Consulta mi ubicación actual en Organic Maps %1 o %2 ¿No tienes mapas offline? Descárguelos aquí: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>¡Eh, mira mi pin en Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Oye, ¡mira mi ubicación actual en el mapa de Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hola, estoy aquí ahora: %1. Haz clic en este enlace %2 o en este otro %3 para ver el lugar en el mapa.
+
+Gracias.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Compartir</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Correo electrónico</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiado al portapapeles: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Hecho</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Datos de OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>¿Estás seguro de que quieres cerrar sesión en tu cuenta de OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Rutas</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Longitud</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Compartir mi ubicación</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Configuración general</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Información</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegación</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botones «+» y «-» en el mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Visualización en el mapa</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estilo nocturno cuando se navega en la oscuridad</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo nocturno</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desactivado</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activado</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automático</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vista en perspectiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edificios 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Los edificios 3D se apagan en el modo de ahorro de energía</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instrucciones de voz</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar los nombres de las calles</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Cuando está activada, el nombre de la calle o de la salida a la que hay que girar se pronuncia en voz alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Lenguaje de voz</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Para descargar una voz de mayor calidad, abre la app Configuración y ve a Accesibilidad → VoiceOver → Voz → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Prueba de instrucciones de voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Verifique el volumen o la configuración de texto a voz del sistema si no escucha la voz ahora.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>No disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automático</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distancia</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver en el mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menú</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Página web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Noticias</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Comentarios</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Valora la aplicación</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ayuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Preguntas frecuentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donar</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ya donado</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Recordar más tarde</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Apoyar Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Apoyar el proyecto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Derechos de autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Informar de un error</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Mejora la dirección de la flecha moviendo el teléfono en forma de ocho para calibrar la brújula.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mueve el teléfono en forma de ocho para calibrar la brújula y fijar la dirección de la flecha en el mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Vuelve a pulsar prolongadamente sobre el mapa para ver la interfaz</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Actualizar todo</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancelar todo</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Descargado</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En cola</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Cerca de mí</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Descargar todo</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Descargar:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Para eliminar el mapa, por favor, detenga la navegación.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Sólo se pueden crear rutas que estén totalmente contenidas en el mapa de una única región.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Descargar el mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Reintentar</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Borrar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Mapa de actualización</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servicios de ubicación de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determine rápidamente su ubicación aproximada mediante Bluetooth, WiFi o red móvil</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Descarga todos los mapas de tu ruta</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Para crear una ruta, necesitamos descargar y actualizar todos los mapas desde tu ubicación hasta tu destino.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Espacio insuficiente</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Activa los servicios de localización</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crear</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rojo</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Amarillo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Morado</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Naranja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marrón</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Púrpura profundo</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Celeste</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cian</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Verde azulado</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Cal</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Naranja intenso</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Azul Gris</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Información</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versión de Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Apariencia</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Luz</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Oscuro</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Claro desde el amanecer hasta el anochecer</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Otros</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>¡Regala mapas gratis y sin anuncios a millones de usuarios!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Informar o corregir datos de mapas incorrectos</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Para ser voluntario</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Síguenos y contáctanos:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>No se ha configurado el cliente de correo electrónico. Por favor, configúrelo o utilice alguna otra forma de ponerse en contacto con nosotros en %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error al enviar correo electrónico</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibración de la brújula</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponible</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Encontrado</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Actualización</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fallido</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>marcador</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Cuando siga la ruta, tenga en cuenta lo siguiente:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Las condiciones de la ruta, las reglas de tráfico y las señales de carretera siempre tienen prioridad sobre las sugerencias de navegación;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— El mapa puede ser impreciso y sugerir una ruta que no siempre puede ser el mejor camino para llegar al destino;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>- Las rutas sugeridas sólo deben entenderse como recomendaciones;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Actúe con cautela en las rutas con zonas fronterizas: las rutas creadas por nuestra aplicación en ocasiones pueden atravesar las fronteras de países en lugares no autorizados;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>¡Manténgase alerta y seguro en las rutas!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Comprobar la señal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>No se ha podido crear la ruta. No se han podido identificar las coordenadas GPS actuales.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifique la señal del GPS. Activar la Wi-Fi mejorará la precisión de su ubicación.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activar los servicios de localización</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>No se pueden localizar las coordenadas GPS actuales. Activa los servicios de localización para calcular la ruta.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>No se puede localizar la ruta</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>No se ha podido crear la ruta.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Por favor, ajuste su punto de partida o destino.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ajustar el punto de partida</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>No se ha creado la ruta. No se ha podido localizar el punto de partida.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Por favor, seleccione un punto de partida más cercano a una carretera.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajustar destino</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>No se ha creado la ruta. No se ha podido localizar el destino.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Seleccione un punto de destino situado más cerca de una carretera.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>No se ha podido localizar el punto intermedio.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Por favor, ajuste su punto intermedio.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Error del sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>No se ha podido crear la ruta debido a un error de la aplicación.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Por favor, inténtelo de nuevo</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ahora no</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>¿Desea descargar el mapa y crear una ruta más óptima que abarque más de un mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Descargue mapas adicionales para crear una ruta mejor que cruce los límites de este mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Descargar los archivos necesarios</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Descargue o actualice todos los mapas a lo largo de la ruta proyectada para calcular una ruta.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Para empezar a buscar y crear rutas, descárgate el mapa. Después ya no necesitarás conexión a Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Seleccionar mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostrar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ocultar</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorías</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historia</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Lo siento, no se han encontrado resultados.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Descargue la región en la que está buscando o pruebe a añadir el nombre de una ciudad o pueblo cercano.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historial de búsqueda</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ver tus búsquedas recientes.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Eliminar el historial de búsqueda</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artículo de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Tu ubicación</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Inicio</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Ruta desde</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Ruta hacia</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navegación sólo está disponible desde tu ubicación actual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>¿Quiere que planeemos una ruta desde su ubicación actual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Siguiente</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>En</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>A</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Añadir horario</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Borrar horario</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Todo el día (24 horas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Abrir</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Añadir horario no comercial</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horario comercial</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modo avanzado</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modo sencillo</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horario no comercial</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Ejemplos de valores</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corregir error</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Seleccione el lugar</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Por favor, describa el problema detalladamente para que la comunidad OpenStreetMap pueda solucionarlo.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>O hazlo tú mismo en https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Enviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Edición</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Este lugar no existe</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Cerrado por mantenimiento</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicar lugar</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Descarga automática de mapas</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diario</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Cerrado hoy</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hoy</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Abre en %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Cierra en %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editar el horario comercial</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>¿No tienes cuenta en OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrarse en OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Iniciar sesión</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>No conectado</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Iniciar sesión en OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Contraseña</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>¿Ha olvidado su contraseña?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Cerrar sesión</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar lugar</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Añadir un idioma</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Calle</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Número de edificio</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalles</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Redes sociales</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edificio</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Añadir una calle</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Introduzca el nombre de la calle</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Elija una lengua</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Elija una calle</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cocina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Seleccionar cocina</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Correo electrónico o nombre de usuario</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Añadir teléfono</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Suelo</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivel: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Todas las ediciones del mapa se eliminarán con él.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Actualizar mapas</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Para crear una ruta, es necesario actualizar todos los mapas y volver a planificar la ruta.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Buscar en el mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Asegúrate de que tu dispositivo está conectado a Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Espacio insuficiente</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Por favor, elimine los datos innecesarios</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Error de inicio de sesión.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Cambios verificados</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arrastre el mapa para colocar la cruz en la ubicación del lugar o negocio.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Edición de</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Añadir</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nombre del lugar</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Como está escrito en el idioma local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoría</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descripción detallada del problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Problema diferente</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Añadir empresa</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ningún objeto puede ser localizado aquí</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Datos de OpenStreetMap creados por la comunidad a fecha de %1. Obtenga más información sobre cómo editar y actualizar el mapa en OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) es un proyecto comunitario para construir un mapa libre y abierto. Es la principal fuente de datos cartográficos de Organic Maps y funciona de forma similar a Wikipedia. Puedes añadir o editar lugares y se ponen a disposición de millones de usuarios de todo el mundo.\N¡Únete a la comunidad y ayuda a hacer un mapa mejor para todos!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Crea una cuenta OpenStreetMap o inicia sesión para publicar tus ediciones de mapas en todo el mundo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>¿Descargar a través de una conexión de red celular?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Esto podría resultar considerablemente caro con algunos planes o en caso de itinerancia.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introduzca un número de edificio válido</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Número de plantas (máximo de %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>El número de plantas no debe superar %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introduzca el código postal correcto</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota para los voluntarios de OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errores en el mapa o cosas que no se pueden editar con Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Sus ediciones se cargan en la base de datos pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Por favor, no añadas información personal o protegida por derechos de autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Más información sobre OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Tu historial de edición</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Sus notas de datos cartográficos</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>¿No encuentra una categoría adecuada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps permite añadir únicamente categorías de puntos sencillos, es decir, no ciudades, carreteras, lagos, contornos de edificios, etc. Por favor, añada dichas categorías directamente a &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte nuestra &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guía&lt;/a&gt; para obtener instrucciones detalladas paso a paso.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>No has descargado ningún mapa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Descarga mapas para buscar y navegar sin conexión.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>La ubicación actual es desconocida.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Más</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notas personales (texto o html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>¿Descartar todos los cambios locales?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Descartar</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>¿Borrar lugar añadido?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Borrar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>El lugar no existe</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Indique el motivo de la supresión de la plaza</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introduzca un número de teléfono correcto</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Introduzca una dirección web válida</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Introduzca un email válido</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introduce una dirección web, una cuenta o un nombre de página de Facebook válidos</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introduce un nombre de usuario o una dirección web de Instagram válidos</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introduzca un nombre de usuario válido de Twitter o una dirección web</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introduce un nombre de usuario de VK o una dirección web válidos</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introduzca un LINE ID o una dirección web válidos</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Agregar lugar a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>O, como alternativa, deja una nota a la comunidad OpenStreetMap para que otra persona pueda añadir o arreglar un lugar aquí.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>La nota se enviará a OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>¿Quieres enviarlo a todos los usuarios?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Asegúrate de que no has introducido ningún dato personal.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Los editores de OpenStreetMap comprobarán los cambios y se pondrán en contacto contigo si tienen alguna duda.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Detener</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Grabación de la pista</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Acepte</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Disminución</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>¿Utilizar Internet móvil para mostrar información detallada?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Utilizar siempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Sólo hoy</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>No utilizar hoy</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet móvil</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Se necesita Internet móvil para las notificaciones de actualización de mapas y para cargar ediciones.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>No usar nunca</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Pregunte siempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Para mostrar los datos de tráfico, los mapas deben estar actualizados.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumentar el tamaño de las etiquetas de los mapas</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Por favor, actualice Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>No se dispone de datos de tráfico</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activar el registro</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Comentarios generales</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Utilizamos el sistema TTS para las instrucciones de voz. Muchos dispositivos Android utilizan Google TTS, puedes descargarlo o actualizarlo desde Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Para algunos idiomas, tendrá que instalar un sintetizador de voz o un paquete de idioma adicional de la tienda de aplicaciones (Google Play, Galaxy Store, App Gallery, FDroid).
+Abra los ajustes de su dispositivo → Idioma y entrada → Voz → Salida de texto a voz.\NAquí puede gestionar los ajustes para la síntesis de voz (por ejemplo, descargar el paquete de idioma para su uso sin conexión) y seleccionar otro motor de texto a voz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Para más información, consulte esta guía.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterar al alfabeto latino</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Más información</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilice la búsqueda, seleccione un marcador o pulse en el mapa para añadir un punto de partida de la ruta</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utilice la búsqueda, seleccione un marcador o pulse en el mapa para añadir un punto de destino.</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Administrar ruta</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planificar</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Quitar Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Añadir tope</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Guardado</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Inicie sesión en OpenStreetMap para cargar automáticamente todas las ediciones de su mapa. Obtenga más información &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aquí&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema de acceso al almacenamiento</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>El almacenamiento externo no está disponible. Es posible que se haya quitado o dañado la tarjeta SD, o que el sistema de archivos solo permita la lectura. Revíselo y escríbanos a support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emular el almacenamiento dañado</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Introduzca un nombre correcto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listas</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ocultar todo</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Mostrar todo</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcador</numerusform>
+<numerusform>%n marcadores</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Crear lista nueva</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar marcadores y pistas</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>No se puede compartir debido a un error de la aplicación</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Error de compartición</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>No se puede compartir una lista vacía</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>El nombre no puede estar vacío</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Escriba el nombre</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nueva lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Este nombre ya está en uso</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Por favor elige otro nombre</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Por favor, espere…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de teléfono</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil de OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Se encontró %n archivo. Lo verás después de la conversión.</numerusform>
+<numerusform>Se encontraron %n archivos. Los verás después de la conversión.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurar</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trayecto</numerusform>
+<numerusform>%n trayectos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidad</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Política de Privacidad</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Términos de uso</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráfico</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Senderismo</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos de mapa y capas</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta lista está vacía</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Para añadir un marcador, toque un lugar en el mapa y después toque el ícono de estrella</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Cambiar el color de todos los marcadores</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Cambiar el color de todos los trayectos</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…más</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Borrar lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radares de tráfico</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descripción de lugares</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Descargador de mapas</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avisar al exceder velocidad límite</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Siempre dar aviso</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nunca dar aviso</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modo de ahorro de energía</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Si el modo de ahorro de energía está activado, la aplicación desactivará las funciones de ahorro de energía, en función de la carga actual del teléfono</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automático</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Siempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nombres de favoritos en el mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Si hay demasiados marcadores, mostrar sus nombres en el mapa puede ralentizar la aplicación.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostrar a la derecha</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostrar en la parte inferior</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Activa esta opción temporalmente para grabar y enviarnos manualmente registros de diagnóstico detallados sobre tu problema mediante &quot;Informar de un error&quot; en el cuadro de diálogo Ayuda. Los registros pueden incluir información de ubicación.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opciones de enrutamiento</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evite los peajes</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evitar vías sin pavimentar</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evite los transbordadores</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evite las autopistas</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>No se puede construir una ruta</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>No se ha podido encontrar una ruta. Esto puede deberse a sus opciones de ruta o a datos incompletos de OpenStreetMap. Cambia tus opciones de ruta y vuelve a intentarlo.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definir las carreteras que deben evitarse</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opciones de enrutamiento activadas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Autopista de peaje</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Carretera sin asfaltar</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Travesía en transbordador</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidad: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Red: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>¡Ya llegó!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenar…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordenar favoritos</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Por defecto</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Por tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Por distancia</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Por fecha</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Por nombre</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Hace una semana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Hace un mes</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Hace más de un mes</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Hace más de un año</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Cerca a mí</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Otros</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Planificación de ruta fallida</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Llegada al %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Descarga y actualiza todos los mapas a lo largo de la ruta proyectada para calcular la ruta.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>¡Has cambiado el mapa del mundo! No te lo guardes para ti; díselo a tus amigos y editalo juntos.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Comparte con tus amigos</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Cerrado</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Abre mañana en %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Abre %1 en %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Abre en %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Cierra en %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Añadir horario de apertura</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Contraseña (8 caracteres como mínimo)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nombre de usuario o contraseña no válidos.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Cuenta OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Última subida</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Gracias</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nombre del lugar</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Teléfono</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Atención</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Error de descarga</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Seleccionar categoría</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Todas las categorías</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Añade nuevos lugares al mapa y edita los existentes directamente desde la aplicación.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Cambiar ubicación</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Para descargar, necesitas más espacio. Por favor, elimine los datos innecesarios.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>He mejorado los mapas de Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentario detallado</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Los cambios sugeridos en el mapa se enviarán a la comunidad OpenStreetMap. Por favor, describa cualquier detalle adicional que no pueda ser editado en Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Se ha producido un error al determinar tu ubicación. Comprueba que tu dispositivo funciona correctamente y vuelve a intentarlo más tarde.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>La identificación de la ubicación está desactivada</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Activar el acceso a la geolocalización en los ajustes del dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Abrir Ajustes</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Toque Ubicación</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Seleccione Mientras usa la aplicación</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Seleccione Privacidad</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Seleccione Servicios de ubicación</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Activar los servicios de localización</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>O continuar usando Organic Maps sin Ubicación</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reserve</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Llame a</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nombre del marcador</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Borrar marcador</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Tu nota se enviará a OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…más</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Actualización</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>¿Desactivar la grabación de su ruta recientemente recorrida?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desactivar</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Echa un vistazo</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps usa su geolocalización en segundo plano para registrar su ruta recorrida recientemente.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Configuración general</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Para visualizar los datos de tráfico, es necesario actualizar la aplicación.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Tamaño del archivo de registro: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arrastre aquí para eliminar</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Sustituir Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Empezar por</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Inicie sesión en OpenStreetMap para cargar automáticamente todas las ediciones de su mapa. Obtenga más información</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aquí</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ocultar pantalla</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Descargando %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Aplicando %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Este nombre es demasiado largo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Se detectaron archivos nuevos</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convertir</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Algunos archivos no se convirtieron.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Ocurrió un error</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ocultar del mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Ocurrió un error al cargar las etiquetas, por favor intente de nuevo</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Derecha</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Fondo</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Vámonos.</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Objetivo</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Vuelva a centrar</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultados de la búsqueda</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Entonces</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>¿Quieres reconstruir la ruta?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>El teclado no está disponible durante la conducción</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>No se puede construir una ruta desde la ubicación actual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>No se puede construir una ruta hasta el punto final. Seleccione otra</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No hay señal de GPS. Vaya a una zona abierta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>No se puede construir una ruta. Seleccione otros puntos de ruta</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Al construir ruta, descargue los mapas ausentes en su dispositivo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Se ha producido un error. Por favor, reinicie la aplicación</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>La ruta se reconstruirá a partir de tu posición actual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>La ruta se cambiará a en auto</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>No se muestran todos los marcadores</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Cambia al teléfono para ver todos los favoritos</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Cám.velocidad.</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Alerta velocidad.</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Descargue mapas en la aplicación Organic Maps en su dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 salida</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenar por defecto</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordenar por tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenar por distancia</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenar por fecha</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordenar por nombre</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Alimentación</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Visores</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museos</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Nadar</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montañas</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animales</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteles</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edificios</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dinero</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Comercio</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Aparcamientos</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gasolinería</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Buscar en la lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Sitios religiosos</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Seleccionar lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navegación por metro aún no disponible en esta región</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No se ha encontrado ninguna ruta de metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Por favor, elija un punto de inicio o final más cercano a una estación de metro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Líneas de contorno</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Para usar la altitud de relieve, actualice o descargue el mapa del área deseada</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>La altitud de relieve no está aún disponible en esta región</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascenso</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descenso</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevación mínima</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevación máxima</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultad</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distancia:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Lapso:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom para explorar isolíneas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Cargando</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Descargar el mapamundi</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>No se pueden crear carpetas ni mover archivos en la memoria interna del dispositivo o en la tarjeta SD.</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Error de disco</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Fallo de conexión</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desconectar el cable USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mantener la pantalla encendida</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Cuando está activada, la pantalla siempre estará encendida al visualizar el mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostrar en la pantalla de bloqueo</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Si está activada, la aplicación funcionará en la pantalla de bloqueo aunque el dispositivo esté bloqueado.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Idioma del mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Datos cartográficos de OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/es/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/es/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Gracias por utilizar nuestros mapas comunitarios.</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Con sus donaciones y su apoyo, ¡podremos crear los mejores mapas del mundo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>¿Le gusta nuestra aplicación? ¡Por favor done para apoyar su desarrollo! ¿Todavía no le gusta? ¡Díganos por qué y lo arreglaremos!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Si conoces a un desarrollador de software, puedes pedirle que implemente una función que necesites.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Pulse en cualquier lugar del mapa para seleccionar cualquier cosa. Un toque prolongado sirve para ocultar y mostrar la interfaz.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>¿Sabías que puedes seleccionar tu ubicación actual en el mapa?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Puedes ayudar a traducir nuestra aplicación a tu idioma.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Nuestra aplicación ha sido desarrollada por unos cuantos entusiastas y la comunidad.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Puedes corregir y mejorar fácilmente los datos del mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Nuestro principal objetivo es construir mapas rápidos, respetuosos con la privacidad y fáciles de usar que te encanten.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Ahora estás utilizando Organic Maps en la pantalla del teléfono</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ahora usa Organic Maps en la pantalla del automóvil</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Estás conectado a Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continuar en el teléfono</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>A la pantalla del auto</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps necesita acceder a la ubicación. Cuando sea seguro, revise la notificación en el teléfono.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Esta aplicación necesita tu permiso</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps en Android Auto necesita un permiso de ubicación para funcionar de manera eficaz</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Conceder permisos</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Senderismo</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>El navegador web no está disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volumen</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportar todos los marcadores y pistas</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Ajustes del sistema de síntesis de voz</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>No se ha encontrado la configuración de la síntesis de voz, ¿estás seguro de que tu dispositivo la admite?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servicio al auto</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Borrar la búsqueda</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Ampliar</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Alejar</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menú Enlace</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ver el menú</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir en otra aplicación</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoservicio</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Seleccionar opción</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Asientos al aire libre</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Para una navegación más precisa, recomendamos desactivar el modo de ahorro de energía en los ajustes de la batería del teléfono.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Grabar trayecto</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Detener grabación de pista</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Grabación de pistas</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Parar sin ahorrar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Seguir grabando</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>¿Guardar en marcadores y pistas?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>La pista está vacía - no hay nada que guardar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>No se puede mostrar el diálogo de selección de carpetas porque no hay ninguna aplicación adecuada instalada en el dispositivo. Instala una aplicación de gestión de archivos e inténtalo de nuevo.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Elegir color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar pista</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No hay ninguna aplicación instalada que pueda abrir la ubicación</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto en navegación</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Seguir el sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Compartir pista</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>¿Borrar %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivel de dificultad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderado</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Duro</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Actualización</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Debe actualizar sus mapas descargados</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Actualizar los mapas mantiene actualizada también la información acerca de los objetos</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Actualizar (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Actualizar después manualmente</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Borrar ruta</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>¿Seguro que quieres borrar esta pista?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nombre de la ruta</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mover</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Ruta</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Cambiar color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>¿Desea enviar un informe de error a los desarrolladores? Confiamos en nuestros usuarios, ya que Organic Maps no recoge ninguna información de error automáticamente. ¡Gracias de antemano por apoyar a Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activar la sincronización con iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La sincronización de iCloud es una función experimental en desarrollo. Asegúrese de haber realizado un respaldo de todos sus marcadores y trayectos.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud está desactivado</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Activa iCloud en los ajustes de tu dispositivo para utilizar esta función.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activar</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Respaldo</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Fallo de sincronización de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: No se ha podido sincronizar debido a un error de conexión</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: No se ha podido sincronizar porque se ha superado la cuota de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud no está disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listas eliminadas recientemente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Claro</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Borrar todo</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar todo</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuir a OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Agregar lugar</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Actualiza el mapa para contribuir</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Debe actualizar el mapa %1 a la última versión antes de poder contribuir a los datos de OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mi posición</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mis lugares</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Almacenamiento privado interno</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Almacenamiento interno compartido</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Tarjeta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Almacenamiento externo compartido</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punto del mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>pie</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Para mostrar las rutas, los mapas deben estar actualizados.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Salida</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>El mapa del metro no está disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Usted</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiones descargadas en morado</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ruta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detectar la ubicación en segundo plano es necesario para disfrutar plenamente de la funcionalidad de la aplicación. Se utiliza para la navegación y para guardar la ruta recorrida recientemente.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determinar su ubicación es necesario para la navegación y para guardar la ruta recorrida recientemente.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Iniciar sesión con contraseña</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Iniciar sesión utilizando el navegador</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recientes</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Color de los marcadores cambiado</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Color de los trayectos cambiado</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Deslizadores</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROJO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>AZUL</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Color hexadecimal sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Cuadrícula</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/es/omim.ts
+++ b/qt/translations/es/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="es">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Atrás</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Descargar mapas</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Error durante la descarga. Toque para intentarlo de nuevo.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Descargando…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilómetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Millas</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Luego</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Buscar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Buscar en el mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>No se puede acceder a los servicios de localización en este dispositivo o aplicación. Actívelos en la configuración.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisión limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Para garantizar una navegación más exacta, active la Precisión de la ubicación en los ajustes.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostrar en el mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Error durante la descarga</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Intentar otra vez</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Acerca de Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis para todos, hecho con amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sin anuncios, sin rastreo, sin recopilación de datos</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Consumo de batería mínimo, funciona sin conexión</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rápido, minimalista, desarrollado por la comunidad</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicación de código abierto creada por entusiastas y voluntarios.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Configuración de ubicación</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Cerrar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>La aplicación requiere OpenGL acelerado por hardware. Lamentablemente, su dispositivo no es compatible.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Descargar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Desconecte el cable USB o inserte una tarjeta de memoria SD para usar Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Libere espacio en la memoria SD o almacenamiento USB para usar la aplicación</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Antes de comenzar, permita que descarguemos en su dispositivo un mapamundi general.
+Se requieren %1 de almacenamiento.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ir al mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Descargando %1. Puedes ahora
+proceder al mapa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>¿Descargar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>¿Actualizar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausar</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuar</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>No se pudo descargar %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Agregar un grupo nuevo</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nombre del grupo de marcadores</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadores</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Marcadores y trayectos</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nombre</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Dirección</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Configuración</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Guardar mapas en</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Seleccione la carpeta donde deben descargarse los mapas.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapas descargados</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 libres de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>¿Mover mapas?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error al mover los archivos de mapas</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Esto podría tardar varios minutos.
+Por favor espera…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidades de medida</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Elija entre millas y kilómetros</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancelar descarga</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Escribir reseña</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Descargar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Grupos de marcadores</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Dónde comer</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Provisiones</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gasolinera</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparcamiento</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compras</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Segunda mano</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Turismo</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretenimiento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Cajero automático</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida nocturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Ocio en familia</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banco</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Baño</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Oficina de correos</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policía</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclaje</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Agua</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Caravanas</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notas</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Marcadores de Organic Maps compartidos con usted</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>¡Hola!
+
+Adjunto mis marcadores; ábralos en Organic Maps. Si no lo ha instalado, puede descargarlo aquí: https://omaps.app/get?kmz
+
+¡Disfrute viajando con Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Cargando marcadores</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>¡Los marcadores se han cargado con éxito! Puede encontrarlos en el mapa o en la pantalla de Gestión de marcadores.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>No se pudieron cargar los marcadores. El archivo podría tener daños o defectos.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>La aplicación no reconoce el tipo de archivo:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>No se ha podido abrir el archivo %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Aún no se ha determinado su ubicación</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Lo sentimos, la configuración del almacenamiento de mapas está desactivada.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>La descarga del mapa está en curso.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>¡Mire mi ubicación actual en Organic Maps! %1 o %2 ¿No tiene mapas offline? Descárguelos aquí: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>¡Mira mi marcador en el mapa de Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>¡Mira mi ubicación actual en el mapa en Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hola:
+
+Ahora estoy aquí: %1. Haz clic en este enlace %2 o esta %3 para verlo en el mapa.
+
+Gracias.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Compartir</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Correo</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiado en el portapapeles: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Hecho</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Datos de OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>¿Quiere salir de su cuenta de OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trayectos</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Longitud</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Compartir mi ubicación</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Configuración general</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Información</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegación</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botones «+» y «-» en el mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Visualización en la pantalla</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estilo nocturno al navegar en la oscuridad</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo nocturno</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desactivado</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activado</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automático</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vista en perspectiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edificios en 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Los edificios 3D se desactivan en el modo de ahorro de energía</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instrucciones de voz</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar nombres de calles</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Cuando se activa, el nombre de la calle o la salida para girar se pronunciará en voz alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Idioma de voz</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Para descargar una voz de mayor calidad, abre la app Ajustes y ve a Accesibilidad → VoiceOver → Voz → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Probar indicaciones de voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Compruebe el volumen o la configuración de texto a voz del sistema si ahora no oye la voz.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>No disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automático</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distancia</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver en el mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menú</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Sitio web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Noticias</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Comentarios</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Valore la aplicación</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ayuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Preguntas frecuentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donar</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ya he donado</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Recordar más tarde</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Apoyar Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Apoye el proyecto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Derechos de autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Informar de un fallo</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Mejore la dirección de la flecha moviendo el teléfono en forma de ocho para calibrar la brújula.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mueva el teléfono en forma de ocho para calibrar la brújula y fijar la dirección de la flecha en el mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Vuelva a pulsar prolongadamente sobre el mapa para ver la interfaz</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Actualizar todos</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancelar todo</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Descargado</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En cola</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Cerca de mí</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Descargar todos</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Descargando:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Para eliminar el mapa, detenga la navegación.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Sólo se pueden crear rutas que estén totalmente contenidas en un mapa de una sola región.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Descargar mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Reintentar</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Eliminar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Actualizar mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servicios de localización de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determina rápidamente su ubicación aproximada mediante Bluetooth, WiFi o red móvil</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Descargue todos los mapas de su ruta</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Para crear una ruta es necesario descargar y actualizar todos los mapas desde su ubicación a su destino.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>No hay suficiente espacio</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Active los servicios de localización</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crear</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rojo</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Amarillo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Morado</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Naranja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marrón</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Morado oscuro</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Azul Claro</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cian</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Verde azulado</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Naranja oscuro</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris azulado</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Información</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versión de Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspecto</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Claro</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Oscuro</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Claro desde el amanecer hasta el anochecer</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Otro</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>¡Regala mapas gratis y sin anuncios a millones de usuarios!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Informar o corregir datos de mapa incorrectos</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Voluntariado</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Síganos y póngase en contacto con nosotros:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>No se ha configurado el cliente de correo electrónico. Configúrelo o contáctenos en %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error de envío de correo</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibración de la brújula</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponible</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Encontrado</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Actualizar</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fallo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>marcador</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Al seguir la ruta, tenga en cuenta:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Las condiciones del camino, las reglas de tránsito y los señalamientos siempre tienen prioridad sobre las sugerencias de navegación;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— El mapa puede ser impreciso y sugerir una ruta que no siempre puede ser el mejor camino para llegar al destino;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Las rutas sugeridas deben entenderse solo como recomendaciones;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Actúe con cautela en las rutas con zonas fronterizas: las rutas creadas por nuestra aplicación en ocasiones pueden atravesar las fronteras de países en lugares no autorizados.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>¡Manténgase alerta y a salvo durante el viaje!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Verificar la señal del GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>No se puede crear la ruta. No se pudieron identificar las coordenadas actuales del GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifique la señal del GPS. Activar la wifi mejorará la precisión de su ubicación.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activar servicios de ubicación</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>No se pueden encontrar las coordenadas del GPS. Active los servicios de ubicación para calcular la ruta.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Imposible de encontrar una ruta</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>No se puede crear la ruta.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ajuste su punto de inicio o su destino.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ajustar el punto de inicio</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>La ruta no se creó. No se pudo encontrar el punto de inicio.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Seleccione un punto de inicio cercano a una carretera.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajustar destino</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>La ruta no se creó. No se pudo encontrar el destino.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Seleccione un punto de destino cercano a una carretera.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>No se ha podido ubicar la parada intermedia.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Ajuste la parada intermedia.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Error del sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>No se pudo crear la ruta debido a un error en la aplicación.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Intentar nuevamente</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>No ahora</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>¿Desea descargar el mapa y crear una ruta mejor que abarque más de un mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Descargue mapas adicionales para crear una ruta mejor que cruce los límites de este mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Descargar archivos requeridos</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Descargue y actualice toda la información de mapas y rutas junto con el trayecto proyectado para calcular la ruta.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Para empezar a buscar y crear rutas, descargue el mapa. Después de eso, ya no necesitará una conexión a Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Seleccionar mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostrar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ocultar</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorías</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historial</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>No se encontró ningún resultado.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Descargue la región en la que está buscando o pruebe a añadir el nombre de una ciudad/pueblo cercano.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historial de búsquedas</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ver búsquedas recientes.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Vaciar historial de búsquedas</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artículo de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Su ubicación</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Empezar</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Ruta desde</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Ruta hacia</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navegación solo está disponible desde su ubicación actual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>¿Quiere planificar un itinerario desde su ubicación actual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Siguiente</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>A</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Añadir horario</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Eliminar horario</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Todo el día (24 horas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Abierto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Añadir horas de cierre</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horario de apertura</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modo avanzado</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modo sencillo</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horas de cierre</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valores de ejemplo</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corregir error</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Seleccione la ubicación</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Describa el problema en detalle para que la comunidad de OpenStreetMap pueda corregir el error.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>O hágalo usted mismo en https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Enviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>El lugar no existe</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Cerrado por mantenimiento</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lugar duplicado</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Descarga automática</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diario</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Cerrado hoy</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hoy</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Abre en %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Cierra en %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Cerrado</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editar los horarios de apertura</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>¿No tiene cuenta en OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrarse en OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Acceder</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>No se ha iniciado sesión</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Acceder a OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Contraseña</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>¿Ha olvidado su contraseña?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Cerrar sesión</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar el lugar</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Añadir un idioma</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Calle</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Número de casa</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalles</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Redes sociales</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edificio</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Añadir una calle</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Ingrese un nombre de calle</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Elegir un idioma</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Elija una calle</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cocina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Seleccionar cocina</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Correo electrónico o usuario</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Añadir teléfono</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Piso</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivel: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Todas las ediciones hechas al mapa se eliminarán junto con este.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Actualizar mapas</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Para crear una ruta, es necesario actualizar todos los mapas y volver a planificar la ruta.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Buscar en el mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Revise la configuración y asegúrese de que su dispositivo esté conectado a Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>No hay suficiente espacio</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Elimine los datos innecesarios</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Error de inicio de sesión.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Cambios verificados</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arrastre el mapa para colocar la cruz en la ubicación del lugar o negocio.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Añadir</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nombre del lugar</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Como está escrito en la lengua local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoría</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descripción detallada del problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Un problema diferente</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Añadir organización</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No se puede ubicar ningún objeto aquí</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Datos de OpenStreetMap creados por la comunidad a fecha de %1. Más información sobre cómo editar y actualizar el mapa en OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) es un proyecto comunitario para construir un mapa gratis y abierto. Es la principal fuente de datos cartográficos de Organic Maps y funciona de forma similar a Wikipedia. Puedes añadir o editar lugares y estos pasan a estar disponibles para millones de usuarios de todo el mundo.
+¡Únete a la comunidad y ayuda a crear un mejor mapa para todos!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Cree una cuenta OpenStreetMap o inicie sesión para publicar sus ediciones de mapas en todo el mundo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>¿Descargar con conexión de red móvil?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Podría ser muy caro con ciertos planes o con itinerancia de datos.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introducir el número de domicilio correcto</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Número de plantas (máx. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>El número de plantas no debe superar %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introduzca un código postal válido</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota para los voluntarios de OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describa los errores en el mapa o las cosas que no se pueden editar con Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Sus ediciones se cargan en la base de datos pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. No añada información personal o protegida por derechos de autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Más acerca de OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Su historial de ediciones</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Mis notas de datos cartográficos</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>¿No halla una categoría adecuada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps permite añadir únicamente categorías de puntos sencillos, es decir, no ciudades, carreteras, lagos, contornos de edificios, etc. Añada dichas categorías directamente a &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte nuestra &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guía&lt;/a&gt; para obtener instrucciones detalladas paso a paso.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>No ha descargado ningún mapa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Descargue mapas para encontrar la ubicación y navegar sin conexión.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Se desconoce la ubicación actual.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Más</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notas personales (texto o html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentario…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>¿Restablecer todos los cambios locales?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Restablecer</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>¿Eliminar el lugar añadido?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>El lugar no existe</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Indique la razón para eliminar el lugar</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introduzca un número de teléfono válido</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Introduzca una dirección web válida</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Introduzca un correo válido</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introduzca una dirección web, una cuenta o un nombre de página de Facebook válidos</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introduzca una dirección web o un nombre de cuenta de Instagram válidos</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introduzca una dirección web o un nombre de usuario válido de Twitter</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introduzca una dirección web o un nombre de cuenta de VK válidos</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introduzca una dirección web o ID de LINE válidos</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Añadir lugar a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>O bien, deje una nota a la comunidad de OpenStreetMap para que otra persona pueda añadir o corregir un lugar.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>La nota se enviará a OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>¿Quiere enviarlo a todos los usuarios?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Cerciórese de que no ha introducido ningún dato privado o personal.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Los editores de OpenStreetMap comprobarán los cambios y se pondrán en contacto con usted si tienen alguna pregunta.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Detener</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Grabando el trayecto</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aceptar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Declinar</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>¿Usar Internet móvil para mostrar información detallada?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usar siempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Solo hoy</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>No usar hoy</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet móvil</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Se necesita Internet móvil para mostrar información detallada de los lugares, como fotografías, precios y reseñas.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>No usar nunca</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Preguntar siempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Para mostrar los datos de tráfico, deben actualizarse los mapas.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumentar tamaño del texto en el mapa</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Actualice Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Los datos de tráfico no están disponibles</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activar registros</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Opinión general</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Utilizamos el sistema TTS para las instrucciones de voz. Muchos dispositivos de Android usan Google TTS. Puede descargar o actualizarlo desde Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Para algunos idiomas, debe instalar otro sintetizador de voz o un paquete de idioma adicional desde la tienda de aplicaciones (Google Play, Galaxy Store, App Gallery, FDroid).
+Abre los Ajustes de tu dispositivo → Idioma y entrada → Voz → Salida de texto a voz.
+Aquí puedes administrar la configuración de síntesis de voz (por ejemplo, descargar un paquete de idioma para poder usarlo sin conexión) o seleccionar otro motor de texto a voz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Para obtener más información, consulte esta guía.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteración al alfabeto latino</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Conocer más</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utiliza búsqueda, selecciona un marcador, o toca en el mapa para añadir el origen de la ruta</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utiliza búsqueda, selecciona un marcador, o toca en el mapa para añadir un destino</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gestionar ruta</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planificar</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Eliminar parada</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Añadir parada</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Guardado</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Acceda a OpenStreetMap para cargar automáticamente todas sus ediciones al mapa. Más información &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aquí&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema de acceso al almacenamiento</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>El almacenamiento externo no está disponible; puede que se haya quitado o dañado la tarjeta SD, o el sistema de archivos solo permite lectura. Compruébelo o escríbanos a support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emular almacenamiento dañado</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Introduzca el nombre correcto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listas</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ocultar todo</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Mostrar todo</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcador</numerusform>
+<numerusform>%n marcadores</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Crear nueva lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar marcadores y trayectos</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>No se puede compartir debido a un error de la aplicación</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Error al compartir</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>No se puede compartir una lista vacía</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>El nombre no puede quedar vacío</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Proporcione el nombre de la lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Lista nueva</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Este nombre ya existe</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Elija otro nombre</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Espere…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de teléfono</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil de OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Se encontró %n archivo. Lo verá después de la conversión.</numerusform>
+<numerusform>Se han encontrado %n archivos. Los verá después de la conversión.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurar</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trayectos</numerusform>
+<numerusform>%n trayectos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidad</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Normativa de privacidad</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Condiciones de uso</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráfico</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Senderismo</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos y capas del mapa</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta lista está vacía</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Para agregar un marcador, toque un lugar en el mapa y después toque el icono de la estrella</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Cambiar el color de todos los marcadores</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Cambiar el color de todos los trayectos</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…más</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Eliminar lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Cámaras de velocidad</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descripción del lugar</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Descargar mapas</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Alertar al exceder velocidad límite</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Alertar siempre</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>No alertar nunca</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modo de ahorro de energía</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Se tratará de reducir el consumo de energía a expensas de ciertas funcionalidades.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Cuando queda poca energía</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Siempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nombres de marcadores en el mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Si hay demasiados marcadores, mostrar sus nombres en el mapa puede ralentizar la aplicación.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostrar a la derecha</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostrar en el fondo</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Active esta opción temporalmente para grabar y enviar de forma manual registros para diagnosticar defectos enviados mediante la opción «Informar de un fallo» en el diálogo Ayuda. Los registros pueden incluir ubicaciones.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opciones de enrutamiento</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evitar peajes</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evitar caminos sin pavimentar</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evitar ferris</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evitar autopistas</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>No se puede calcular la ruta</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>No se pudo encontrar una ruta. Quizá se deba a las opciones de enrutamiento o a datos faltantes en OpenStreetMap. Revise sus opciones de enrutamiento y vuelva a intentarlo.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Defina los caminos para evitar</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opciones de enrutamiento activadas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Carretera de peaje</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Camino sin pavimentar</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Cruce de ferri</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sí</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidad: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Red: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>¡Ha llegado!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Aceptar</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenar…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordenar marcadores</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Por defecto</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Por tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Por distancia</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Por fecha</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Por nombre</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Hace una semana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Hace un mes</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Hace más de un mes</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Hace más de un año</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Cerca de mí</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Otros</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Error al planificar la ruta</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Llegada: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Descargue y actualice todos los mapas a lo largo del camino proyectado para calcular la ruta.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Ha cambiado el mapa del mundo. ¡No se lo guarde para usted! Dígaselo a sus amigos y edítenlo juntos.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Compartir con amigos</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Cerrado ahora</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Abre mañana a las %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Abre el %1 a las %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Abre a las %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Cierra a las %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Añadir horarios de apertura</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Contraseña (mínimo 8 caracteres)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Usuario o contraseña incorrectos.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Cuenta OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Última carga</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Gracias</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nombre del lugar</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Teléfono</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Atención</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Error de descarga</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Seleccionar categoría</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Todas las categorías</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Añada lugares nuevos al mapa y edite los existentes directamente desde la aplicación.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Cambiar ubicación</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Necesita más espacio para descargar. Elimine los datos innecesarios.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>He mejorado los mapas de Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentario detallado</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Los cambios que ha sugerido se enviarán a la comunidad de OpenStreetMap. Describa los detalles que no pueden editarse en Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Se ha producido un error al buscar su ubicación. Compruebe que su dispositivo funciona correctamente e inténtelo más tarde.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Los servicios de ubicación están desactivados</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Active el acceso a la geolocalización en los ajustes del dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Abra Configuración</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Pulse Localización</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Seleccione Cuando se use la app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Seleccione Privacidad</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Seleccione Localización</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Active la Localización</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>O seguir utilizando Organic Maps sin localización</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reservar</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Llamar</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nombre del marcador</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Eliminar marcador</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Su nota se enviará a OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>… más</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Actualizar</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>¿Quiere dejar de grabar el trayecto recién recorrido?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desactivar</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Comprueba</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps usa su ubicación en segundo plano para grabar la ruta recién recorrida.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Configuración general</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Para mostrar los datos de tráfico, debe actualizar la aplicación.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Tamaño del archivo de registro: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arrastre aquí para eliminar</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Sustituir Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Empezar desde</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Inicia sesión en OpenStreetMap para cargar automáticamente todas tus ediciones de mapas. Más información</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aquí</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ocultar pantalla</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Descargando %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Aplicando %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Este nombre es demasiado largo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nuevos archivos detectados</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convertir</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>No se convirtieron algunos archivos.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Se ha producido un error</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ocultar del mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Se produjo un error al cargar las etiquetas; inténtelo de nuevo</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Derecha</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Inferior</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Vamos</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destino</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrar</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultados de búsqueda</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Después</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>¿Quiere reconstruir la ruta?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>El teclado no está disponible al conducir</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>No se puede construir la ruta desde su ubicación actual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>No se puede construir una ruta al destino. Elija por favor otro punto</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No hay señal GPS. Muévase por favor a una zona abierta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>No se puede construir una ruta. Especifique por favor otros puntos de ruta</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Para construir una ruta, descargue los mapas faltantes en su dispositivo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Ocurrió un error. Reinicie la aplicación</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>La ruta se reconstruirá desde su ubicación actual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>La ruta se cambiará a coche</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>No se muestran todos los marcadores</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Cambie al teléfono para ver todos los marcadores</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Cám.velocidad</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Alerta velocidad</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Descargue los mapas en la aplicación del dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 salida</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Orden predeterminado</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordenar por tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenar por distancia</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenar por fecha</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordenar por nombre</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Comida</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sitios de interés</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museos</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natación</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montañas</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animales</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteles</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edificios</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dinero</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Tiendas</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Estacionamiento</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gasolineras</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Buscar en la lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Lugares sagrados</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Seleccionar lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navegación en metro aún no está disponible en esta región</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No se encontró ninguna ruta de metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Elija un punto de inicio o fin de ruta más cercano a una estación de metro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Alturas</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Para usar las curvas de nivel, actualice o descargue el mapa del área deseada</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>La altitud de relieve aún no está disponible en esta región</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascenso</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descenso</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevación mín.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevación máx.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultad</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tiempo:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Amplíe el mapa para ver las isolíneas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Descargando</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Descarga el mapa mundial de previsualización</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>No se ha podido crear la carpeta y mover los ficheros en la memoria interna del dispositivo o en la tarjeta SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Error de disco</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Fallo de conexión</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desconecte el cable USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mantener pantalla encendida</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Si se activa, la pantalla permanecerá encendida al mostrar el mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostrar en la pantalla de bloqueo</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Cuando se activa, no tiene que desbloquear el dispositivo para ejecutar la aplicación.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Idioma del mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Datos cartográficos de OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/es/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/es/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>¡Gracias por utilizar nuestros mapas creados por la comunidad!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>¡Con sus donaciones y apoyo, podemos crear los mejores mapas del mundo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>¿Le gusta nuestra aplicación? ¡Done para apoyar su desarrollo! ¿Todavía no le gusta? ¡Díganos por qué y lo arreglaremos!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Si conoce a algún desarrollador o desarrolladora de software, le puede pedir que implemente alguna funcionalidad que usted necesite.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Toque en cualquier lugar del mapa para seleccionar cualquier elemento. Mantenga pulsado para ocultar y volver a mostrar la interfaz.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>¿Sabía que su ubicación actual en el mapa se puede seleccionar?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Puede ayudar a traducir nuestra aplicación a su idioma.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Nuestra aplicación está desarrollada por unos pocos entusiastas y la comunidad.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Puede arreglar y mejorar fácilmente los datos del mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Nuestro principal objetivo es crear mapas rápidos, centrados en la privacidad y fáciles de utilizar que le encantarán.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Ahora usa Organic Maps en la pantalla del teléfono</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ahora usa Organic Maps en la pantalla del coche</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Se ha conectado a Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Pasar al teléfono</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>A la pantalla del coche</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps necesita acceder a la ubicación. Cuando sea seguro, compruebe la notificación en el teléfono.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Esta aplicación necesita su permiso</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps en Android Auto necesita permisos de ubicación para funcionar eficazmente</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Conceder permisos</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Al aire libre</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>El navegador web no está disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volumen</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportar todos los marcadores y trayectos</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Configuración de síntesis de voz del sistema</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>No se encontraron las configuraciones de síntesis de voz. ¿Sabe si su dispositivo la admite?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servicio desde el coche</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Borrar búsqueda</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Acercar</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Alejar</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Enlace al menú</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ver menú</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir en otra aplicación</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoservicio</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selecciona la opción</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Asientos al aire libre</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Para una navegación más precisa, recomendamos que desactive el modo de ahorro de energía en la configuración de la batería del teléfono.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Grabar trayecto</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Detener grabación de trayecto</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Grabación de pista</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Parar sin guardar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuar grabación</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>¿Guardar en Marcadores y trayectos?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>El trayecto está vacío; no hay nada que guardar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>No se puede mostrar el diálogo de selección de carpetas porque no hay ninguna aplicación adecuada instalada en el dispositivo. Instale un gestor de archivos e inténtelo de nuevo.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Elegir color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar trayecto</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No hay ninguna aplicación instalada que pueda abrir la ubicación</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto en navegación</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Seguir el sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Compartir recorrido</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>¿Borrar %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivel de dificultad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderado</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Actualizando</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Actualice sus mapas descargados</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>La actualización de mapas mantiene actualizada la información sobre objetos</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Actualizar (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Actualizar más tarde de forma manual</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Eliminar trayecto</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>¿Confirma que quiere eliminar este trayecto?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nombre del trayecto</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mover</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trayecto</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Cambiar color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>¿Quiere enviar un informe de error a los desarrolladores?
+Dependemos de nuestros usuarios, ya que Organic Maps no recoge ninguna información sobre errores de forma automática. ¡Gracias de antemano por apoyar a Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activar sincronización con iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La sincronización con iCloud es una función experimental en desarrollo. Asegúrese de haber realizado una copia de respaldo de todos sus marcadores y trayectos.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud está desactivado</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Active iCloud en la configuración del dispositivo para utilizar esta función.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activar</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Copia de seguridad</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Error de sincronización de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: no se ha podido sincronizar debido a un error de conexión</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: no se ha podido sincronizar porque se ha superado la cuota de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud no está disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listas eliminadas recientemente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Limpiar</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Eliminar todo</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar todo</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuir a OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Añadir lugar</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Actualizar el mapa para contribuir</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Debes actualizar el mapa %1 a la versión más reciente antes de poder contribuir a los datos de OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mi posición</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mis lugares</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Almacenamiento interno privado</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Almacenamiento interno compartido</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Tarjeta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Almacenamiento externo compartido</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punto del mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>pie</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Para mostrar las rutas, debes actualizar los mapas.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Salida</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>El mapa del metro no está disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Usted</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiones descargadas en morado</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ruta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Es necesario definir la ubicación actual en el entorno para disfrutar al máximo de la funcionalidad de la aplicación. Se emplea en las opciones de seguir la ruta y guardar el camino recorrido reciente.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>La definición de la ubicación actual se utiliza en las opciones de seguir la ruta y guardar el camino recorrido reciente.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Inicio de sesión con contraseña</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Inicio de sesión mediante navegador</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recientes</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Color de los marcadores cambiado</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Color de los trayectos cambiado</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Deslizadores</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROJO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>AZUL</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Color hexadecimal sRGB</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Cuadrícula</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/et/omim.ts
+++ b/qt/translations/et/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="et">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Tagasi</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Katkesta</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Kustuta</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Laadi kaarte</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Allalaadimine ei õnnestunud. Uuesti proovimiseks puuduta.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Allalaadimisel…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilomeetrid</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miilid</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Hiljem</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Otsi</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Otsi kaardilt</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Nutiseadme või rakenduse kõik asukohateenused on praegu välja lülitatud. Luba need seadistustest.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Piiratud täpsus</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Täpse tee juhatamise tagamiseks lülita seadistuses sisse Täpne asukoht.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Näita kaardil</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Allalaadimine ei õnnestunud</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Proovi uuesti</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Mapsi teave</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Tasuta ja vaba kõigi jaoks, tehtud armastusega</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Pole reklaame, jälitamist ega andmekogumist</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Ei tühjenda akut, töötab võrguühenduseta</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Kiire, minimalistlik, kogukonna poolt väljatöötatud</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Huviliste ja vabatahtlike poolt loodud avatud lähtekoodil põhinev rakendus.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Asukoha seadistused</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Sulge</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Rakendus vajab riistvaralist OpenGLi tuge. Kahjuks sinu nutiseade ei ole toetatud.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Laadi alla</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps kasutamiseks palun ühenda USB kaabel lahti või sisesta mälukaart</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Rakenduse kasutamiseks palun vabasta kõigepealt piisavalt ruumi mälukaardil/USB salvestusseadmel</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Enne rakenduse kasutamise alustamist luba meil laadida seadmesse alla maailma üldkaart.&#32;
+See kasutab %1 mälumahtu.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ava kaart</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Allalaadimisel on %1. Võid nüüd
+kaardiga jätkata.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Kas laadime %1 alla?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Kas uuendame %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Peata</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Jätka</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 allalaadimine ei õnnestunud</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Lisa uus loend</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Järjehoidjate loendi nimi</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Järjehoidjad</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Järjehoidjad ja rajad</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nimi</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Aadress</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Loend</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Seadistused</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Salvesta kaardid asukohta</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Vali asukoht, kuhu laadime kaardid.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Allalaaditud kaardid</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 vaba ruumist %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Kas teisaldame kaardid?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Kaardipaanide teisaldamine ei õnnestunud</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>See võib võtta mitu minutit.
+Palun oota…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mõõtühikud</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Vali miilide ja kilomeetrite vahel</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Tühista allalaadimine</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Kirjuta arvustus</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Jah</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Laadi kaart alla</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Järjehoidjate loetelud</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Söögikohad</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Toidukaubad</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Tanklad</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkimine</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Poed</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Taaskasutuspoed</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotell</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Vaatamisväärsused</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Meelelahutus</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Pangaautomaat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Ööelu</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Perepuhkus</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Pank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apteek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Haigla</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Tualett</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Politsei</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Jäätmekäitlus</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vesi</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Haagiselamud</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Märkmed</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps järjehoidjaid jagati Sinuga</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Tere!
+
+Manuses on minu järjehoidjad rakendusest Organic Maps. Palun ava need kui Sul on Organic Maps paigaldatud. Või kui ei ole, laadi rakendus alla oma iOSi või Androidi seadmesse, järgides seda linki: https:omaps.appget?kmz
+
+Naudi reisimist Organic Mapsiga!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Järjehoidjate laadimine</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Järjehoidjad edukalt laaditud! Leiad need kaardil või järjehoidjate halduri vaates.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Järjehoidjate laadimine ei õnnestunud. Fail võib olla vigane.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Rakendus ei tunnista failitüüpi:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>„%1“ faili avamine ei õnnestunud
+&#32;
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Muuda</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Sinu asukoht ei ole veel tuvastatud</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Vabandust, kaardi salvestuse seadistused on hetkel keelatud.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Kaardi allalaadimine on hetkel käimas.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hei, vaata minu praegust asukohta Organic Mapsi kaardil! %1 või %2 Võrguühenduseta kaardid puuduvad? Laadi siit: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hei, vaata minu asukoha märget Organic Mapsi kaardil!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hei, vaata minu praegust asukohta Organic Mapsi kaardil!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Tere,
+
+Olen praegu siin: %1. Ava see link %2 või see %3, et näha seda kohta kaardil.
+
+Aitäh.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Jaga</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-post</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopeeritud lõikelauale: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Valmis</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMapi andmed: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Kas oled kindel, et soovid oma OpenStreetMapi kontost välja logida?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Rajad</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Pikkus</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Jaga minu asukohta</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Üldseadistused</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Teave</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Tee juhatamine</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Nupud „+” ja „-” kaardil</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Kuva kaardil</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Öine stiil pimedas navigeerimisel</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Öörežiim</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Väljas</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Sees</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automaatne</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektiivi vaade</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-vaated</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-vaated lülitatakse energiasäästurežiimis välja</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Hääljuhised</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Teata tänavanimesid</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Kui see on lubatud, öeldakse valjusti tänava või ärapöörde nimi, kuhu peaksid keerama.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Hääljuhiste keel</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Kõrgema kvaliteediga hääle allalaadimiseks ava rakendus Seaded ja mine jaotisse Juurdepääsetavus → VoiceOver → Kõne → Hääl.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testi hääljuhised (Kõnesüntees, TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kui sa ei kuule nüüd häält, siis kontrolli helivaljust või süsteemi kõnesünteesi seadistusi.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ei ole saadaval</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automaatne suum</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Kaugus</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Vaata kaardil</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menüü</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Veebisait</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Uudised</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Tagasiside</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Hinda rakendust</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Abiteave</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Korduma kippuvad küsimused</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Anneta</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Juba annetasin</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Meenuta hiljem</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Toeta Organic Mapsi</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Toeta meie projekti</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autoriõigused</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Teata veast</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Kompassi kalibreerimiseks paranda noole suunda liigutades telefoni kaheksa-kujulise liigutusega.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Kompassi kalibreerimiseks ja noole suuna parandamisekskaardil liiguta telefoni kaheksa-kujulise liigutusega.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Kasutajaliidese nägemiseks vajuta kaarti pikalt</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Uuenda kõik</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Katkesta kõik</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Allalaaditud</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Järjekorras</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Minu lähedal</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kaardid</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Laadi kõik alla</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Allalaadimisel:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Kaardi kustutamiseks palun lõpeta tee juhatamine.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Koostada saad ainult täielikult ühe regiooni kaardi piiridesse jäävaid teekondi.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Laadi kaart alla</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Proovi uuesti</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Kustuta kaart</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Uuenda kaarti</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play asukohateenused</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Määra kiiresti oma ligikaudne asukoht Bluetoothi, WiFi või mobiilivõrgu kaudu</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Laadi alla kõik kaardid oma teekonnal</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Teekonna koostamiseks on meil vaja alla laadida ja värskendada kõiki sinu lähte- ja sihtkoha vahele jäävaid kaarte.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ei ole piisavalt ruumi</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Palun luba asukohateenused</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Salvesta</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>loo</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Punane</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Kollane</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Sinine</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Roheline</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Lilla</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranž</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Pruun</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Roosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tumelilla</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Helesinine</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Rohekassinine</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Sinakasroheline</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Laimiroheline</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tumeoranž</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Hall</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Sinakashall</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Teave</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Mapsi versioon: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Välimus</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Hele kujundus</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tume kujundus</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Hele hommikust kuni õhtuhämaruni</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Muu</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Kingi miljonitele kasutajatele tasuta ja reklaamideta kaardid!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Paranda vigaseid kaardiandmeid või teata neist</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Vabatahtlik kaastöö</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Jälgi ja võta meiega ühendust:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-posti klienti ei ole seadistatud. Palun seadista see või kasuta mõnda muud võimalust meiega ühenduse võtmiseks aadressil %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Viga teate saatmisel</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompassi kalibreerimine</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Saadaval</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Leidus</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Värskenda</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Ebaõnnestus</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>järjehoidja</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Teekonda järgides palun pea meeles:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>- Teeolud, liikluseeskirjad ja liiklusmärgid omavad alati prioriteeti tee juhatamise ees;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>- Kaart võib olla ebatäpne ja soovitatud teekond ei pruugi alati olla optimaalne viis sihtkohta jõudmiseks;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>- Soovitatud teekondi tuleks võtta just sellistena;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>- Ole piiritsoonides teekondade kulgemisega ettevaatlik: meie rakenduse loodud teekonnad võivad mõnikord ületada riigipiire volitamata kohtades.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Ole teel tähelepanelik ja liigu turvaliselt!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Kontrolli GPSi signaali</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Teekonda ei õnnestu koostada. GPSi koordinaate ei õnnestu tuvastada.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Palun kontrolli GPSi signaali. WiFi lubamine parandab asukoha täpsust.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Luba asukohateenused</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Ei suuda praeguseid GPS-koordinaate määrata. Teekonna koostamiseks luba asukohateenused.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Teekonda ei õnnestu leida</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Teekonda ei õnnestu luua.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Palun kohenda oma algpunkti või sihtkohta.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Kohenda algpunkti</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Teekond jäi koostamata. Ei suuda tuvastada algpunkti.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Palun vali algpunkt teele lähemal.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Kohenda sihtkohta</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Teekond jäi koostamata. Ei suuda tuvastada sihtkohta.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Palun vali sihtkoht teele lähemal.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Ei suuda määrata teekonna vahepunkti.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Palun kohanda vahepunkti.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Süsteemi viga</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Teekonda ei saa koostada rakenduse vea tõttu.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Palun proovi uuesti</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Mitte praegu</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Kas sooviksid kaardi alla laadida ja luua optimaalse rohkem kui ühte kaarti hõlmava teekonna?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Laadi alla täiendavad kaardid, et luua parem, selle kaardi piire ületav teekond.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Laadi alla vajalikud failid</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Marsruudi arvutamiseks laadi alla ja värskenda kogu kavandatud teekonna kaart ja marsruuditeave.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Marsruutide otsimise ja loomise alustamiseks laadi kaart alla. Pärast seda ei ole Interneti-ühendus enam vajalik.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Vali kaart</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Näita</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Peida</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategooriad</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Ajalugu</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Vabandust, tulemusi ei leidu.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Laadi alla otsitav piirkond või proovi lisada lähedalasuva linna/küla nimi.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Otsinguajalugu</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Vaata hiljutisi otsinguid.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Kustuta otsinguajalugu</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Vikipeedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikkel saidilt wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Sinu asukoht</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Alusta</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Teekond lähtekohast</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Teekond sihtkohta</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Tee juhatamine on saadaval ainult sinu praegusest asukohast.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Kas soovid, et planeeriksime teekonna sinu praegusest asukohast?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Järgmine</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Kell</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Kuni</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Lisa ajakava</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Kustuta ajakava</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Kogu päev (24 tundi)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Avatud</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Suletud</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Lisa suletud tunnid</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Tööaeg</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Täpsem režiim</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Lihtne režiim</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Suletud tunnid</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Näidisväärtused</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Paranda viga</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Vali asukoht</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Palun kirjelda probleemi üksikasjalikult, et OpenStreetMapi kogukond saaks selle parandada.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Või tee seda ise aadressil https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Saada</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Probleem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Sellist kohta pole olemas</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Suletud hoolduseks</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Dubleeritud koht</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Laadi kaardid automaaselt alla</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Iga päev</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Täna suletud</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Suletud</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Täna</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Avatakse %1 jooksul</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Suletakse %1 jooksul</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Suletud</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Muuda tööaega</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Sul puudub OpenStreetMapi konto?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registreeru OpenStreetMapis</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Logi sisse</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Pole sisse logitud</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Logi sisse OpenStreetMappi</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Salasõna</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Unustasid oma salasõna?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Logi välja</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Muuda kohta</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Lisa keel</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Tänav</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Majanumber</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Üksikasjad</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sotsiaalmeedia</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Hoone</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Lisa tänav</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Palun sisesta tänava nimi</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Vali keel</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Vali tänav</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Köök</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Vali köök</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-post või kasutajanimi</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Lisa telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Korrus</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Korrus: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Kõik sinu kaardimuudatused kustutatakse koos kaardiga.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Uuenda kaarte</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Teekonna loomiseks uuenda kõiki kaarte ja seejärel proovi teekond uuesti luua.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Leia kaart</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Palun kontrolli oma nutiseadme internetiühendust.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ei ole piisavalt andmeruumi</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Palun kustuta ebavajalikud andmed</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Sisselogimise viga.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Kinnitatud muudatused</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Lohista kaarti, et asetada rist koha või ettevõtte asukoha juurde.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Muutmine</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Lisamine</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Koha nimi</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Nagu on kirjutatud kohalikus keeles</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategooria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Probleemi üksikasjalik kirjeldus</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Erinev probleem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Lisa ettevõte või äri</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ükski objekt ei saa siin asuda</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Kogukonna loodud OpenStreetMapi andmed seisuga %1. Lisateavet kaardi muutmise ja uuendamise kohta leiad OpenStreetMap.org saidist</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) on kogukonna projekt, mille eesmärk on luua vaba, tasuta ja avatud kaart. See on Organic Mapsi peamine kaardiandmete allikas ja toimib sarnaselt Vikipeediaga. Saad lisada või muuta kohti ja need muutuvad kättesaadavaks miljonitele kasutajatele üle kogu maailma.
+Liitu kogukonnaga ja aita luua kõigi jaoks paremat kaarti!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Loo OpenStreetMapi konto või logi sisse, et avaldada oma kaardimuudatused kogu maailmale.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Kas laadime alla mobiilivõrgu kaudu?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>See võib mõningate lepingute või rändluse korral olla märgatavalt kallim.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Sisesta kehtiv majanumber</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Korruste arv (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Korruste arv ei või olla üle %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postiindeks</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Sisesta korrektne postiindeks</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Märkus OpenStreetMapi vabatahtlikele (valikuline)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Kirjelda kaardil olevaid vigu või objekte, mida ei saa Organic Mapsiga muuta</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Sinu muudatused laaditakse üles avalikku &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; andmebaasi. Palun ära lisa isiklikku või autoriõigusega kaitstud teavet.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Lisateave OpenStreetMapi kohta</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Sinu muudatuste ajalugu</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Sinu kaardiandmete märkmed</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Käitaja</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Käitaja: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Ei leia sobivat kategooriat?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps võimaldab lisada ainult lihtsaid huvipunkte, see tähendab, et ei mingeid linnu, teid, järvi, hoonete piirjooni jne. Palun lisa sellised kategooriad otse &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; saidis. Vaata meie &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;juhendit&lt;/a&gt; üksikasjalike samm-sammuliste juhiste saamiseks.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Sa ei ole kaarte alla laadinud</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Laadi alla kaardid asukoha otsimiseks ja võrguühenduseta tee juhatamiseks.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Hetkeasukoht on teadmata.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>p</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>sek</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Veel</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Muuda järjehoidjat</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Isiklikud märkmed (tekst või html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommenteeri…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Kas loobud kõigist kohalikest muudatustest?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Loobu</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Kas kustutad lisatud koha?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Kustuta</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Kohta pole olemas</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Palun märgi põhjus koha kustutamiseks</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Sisesta kehtiv telefoninumber</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Sisesta kehtiv veebiaadress</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Sisesta kehtiv e-posti aadress</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Sisesta kehtiv Facebooki veebiaadress, konto või lehekülje nimi</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Sisesta kehtiv Instagrami veebiaadress või konto nimi</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Sisesta kehtiv Xi (Twitteri) veebiaadress või kasutajanimi</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Sisesta kehtiv VK veebiaadress või konto nimi</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Sisesta kehtiv LINE&#x27;i veebiaadress või LINE ID</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Lisa koht OpenStreetMappi</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Või alternatiivina lisa märkus OpenStreetMapi kogukonna liikmetele, mis võimaldaks teistel kaardistajatel selle koha lisada või tema andmeid parandada.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Märkus lisatakse OpenStreetMapi andmebaasi</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Kas soovid saata selle kõigile kasutajatele?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Palun kontrolli, et sa ei sisestanud isiklikke andmeid.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMapi haldajad kontrollivad muudatused üle ja võtavad küsimuste korral sinuga ühendust.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Lõpeta</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Rada on salvestamisel</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Nõustu</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Keeldu</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Kas kasutame mobiilset internetiühendust üksikasjaliku teabe kuvamiseks?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Kasuta alati</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Ainult täna</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ära kasuta täna</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiilne internetiühendus</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobiilne internetiühendus on vajalik kaardi uuendamise teavituste jaoks ning muudatuste üleslaadimiseks.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ära kasuta kunagi</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Küsi alati</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Liiklusinfo kuvamiseks palun uuenda kaardid.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Suurenda teksti suurust kaardil</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Palun uuenda Organic Mapsi rakendust</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Liiklusinfo ei ole saadaval</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Luba logimine</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Üldine tagasiside</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Hääljuhiste jaoks kasutame kõnesünteesi. Paljud Android-seadmed kasutavad Google&#x27;i TTS-i, saad selle alla laadida või värskendada Google Play teenusest</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Mõne keele puhul pead paigaldama kõnesüntesaatori või täiendava keelepaketi rakenduste poest (Google Play, Galaxy Store, App Gallery, F-Droid).&#32;
+Ava oma nutiseadmes „Seadistused → Keel ja sisend → Kõne → Kõnesüntees“ väljund.&#32;
+Siin saad hallata kõnesünteesi seadistusi (näiteks alla laadida keelepaketti võrguühenduseta kasutamiseks) ja valida mõne muu teksti kõneks muutmise mootori.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Lisainfo saamiseks palun vaata seda juhist.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteratsioon ladina tähestikku</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Lisateave</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Teekonna alguspunkti lisamiseks kasuta otsingut, vali järjehoidja või puuduta soovitud kohta kaardil</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Sihtkoha lisamiseks kasuta otsingut, vali järjehoidja või puuduta soovitud kohta kaardil</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Halda teekonda</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Kavanda</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Eemalda peatus</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Lisa peatus</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Salvestatud</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Oma kaastöö automaatseks üleslaadimiseks palun logi OpenStreetMappi sisse. Lisateave &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;leidub siin&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Andmeruumi ligipääsu probleem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Väline andmeruum pole juurdepääsetav. SD-kaart võib olla eemaldatud, kahjustatud või failisüsteem on kirjutuskaitstud. Palun kontrolli oma SD-kaarti või võta meiega ühendust aadressil support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Imiteeri vigast andmeruumi</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Palun sisesta korrektne nimi</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Loendid</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Peida kõik</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Näita kõiki</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n järjehoidja</numerusform>
+<numerusform>%n järjehoidjat</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Loo uus loend</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Impordi järjehoidjaid ja radasid</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Jagamine polnud võimalik rakenduse vea tõttu</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Viga jagamisel</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Tühja loendit ei saa jagada</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Nimi ei saa olla tühi</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Palun sisesta loendi nimi</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Uus loend</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>See nimi on juba kasutusel</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Palun vali teine nimi</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Palun oota…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefoni number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMapi profiil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Leidsime %n faili. Näed seda peale teisendamist.</numerusform>
+<numerusform>Leidsime %n faili. Näed neid peale teisendamist.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Taasta</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n rada</numerusform>
+<numerusform>%n rada</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privaatsus</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Andmekaitsepõhimõtted</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Kasutustingimused</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Liiklus</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Matkamine</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Jalgrattasõit</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metroo</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kaardi stiilid ja kihid</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>See loend on tühi</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Järjehoidja lisamiseks puuduta kohta kaardil ja seejärel puuduta tähekese ikooni</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Muuda kõigi järjehoidjate värvi</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Muuda kõigi radade värvi</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…veel</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Ekspordi KMZ-failina</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Ekspordi GPX-failina</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Ekspordi GeoJSON-failina</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Kustuta loend</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Kiiruskaamerad</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Koha kirjeldus</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kaartide allalaadija</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Hoiata piirkiiruse ületamisel</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Hoiata alati</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Ära kunagi hoiata</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energiasäästurežiim</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Proovi funktsionaalsuse vähendamise arvel vähendada aku voolutarbimist.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Mitte kunagi</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Madala akutäituvuse korral</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Alati</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Kaardil leiduvate järjehoidjate nimed</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Kui kaardil on palu järjehoidjaid, siis nende nimede kuvamine aeglustab kaardi joonistamist.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Näita paremale</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Näita alla</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Kasuta seda võimalust üksikasjaliku logi ajutiseks salvestamiseks ja meile käsitsi saatmiseks Abiteabe „Teata veast“ vaatest. Andmed võivad sisaldada sinu asukoha teavet.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Tee juhatamise valikud</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Väldi tasulisi teid</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Väldi sillutamata teid</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Väldi praamiületusi</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Väldi kiirteed</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Teekonna koostamine ei õnnestu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Teekonda ei õnnestunud koostada. See võib olla põhjustatud sinu seatud tingimustest või OpenStreetMapi andmete puudumisest. Muuda algtingimusi ja proovi uuesti.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Määra välditavad teed</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Lubatud valikud teekonna koostamisel</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Tasuline tee</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Sillutamata tee</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Praamiületus</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Jah</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ei</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>olemas</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>puudub</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kohti: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Võrgustik: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Oled kohal!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Sobib</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Järjesta…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Järjesta järjehoidjaid</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Vaikimisi</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Liigiti</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Kauguse järgi</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Kuupäeva järgi</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Nime järgi</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Nädal tagasi</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Kuu tagasi</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Üle kuu tagasi</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Üle aasta tagasi</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Minu lähedal</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Muud</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Teekonna planeerimine ei õnnestunud</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Saabumine: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Marsruudi arvutamiseks laadi alla ja värskenda kõik kavandatud teekonnale jäävad kaardid.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Oled muutnud maailmakaarti. Ära hoia seda ainult enda teada! Räägi ka oma sõpradele ja muutke seda koos.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Jaga oma sõpradega</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Praegu suletud</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Avatakse homme kell %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Avatakse %1 kell %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Avatakse kell %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Suletakse kell %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Lisa tööaeg</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Salasõna (vähemalt 8 märki)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Vigane kasutajanimi või salasõna.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSMi kasutajakonto</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Viimane üleslaadimine</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Aitäh</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Koha nimi</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Palun arvesta</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Viga allalaadimisel</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Vali kategooria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populaarne</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kõik kategooriad</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Lisa kaardile uusi kohti ja muuda olemasolevaid otse rakenduses.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Muuda asukohta</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Allalaadimiseks vajad rohkem andmeruumi. Palun kustuta ebavajalikke andmeid.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Parandasin Organic Maps kaarte</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Üksikasjalik kommentaar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Sinu soovitatud kaardimuudatused saadetakse OpenStreetMapi kogukonnale. Kirjelda kõiki täiendavaid üksikasju, mida ei saa Organic Mapsis muuta.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Sinu asukoha otsimisel ilmnes viga. Kontrolli, kas sinu nutiseade töötab korralikult ja proovi hiljem uuesti.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Asukohateenused on keelatud</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Luba nutiseadme seadistustes juurdepääs geograafilisele asukohale</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ava seadistused</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Klõpsi valikut „Asukoht“</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Vali „Rakenduse kasutamise ajal“</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Vali „Privaatsus“</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Vali „Asukohateenused“</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Lülita sisse asukohateenused</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Või jätka Organic Mapsi kasutamist ilma asukohata</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reserveeri</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Helista</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Järjehoidja nimi</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Kustuta järjehoidja</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Sinu märkus saadetakse OpenStreetMapile</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…veel</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Värskenda</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Kas keelame hiljuti läbitud teekonna salvestamine?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Keela</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Vaata järele</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps kasutab Sinu geograafilist asukohta taustal Sinu hiljuti läbitud teekonna salvestamiseks.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Üldseadistused</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Liiklusinfo kuvamiseks pead rakendust uuendama.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Logifaili suurus: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Eemaldamiseks lohista siia</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Asenda peatus</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Alusta kohast</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Oma kaardimuudatuste automaatseks üleslaadimiseks palun logi sisse OpenStreetMappi. Lisateave</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>kuskil siin</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Peida vaade</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Allalaadimisel %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Võtame %1 kasutusele…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>See nimi on liiga pikk</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Leidsime uusi faile</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Teisenda</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Viga</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Mõned failid jäid teisendamata.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Tekkis viga</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populaarne</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Peida kaardilt</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Siltide laadimisel tekkis viga, palun proovi uuesti</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Paremal</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>All</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Läksime</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Sihtkoht</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Säti keskele</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Otsingutulemused</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Seejärel</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Kas soovid teekonna uuesti luua?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Klaviatuur ei ole sõidu ajal kasutatav</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Sinu praegusest asukohast ei õnnestu teekonda koostada</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Ei õnnestu luua teekonda sinu sihtkohta. Palun vali teine lõpp-punkt</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPSi signaal puudub. Palun liigu avaramasse kohta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Teekonna loomine ei õnnestu. Palun määra muud teekonnapunktid</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Teekonna loomiseks laadi puuduvad kaardid alla oma nutiseadmesse</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Tekkis viga. Palun taaskäivita rakendus</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Teekond luuakse uuesti sinu hetkeasukohast</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>See teekond teisendatakse autoga läbitavaks</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Kõiki järjehoidjaid ei kuvata</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Kõigi järjehoidjate nägemiseks suundu telefoni vaatesse</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kiiruskaamerad</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Kiiruse hoiatused</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Palun laadi alla kaardid oma nutiseadme Organic Maps rakenduses</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 ärapööre</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Vaikimisi järjestus</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Järjesta liigiti</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Järjesta kauguse alusel</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Järjesta kuupäeva alusel</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Järjesta nime alusel</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Toit</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Vaatamisväärsused</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muuseumid</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Pargid</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Ujumine</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mäed</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Loomad</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotellid</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Hooned</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Raha</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Poed</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkimine</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Tanklad</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Tervishoid</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Otsi loendist</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religiooniga seotud kohad</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Vali loend</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Tee juhatamine metroos ei ole selles piirkonnas veel saadaval</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metroo marsruuti ei leidu</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Palun vali metroojaamale lähemal asuv alg- või lõpp-punkt</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Kontuurjooned</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Topograafilise kihi aktiveerimiseks ja kasutamiseks laadi alla piirkonna kaart</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Topograafiline kiht ei ole selles piirkonnas veel saadaval</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Tõus</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Langus</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. kõrgus</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. kõrgus</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Raskusaste</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Kaugus:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Aeg:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Samakõrgusjoonte sirvimiseks suurenda kaarti</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Allalaadimisel</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Maailma üldkaart on allalaadimisel</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Seadme sisemällu või mälukaardile ei saa kausta luua ja faile sinna teisaldada</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Salvestusseadme viga</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Ühenduse viga</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Ühenda USB kaabel lahti</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Hoia ekraan sisselülitatuna</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Kui see on lubatud, on ekraan kaardi kuvamisel alati sisse lülitatud.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Näita lukustusvaates</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Kui see eelistus lubatud, siis rakendus töötab ka lukustusvaates.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kaardi keel</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMapi kaardiandmed</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/et/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/et/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Aitäh, et kasutad meie kogukonna koostatud kaarte!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Sinu annetuste ja toetusega saame luua maailma parimaid kaarte!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Kas sulle meeldib meie rakendus? Palun anneta arendustöö toetamiseks! Ei meeldi veel? Palun anna põhjusest meile teada ja me parandame selle!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Kui tead mõnda tarkvaraarendajat, võid paluda tal osaleda vajaliku funktsionaalsuse loomisel.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Puuduta kaardil ükskõik kus, et valida midagi. Pika puudutusega saad peita ja kuvada kasutajaliidest.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Kas tead, et saad kaardil valida oma praeguse asukoha?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Saad aidata meie rakendust oma keelde tõlkida.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Meie rakenduse on loonud mõned entusiastid ja kogukond.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Saad hõlpsasti kaardiandmeid parandada ja täiustada.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Meie põhieesmärk on luua kiireid, privaatsusele keskenduvaid ja hõlpsasti kasutatavaid kaarte, mis sulle meeldivad.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Nüüd kasutad telefoni ekraanil Organic Mapsi</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Nüüd kasutad auto ekraanil Organic Mapsi</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Oled ühendatud Android Auto&#x27;ga</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Jätka telefonis</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Auto ekraanile</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps vajab juurdepääsu asukohale. Kui see on turvaline, kontrolli oma telefonis olevat teadet.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>See rakendus vajab sinu luba</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto liidestusega Organic Maps vajavab tõhusaks tööks luba asukoha tuvastamiseks</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Anna luba</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Matkamine ja seiklemine</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Veebibrauser ei ole saadaval</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Helivaljus</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Ekspordi kõik järjehoidjad ja rajad</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Süsteemsed kõnesünteesi seadistused</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Kõnesünteesi seadistusi ei leidu, kas oled kindel, et sinu nutiseade toetab seda?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Läbisõit</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Tühjenda otsing</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Suumi sisse</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Suumi välja</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menüü link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Vaata menüüd</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Ava teises rakenduses</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Iseteenindus</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Vali eelistus</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Istekohad õues</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Kõige täpsema tee juhatamise tagamiseks soovitame, et lülitad telefoni akuhalduse seadistused energiasäästurežiimi välja.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Salvesta rada</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Peata raja salvestamine</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Rada salvestamine</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Lõpeta ilma salvestamata</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Jätka salvestamist</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Kas salvestame järjehoidjatesse ja radadesse?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Rada on tühi - ei ole midagi salvestada</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kaustavaliku vaadet ei ole võimalik kuvada, sest sinu nutiseadmes ei leidu sobivat rakendust. Palun paigalda failihaldur ja proovi uuesti.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Vali värv</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Muuda rada</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ei ole paigaldatud rakendust, mis oskaks asukohta avada</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automaatne tee juhatamine</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Järgi süsteemi</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Jaga rada</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Kas kustutame %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Raskusaste</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Lihtne</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Keskmine</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Raske</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Uuendamine</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Värskenda oma allalaaditud kaarte</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Kaartide värskendamine hoiab objektide info ajakohasena</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Uuenda (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Uuenda hiljem käsitsi</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Kustuta rada</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Kas oled kindel, et soovite selle raja kustutada?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Raja nimi</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Teisalda</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Rada</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Muuda värvi</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kaart</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Kas soovid saata arendajatele veateate?
+Me toetume oma kasutajatele, kuna Organic Maps ei kogu automaatselt mingit veateavet. Täname sind juba ette Organic Mapsi toetamise eest!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Luba iCloudi sünkroniseerimine</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloudi sünkroniseerimine on eksperimentaalne funktsioon, mis on arendamisel. Igaks juhuks veendu, et oled teinud varukoopia kõigist oma järjehoidjatest ja radadest.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud on välja lülitatud</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Selle funktsionaalsuse kasutamiseks luba nutiseadme seadistustes iCloud.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Luba</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Varundus</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloudi sünkroniseerimise viga</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Viga: Sünkroniseerimine ei õnnestunud võrguühenduse vea tõttu</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Viga: sünkroniseerimine ei õnnestunud iCloudi kvoodi ületamise tõttu</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Viga: iCloud ei ole saadaval</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Hiljuti kustutatud loendid</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Kustuta</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Kustuta kõik</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Taasta</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Taasta kõik</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Panusta OpenStreetMap-i</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Lisa koht</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Uuenda kaarti, et panustada</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Enne OpenStreetMap andmetesse panustamist peate uuendama %1 kaardi uusimale versioonile</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Minu asukoht</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Minu kohad</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Sisemine privaatne andmeruum</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Sisemine jagatud andmeruum</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kaart</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Väline jagatud andmeruum</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postiindeks</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kaardipunkt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>jalga</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Teekondade kuvamiseks peavad kaardid olema uuendatud.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Välju</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Sissepääs</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metrookaart ei ole saadaval</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Sa</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Lillad allalaaditud piirkonnad</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Marsruut</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Rakenduse funktsionaalsuse täielikuks nautimiseks on vaja asukoha tuvastamist taustal. Seda kasutatakse navigeerimiseks ja hiljuti reisitud tee salvestamiseks.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Teie asukoha määramine on vajalik navigeerimiseks ja hiljuti reisitud raja salvestamiseks.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Sisselogimine parooliga</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Sisselogimine brauseri abil</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Hiljuti kasutatud</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Järjehoidjate värv on muudetud</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Radade värv on muudetud</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektri</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Liugurid</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>PUNANE</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ROHELINE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex-värv #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Ruudustik</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/eu/omim.ts
+++ b/qt/translations/eu/omim.ts
@@ -1,0 +1,3933 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="eu">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Atzera</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Utzi</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Ezabatu</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Deskargatu mapak</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Errore bat gertatu da deskargatzean. Klik egin berriz saiatzeko.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Deskargatzen…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometro</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miliak</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Geroago</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Bilatu</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Bilatu mapan</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Ezin da kokapen-zerbitzua atzitu. Mesedez, aktibatu ezarpenetan.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Zehaztasun mugatua</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Nabigazio zehatzagoa ziurtatzeko, gaitu kokapen zehatza ezarpenetan.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Erakutsi mapan</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Deskargak huts egin du</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Saiatu berriro</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps-i buruz</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Denontzat doan, maitasunez egina</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Ez iragarkirik, ez jarraipenik, ez datu-bilketarik</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Ez da bateria deskargatzen, konexiorik gabe funtzionatzen du</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Azkarra, minimalista, komunitateak garatua</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Zale eta bolondresek sortutako kode irekiko aplikazioa.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Kokapen ezarpenak</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Itxi</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Aplikazioak hardwarez azeleratutako OpenGL behar du. Zoritxarrez, zure gailuak ez du hau eskaintzen.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Deskargatu</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Mesedez, deskonektatu USB kablea edo sartu SD memoria Organic Maps erabiltzeko</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Mesedez, egin lekua SD memorian/USB biltegian aplikazioa erabiltzeko</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Hasi aurretik deskargatu mesedez mundu-mapa orokorra zure gailura.
+Memorian %1 erabiliko ditu.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Joan mapara</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 deskargatzen. Orain mapara
+&#32;joan zaitezke.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 deskargatu?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 eguneratu?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausa</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Jarraitu</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 deskargak huts egin du</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Gehitu zerrenda berri bat</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Markagailuen zerrendaren izena</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Markagailuak</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Markagailuak eta arrastoak</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Izena</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Helbidea</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Zerrenda</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Ezarpenak</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Mapak gordetzeko tokia</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Hautatu mapak non deskargatu behar diren.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Deskargatutako mapak</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2-tik %1 libre</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Mapak mugitu?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Ezin izan dira mapak mugitu</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Honek minutu batzuk iraun ditzake.
+&#32;Itxaron mesedez…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Neurketa unitateak</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Aukeratu mila eta kilometroen artean</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Utzi deskarga</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Idatzi iritzia</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Bai</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Deskargatu mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Markagailuen zerrenda</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Non jan</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Janari-denda</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Garraioa</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gasolindegia</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparkalekua</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Erosketak</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Bigarren eskuko</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotela</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Turismoa</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretenimendua</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Kutxazain automatikoa</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Gaueko giroa</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Familiako jarduerak</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bankua</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmazia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Ospitalea</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Komuna</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta bulegoa</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polizia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Birziklapena</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Ura</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Karabanak</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Oharrak</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps-eko markagailuak zurekin partekatu dira</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Kaixo!
+Nire markagailuak Organic Maps aplikazioan erantsi ditut. Mesedez, ireki itzazu Organic Maps instalatuta baduzu. Edo, ez baduzu, deskargatu aplikazioa zure iOS edo Android gailurako esteka hau jarraituz: https://omaps.app/get?kmz
+
+Gozatu bidaiatzen Organic Maps-ekin!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Markagailuak kargatzen</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Markagailuak behar bezala kargatu dira! Mapan edo markagailuak kudeatzeko pantailan aurki ditzakezu.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Ezin izan dira markagailuak kargatu. Fitxategia akastuna izan daiteke.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Aplikazioak ez du fitxategi mota ezagutzen:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Ezin izan da fitxategia ireki %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editatu</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Zure kokapena ez da oraindik zehaztu</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Barkatu, mapa biltegiratzeko ezarpena desgaituta dago.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Mapak deskargatzen ari dira.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Ikusi nire uneko kokapena Organic Maps-en! %1 edo %2 Ez al duzu lineaz kanpoko maparik? Deskargatu hemendik: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Begiratu nire markagailua Organic Maps-en!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Ikusi nire uneko kokapena Organic Maps mapan!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Kaixo:
+
+Orain hemen nago: %1. Egin klik esteka honetan %2 edo %3 honetan mapan ikusteko.
+
+Eskerrik asko.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Partekatu</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Posta elektronikoa</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Arbelean kopiatu da: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Eginda</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap datuak: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ziur zure OpenStreetMap kontutik saioa amaitu nahi duzula?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Arrastoak</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Luzera</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Partekatu nire kokapena</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Ezarpen orokorrak</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informazioa</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Nabigazioa</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Mapako “+” eta “-” botoiak</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Erakutsi mapan</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Gau estiloa ilunpean nabigatzean</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Gaueko modua</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desgaituta</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Aktibatuta</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatikoa</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektiba ikuspegia</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D eraikinak</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D eraikinak desgaituta daude energia aurrezteko moduan</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Ahots argibideak</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Kaleen izenak iragarri</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Gaituta dagoenean, biratzeko kalearen edo irteeraren izena ozen esango da.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Ahots hizkuntza</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Kalitate handiagoko ahotsa deskargatzeko, ireki Ezarpenak aplikazioa eta joan Irisgarritasuna → VoiceOver → Ahotsa → Ahotsa.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Probatu ahots bidezko jarraibideak (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Egiaztatu bolumena edo sistemaren testu-ahotsaren ezarpenak ahotsa entzuten ez baduzu.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ez dago erabilgarri</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automatikoa</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distantzia</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ikusi mapan</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menua</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webgunea</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Albisteak</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Iruzkinak</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Baloratu aplikazioa</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Laguntza</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Ohiko galderak</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Dohaintza eman</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Dohaintza jada emana</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Gogoratu geroago</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Sustatu Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Proiektuari laguntza eman</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Egile eskubideak</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Errore baten berri eman</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Hobetu geziaren norabidea telefonoa zortzi irudiko mugimenduan mugituz iparrorratza kalibratzeko.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mugitu telefonoa zortzi irudiko mugimenduan iparrorratza kalibratzeko eta geziaren norabidea mapan finkatzeko.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Sakatu luze berriro mapan interfazea ikusteko</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Eguneratu guztiak</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Utzi guztiak</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Deskargatuta</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Ilaran</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Nigandik gertu</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapak</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Deskargatu guztiak</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Deskargatzen:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Mapa ezabatzeko, gelditu nabigazioa.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Eskualde bakarreko mapa batean guztiz bilduta dauden arrastoak soilik sor daitezke.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Deskargatu mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Saiatu berriro</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Ezabatu mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Eguneratu mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Kokapen Zerbitzuak</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Zehaztu azkar zure gutxi gorabeherako kokapena Bluetooth, WiFi edo sare mugikorra erabiliz</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Deskargatu zure arrastoaren mapa guztiak</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Arrasto bat sortzeko beharrezkoa da helmugako kokapenaren mapa guztiak deskargatzea eta eguneratzea.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Leku nahikorik ez</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Mesedez, aktibatu kokapen zerbitzuak</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Gorde</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>sortu</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Gorria</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Horia</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Urdina</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Berdea</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Morea</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Laranja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marroia</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Arrosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>More iluna</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Urdin argia</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Ziana</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Berde urdinxka</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Laranja iluna</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grisa</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris urdinxka</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informazioa</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps bertsioa: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Itxura</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Argi</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Iluna</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Argi egunsentitik iluntzerarte</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Beste batzuk</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Oparitu doako mapak iragarkirik gabe milioika erabiltzaileri!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Salatu edo konpondu maparen datu okerrak</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Boluntario izateko</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Jarraitu eta jarri gurekin harremanetan:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Posta elektronikoko bezeroa ez da konfiguratu. Mesedez, konfigura ezazu edo erabili beste moduren bat gurekin harremanetan jartzeko %1 helbidean</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Errore bat mezua bidaltzean</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Iparrorratzaren kalibrazioa</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Eskuragarria</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Aurkituta</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Eguneratu</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Huts eginda</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>Markagailua</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Arrastoa jarraitzean, kontuan izan:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Bidearen egoera, zirkulazio arauek eta bide seinaleek lehentasuna dute beti nabigazio-iradokizunen gainetik;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Zehaztasunik gabeko mapa izan daiteke eta helmugara iristeko biderik onena ez den ibilbide bat iradoki dezake;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Iradokitako ibilbideak gomendio gisa soilik hartu behar dira;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Kontuz ibili muga-eremuak dituzten ibilbideetan: gure aplikazioak sortutako ibilbideek batzuetan herrialdeen mugak zeharkatu ditzakete baimendu gabeko tokietan.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Egon adi eta seguru errepideetan!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Egiaztatu GPS seinalea</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Ezin da ibilbidea sortu. Ezin izan dira uneko GPS koordenatuak identifikatu.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Egiaztatu GPS seinalea. WiFi konexioa aktibatuz gero, zure kokapenaren zehaztasuna hobetuko da.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktibatu kokapen zerbitzuak</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Ezin dira GPS koordenatuak aurkitu. Aktibatu kokapen zerbitzuak arrastoa kalkulatzeko.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Ezin da ibilbiderik aurkitu</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Ezin da ibilbidea sortu.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ezarri zure abiapuntua edo helmuga.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ezarri abiapuntua</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Ibilbidea ez da sortu. Abiapuntua ezin izan da aurkitu.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Hautatu errepide batetik gertuko abiapuntua.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Zehaztu norakoa</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Ibilbidea ez da sortu. Ezin izan da helmuga aurkitu.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Hautatu helmuga puntu bat errepide batetik gertu.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Ezin izan da tarteko puntua kokatu.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Mesedez, zehaztu tarteko puntua.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistemaren errorea</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Ibilbidea ezin izan da sortu aplikazioaren errore baten ondorioz.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Saiatu berriro</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Orain ez</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Mapa deskargatu eta mapa bat baino gehiago hartzen duen ibilbide hobe bat sortu nahi duzu?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Deskargatu mapa osagarriak mapa honen mugak gainditzen dituen ibilbide hobea sortzeko.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Deskargatu beharrezko fitxategiak</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Deskargatu eta eguneratu mapa eta ibilbideen informazio guztia aurreikusitako ibilbidearekin batera arrastoa kalkulatzeko.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Ibilbideak bilatzen eta sortzen hasteko, deskargatu mapa. Horren ondoren, ez duzu Interneterako konexiorik beharko.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Hautatu mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Erakutsi</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ezkutatu</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategoriak</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historiala</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Barkatu, ez dut ezer aurkitu.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Deskargatu bilatzen ari zaren eskualdea edo saiatu inguruko herri/hiri izena gehitzen.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Bilaketa historia</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ikusi azken bilaketak.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Garbitu bilaketa historia</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org-eko artikulua</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Zure kokapena</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Hasi</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Abiapuntua</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Helmuga</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Nabigazioa zure uneko kokapenetik soilik dago erabilgarri.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Zure uneko kokapenetik ibilbide bat antolatzea nahi duzu?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Hurrengoa</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>etatik</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Etara</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Gehitu ordutegia</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Ezabatu ordutegia</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Egun osoa (24 ordu)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Ireki</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Itxita</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Gehitu ixteko ordutegia</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Irekitzeko ordutegia</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modu aurreratua</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modu erraza</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Ixteko orduak</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Adibide balioak</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Konpondu akatsa</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Hautatu kokapena</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Mesedez, deskribatu arazoa xehetasunez, OpenStreetMap komunitateak akatsa konpondu dezan.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Edo zuk zeuk egin hemen https://www.openstreetmap.org/ helbidean</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Bidali</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Arazoa</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Tokia ez da existitzen</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Mantentze lanetarako itxita</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Toki bikoiztua</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Deskarga automatikoa</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Egunero</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Gaur atseden eguna</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Itxita</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Gaur</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>%1 barru irekiko da</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>%1 barru itxiko da</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Itxita</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editatu ordutegia</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Ez al duzu OpenStreetMap konturik?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Eman izena OpenStreetMap-en</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Saioa hasi</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Ez zaude saiatuta</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Hasi saioa OpenStreetMap-en</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Pasahitza</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Pasahitza ahaztu duzu?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Saioa itxi</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editatu tokia</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Gehitu hizkuntza bat</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Kalea</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Etxeko zenbakia</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Xehetasunak</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sare sozialak</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Eraikina</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Gehitu kale bat</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Sartu kalearen izena</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Aukeratu hizkuntza bat</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Aukeratu kale bat</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Sukaldea</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Aukeratu sukaldea</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Posta elektronikoa edo erabiltzailea</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Gehitu telefonoa</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Solairua</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Maila: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Mapan egin dituzun aldaketa guztiak maparekin batera ezabatuko dira.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Eguneratu mapak</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Ibilbide bat sortzeko, beharrezkoa da mapa guztiak eguneratzea eta ibilbidea berriro planifikatzea.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Bilatu mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Mesedez, egiaztatu ezarpenak eta ziurtatu zure gailua Internetera konektatuta dagoela.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Leku nahikorik ez</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Ezabatu beharrezkoak ez diren datuak</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Saioa hasteko errorea.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Egiaztatutako aldaketak</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arrastatu mapa gurutzea tokiaren edo negozioaren kokalekuan kokatzeko.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editatzen</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Gehitzen</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Tokiaren izena</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Bertako hizkuntzan idatzita dagoenez</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Arazoaren deskribapen zehatza</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Beste arazo bat</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Gehitu aktibitatea</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Hemen ezin da objekturik jarri</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Komunitateak sortutako OpenStreetMap datuak %1-tik aurrera. Lortu informazio gehiago mapa editatu eta eguneratzeari buruz OpenStreetMap.org helbidean</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) mapa libre eta irekia eraikitzeko komunitateko proiektu bat da. Organic Maps-en mapen datuen iturri nagusia da eta Wikipediaren antzera funtzionatzen du. Tokiak gehitu edo edita ditzakezu eta mundu osoko milioika erabiltzailerentzat eskuragarri egongo dira.
+Sartu komunitatean eta lagundu mapa hobea egiten guztiontzat!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Sortu OpenStreetMap kontu bat edo hasi saioa zure maparen aldaketak munduan argitaratzeko.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Deskargatu sare mugikorreko konexioarekin?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Oso garestia izan daiteke roaming plan batzuekin edo datu-ibiltaritzarekin.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Sartu etxeko zenbaki baliozkoa</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Solairu kopurua (gehienez %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Solairu kopurua ez da %1-tik gorakoa izan behar</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Posta kodea</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Sartu baliozko posta-kodea</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap-eko boluntarioentzako oharra (aukerakoa)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Deskribatu mapako akatsak edo editatu ezin diren gauzakOrganic Maps erabiliz.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Zure aldaketak &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; datu-base publikora kargatzen dira. Mesedez, ez gehitu informazio pertsonalik edo copyrightdun informaziorik.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap-i buruzko informazio gehiago</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Zure edizio-historia</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Zure mapa-datuen oharrak</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operadorea</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operadorea: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Ezin duzu kategoria egokirik aurkitu?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps-ek puntu kategoria soilak gehitzeko aukera ematen du, hau da, ez da herririk, errepiderik, lakurik, eraikinen eskemarik, etab. Gehitu kategoria horiek zuzenean &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Begiratu gure &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;gida&lt;/a&gt; urratsez urrats argibide zehatzak lortzeko.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Ez duzu maparik deskargatu</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Deskargatu mapak kokapena aurkitzeko eta lineaz kanpo nabigatzeko.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Uneko kokapena ezezaguna da.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>e</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Gehiago</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editatu markagailua</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Ohar pertsonalak (testua edo html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Iruzkina…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Tokiko aldaketa guztiak berrezarri nahi dituzu?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Berreskuratu</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Gehitutako tokia ezabatu?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Ezabatu</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Tokia ez da existitzen</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Zehaztu tokia ezabatzeko arrazoia</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Idatzi baliozko telefono zenbaki bat</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Sartu baliozko web helbide bat</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Sartu baliozko posta elektroniko bat</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Idatzi baliozko Facebook-eko web helbide, kontu edo orri izena</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Sartu baliozko Instagram kontuaren izena edo web helbidea</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Sartu baliozko Twitter erabiltzaile izena edo web helbide bat</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Sartu baliozko web helbide bat edo VK kontuaren izena</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Sartu baliozko web helbidea edo LINEko IDa</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Gehitu lekua OpenStreetMap-era</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Edo, bestela, utzi ohar bat OpenStreetMap komunitateari, beste norbaitek hemen leku bat gehitu edo konpon dezan.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Oharra OpenStreetMap-era bidaliko da</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Erabiltzaile guztiei bidali nahi diezu?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Ziurtatu ez duzula datu pertsonalik sartu.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editoreek aldaketak egiaztatuko dituzte eta zurekin harremanetan jarriko dira zalantzaren bat izanez gero.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Gelditu</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Arrastoa grabatzen</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Onartu</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Ukatu</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Internet mugikorra erabili informazio zehatza bistaratzeko?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Erabili beti</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Gaur bakarrik</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ez erabili gaur</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mugikorra</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Internet mugikorra behar da tokiei buruzko informazio zehatza bistaratzeko, hala nola argazkiak, prezioak eta iritziak.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ez erabili inoiz</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Galdetu beti</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Trafiko datuak bistaratzeko, mapak eguneratu behar dira.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Handitu letra tamaina mapan</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Eguneratu Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Trafiko datuak ez daude eskuragarri</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Historia gaitu</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Iritzi orokorra</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>TTS sistema erabiltzen dugu ahots argibideetarako. Android gailu askok Google TTS erabiltzen dute. Google Play-tik deskargatu edo egunera dezakezu</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Zenbait hizkuntzatan, beste ahots-sintetizadore bat edo hizkuntza-pakete gehigarri bat instalatu behar duzu aplikazio-dendatik (Google Play, Galaxy Store, App Gallery, FDroid).&#32;
+Ireki zure gailuaren Ezarpenak &gt; Hizkuntza eta sarrera &gt; Hizkera &gt; Hizketarako testurako aukerak.&#32;
+Hemen ahots-sintesiaren ezarpenak kudea ditzakezu (adibidez, hizkuntza pakete bat deskargatu, konexiorik gabe erabiltzeko) edo testu-hizketarako beste motor bat hauta dezakezu.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Informazio gehiago lortzeko, ikusi gida hau.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Latinezko transliterazioa</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Irakurri gehiago</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Erabili bilaketa edo sakatu mapan ibilbidearen abiapuntua gehitzeko</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Erabili bilaketa edo sakatu mapan helmuga puntu bat gehitzeko</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Kudeatu ibilbidea</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifikatu</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Kendu geltokia</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Gehitu geltokia</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Gordeta</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Hasi saioa OpenStreetMap-en zure mapen aldaketa guztiak automatikoki kargatzeko. Lortu informazio gehiago &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hemen&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Biltegiratze sarbidearen arazoa</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Kanpoko biltegiratzea ez dago erabilgarri; Baliteke SD txartela kendu edo hondatuta egotea, edo fitxategi sistema irakurtzeko soilik izatea. Mesedez, begiratu edo idatzi iezaguzu support@organicmaps.app helbidera</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulatu kaltetutako biltegiratzea</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Mesedez, idatzi baliozko izen bat</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Zerrendak</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ezkutatu guztiak</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Erakutsi guztiak</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n markagailu</numerusform>
+<numerusform>%n markagailuak</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Sortu zerrenda berria</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Inportatu markagailuak eta arrastoak</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Ezin izan da partekatu aplikazioaren errore baten ondorioz</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Partekatzeak huts egin du</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Ezin da partekatu zerrenda hutsik</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Izena ezin da hutsik egon</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Idatzi zerrendaren izena</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Zerrenda berria</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Izen hau dagoeneko hartua da</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Aukeratu beste izen bat</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Itxaron mesedez…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefono zenbakia</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profila</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>fitxategi %n aurkitu da. Elkarrizketaren ondoren ikusiko duzu.</numerusform>
+<numerusform>%n fitxategi aurkitu dira. Elkarrizketaren ondoren ikusiko dituzu.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Berreskuratu</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n arrasto</numerusform>
+<numerusform>%n arrastos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Pribatutasuna</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Pribatutasun politika</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Erabilera baldintzak</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafikoa</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Mendi-ibilaldiak</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Txirrindularitza</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metroa</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Maparen estiloak eta geruzak</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Zerrenda hau hutsik dago</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Markagailu bat gehitzeko, ukitu mapako toki bat eta, ondoren, ukitu izarraren ikonoa</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Aldatu markagailu guztien kolorea</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Aldatu ibilbide guztien kolorea</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…gehiago</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Esportatu KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Esportatu GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Esportatu GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Ezabatu zerrenda</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Abiadura kamerak</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Tokiaren deskribapena</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Deskargatu mapak</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Abiaduraz ohartarazi</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Beti abisatu</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Inoiz ez abisatu</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energia aurrezteko modua</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Energia aurrezteko modua aktibatuta badago, aplikazioak energia kontsumitzen duten funtzioak itzaliko ditu, telefonoaren uneko kargaren arabera.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Inoiz ez</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automatikoa</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Energia aurrezpen handiena</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Laster-markak mapan</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Laster-marka gehiegi badaude, mapan laster-markak bistaratzeak aplikazioa moteldu dezake.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Erakutsi eskuinean</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Erakutsi behean</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aukera hau diagnostiko helburua duten erregistro ekintzetarako gaituta dago. Honek gure taldeari aplikazioarekin arazoak identifikatzen laguntzen dio. Gaitu aukera Organic Maps laguntzari eskatuta soilik.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Bideratzeko aukerak</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Bidesariak saihestea</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Asfaltatu gabeko saihestea</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Ferriak saihestea</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Autobideak saihestea</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Ezin da ibilbidea proposatu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Zoritxarrez, ezin izan dugu aukeratutako aukerekin ibilbiderik proposatu. Aldatu ezarpenak eta saiatu berriro.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Zehaztu saihestu beharreko bideak</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Bideratze aukerak gaituta</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Ordainpeko errepidea</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Asfaltatu gabeko errepidea</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry zeharkaldia</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Bai</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ez</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Bai</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ez</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Edukiera: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Sarea: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Iritsi zara!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ados</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenatu…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordenatu markagailuak</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Lehenetsia</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Motaren arabera</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Distantziaren arabera</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Dataren arabera</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Izenaren arabera</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Duela aste bat</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Duela hilabete bat</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Duela hilabete baino gehiago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Duela urtebete baino gehiago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Nigandik gertu</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Beste batzuk</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Ibilbidea planifikatzeko errorea</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Iristeko unea: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Deskargatu eta eguneratu proiektatutako bideko mapa guztiak ibilbidea kalkulatzeko.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Munduko mapa aldatu duzu. Ez ezazu zeuretzat gorde. Esan zure lagunei eta editatu elkarrekin.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Partekatu lagunekin</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Orain itxita</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Bihar %1ean irekiko da</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1ean %2etan irekiko da</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1etan irekiko da</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1etan itxiko da</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Gehitu ordutegia</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Pasahitza (gutxienez 8 karaktere)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Erabiltzaile izena edo pasahitza baliogabea.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM kontua</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Azken karga</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Eskerrik asko</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Tokiaren izena</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefonoa</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Abisua</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Deskargaren errorea</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Hautatu kategoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Ospetsua</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kategoria guztiak</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Gehitu toki berriak mapan eta editatu uneko tokiak zuzenean aplikaziotik.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Aldatu kokapena</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Leku gehiago behar duzu deskargatzeko. Ezabatu beharrezkoak ez diren datuak.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Organic Maps mapak hobetu ditut</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Iruzkin zehatza</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Zure proposatutako mapen aldaketak OpenStreetMap komunitateari bidaliko zaizkio. Mesedez, azaldu Organic Maps-en editatu ezin diren bestelako xehetasun guztiak.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Errore bat gertatu da zure kokapena bilatzean. Egiaztatu gailua behar bezala dabilela eta saiatu berriro geroago.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Kokapen zerbitzuak desaktibatuta daude</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aktibatu geokokapenerako sarbidea gailuaren ezarpenetan</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ireki ezarpenak</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Sakatu &quot;Kokapena&quot;</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Hautatu aplikazioa erabiltzean</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Hautatu Pribatutasuna</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Hautatu Kokapen zerbitzuak</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Aktibatu Kokapen Zerbitzuak</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Edo jarraitu kokapenik gabeko Organic Maps erabiltzen</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Erreserba</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Deitu</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Markagailuaren izena</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Ezabatu markagailua</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Zure oharra OpenStreetMap-era bidaliko da</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…gehiago</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Eguneratu</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Bidaiatutako azken ibilbidearen grabaketa desaktibatu nahi duzu?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desgaitu</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Egiaztatu</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps-ek zure geokokapena erabiltzen du atzeko planoan egindako azken ibilbidea erregistratzeko.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Ezarpen orokorrak</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Trafiko datuak bistaratzeko, aplikazioa eguneratu behar duzu.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Erregistro fitxategiaren tamaina: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arrastatu hona kentzeko</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Ordeztu geldialdia</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Hasi hemendik</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Hasi saioa OpenStreetMap-en zure mapen aldaketa guztiak automatikoki kargatzeko. Lortu informazio gehiago</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hemen</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ezkutatu pantaila</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2/%3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 deskargatzen…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 aplikatzen…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Izen hau luzeegia da</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Fitxategi berriak detektatu dira</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Bihurtu</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Errorea</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Fitxategi batzuk ez dira bihurtu.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Akats bat gertatu da</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Ospetsua</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ezkutatu mapan</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Errore bat gertatu da etiketak kargatzean. Saiatu berriro</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Eskubidea</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Behealdea</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Goazen</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Helmuga</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Berriz zentratu</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Bilaketa emaitzak</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Gero</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Ibilbidea berreraiki nahi duzu?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Teklatua ez dago erabilgarri mugimenduan zehar</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Ezin da ibilbidea eraiki uneko kokapenetik</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Ezin da sortu helmugarako ibilbidea. Aukeratu beste bat</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ez dago GPS seinalerik. Joan eremu ireki batera</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Ezin da ibilbiderik eraiki. Aukeratu beste bide-puntu batzuk</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Ibilbide bat eraikitzeko, deskargatu falta diren mapak zure gailura</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Akats bat gertatu da. Berrabiarazi aplikazioa</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Ibilbidea zure uneko kokapenetik birkalkulatuko da</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Ibilbidea auto modura aldatuko da</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ez dira laster-marka guztiak erakusten</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Aldatu telefonora laster-mark guztiak ikusteko</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Abiadura kamerak.</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Abiadura alertak.</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Deskargatu mapak zure gailuko Organic Maps aplikazioan</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 irteera</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenatu lehenespenez</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordenatu motaren arabera</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenatu distantziaren arabera</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenatu dataren arabera</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordenatu izenaren arabera</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Janariak</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Toki interesgarriak</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museoak</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parkeak</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Igerilekua</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mendiak</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animaliak</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotelak</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Eraikinak</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dirua</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Dendak</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Aparkalekuak</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gasolindegiak</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medikuntza</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Bilatu zerrendan</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Erlijio guneak</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Hautatu zerrenda</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metroko nabigazioa oraindik ez dago erabilgarri eskualde honetan</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Ez da aurkitu metroko ibilbiderik</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Aukeratu metrotik hurbilen dagoen ibilbidearen hasiera edo amaiera puntua</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Sestra kurbak</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Sestra kurbak erabiltzeko, eguneratu edo deskargatu nahi duzun eremuko mapa</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Erliebearen altitudea oraindik ez dago eskuragarri eskualde honetan</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Maldan gora</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Maldan behera</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Altitude min</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Altitude max</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Zailtasuna</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distantzia:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Denbora:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Handitu mapa sestra kurbak ikusteko</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Deskargatzen</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Deskargatu munduko aurrebista mapa</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Ezin da karpeta sortu eta fitxategiak mugitu barneko gailuaren memorian edo sd txartelan</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Diskoaren akatsa</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Konexio arazoa</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Deskonektatu USB kablea</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mantendu pantaila piztuta</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Gaituta dagoenean, pantaila beti egongo da piztuta mapa bistaratzen denean.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Erakutsi pantaila blokeatuan</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Gaituta dagoenean, ez duzu gailua desblokeatu beharrik aplikazioa abian dagoen bitartean.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Maparen hizkuntza</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap-eko mapa-datuak</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/eu/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/eu/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Eskerrik asko gure komunitateak eraikitako mapak erabiltzeagatik!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Zure dohaintza eta laguntzarekin, Munduko mapa onenak sor ditzakegu!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Gure aplikazioa gustatzen zaizu? Mesedez, eman dohaintza garapena laguntzeko! Oraindik ez al zaizu gustatzen? Mesedez, jakinarazi iezaguzu, eta konponduko dugu!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Software garatzaile bat ezagutzen baduzu, behar duzun funtzio bat ezartzeko eska diezaiokezu.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Sakatu mapako edozein tokitan edozer hautatzeko. Luze sakatu interfazea ezkutatzeko eta berriro erakusteko.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Ba al dakizu zure uneko kokapena mapan hauta dezakezula?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Gure aplikazioa zure hizkuntzara itzultzen lagun dezakezu.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Gure aplikazioa zale gutxi batzuek eta komunitateak garatzen dute.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Maparen datuak erraz konpondu eta hobetu ditzakezu.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Gure helburu nagusia maite dituzun mapa azkarrak, pribatutasunari begira eta erabilerrazak sortzea da.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Organic Maps telefonoaren pantailan erabiltzen ari zara</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Organic Maps autoaren pantailan erabiltzen ari zara</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Android Auto-ra konektatuta zaude</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Jarraitu telefonoan</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Autoaren pantailara</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps-ek kokapenerako sarbidea behar du. Seguru dagoenean, egiaztatu zure telefonoko jakinarazpena.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Aplikazio honek zure baimena behar du</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto-ko Organic Maps-ek kokapen-baimena behar du eraginkortasunez funtzionatzeko</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Eman baimenak</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Landa-eremua</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web arakatzailea ez dago erabilgarri</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Bolumena</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Esportatu markagailu eta arrasto guztiak</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Sistemaren ahots-sintesiaren ezarpenak</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Ahots-sintesiaren ezarpenak ez dira aurkitu. Ziur zure gailuak onartzen duela?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Autoz hartzeko</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Garbitu bilaketa</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Handitu</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Txikiagotu</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menuaren esteka</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ikusi menua</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Ireki beste aplikazio batean</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autozerbitzu</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Hautatu aukera</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Kanpoko eserlekuak</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Nabigazio zehatzena lortzeko, telefonoaren bateriaren ezarpenetan energia aurrezteko modua desgaitzea gomendatzen dugu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Grabatu arrastoa</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Gelditu arrastoaren grabaketa</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Ibilbidearen grabaketa</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Gelditu gorde gabe</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Jarraitu grabatzen</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Markagailu eta arrastoetan gorde nahi duzu?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Arrastoa hutsik dago; ez dago ezer gordetzeko</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Ezin da karpeta hautatzeko elkarrizketa-koadroa erakutsi zure gailuan ez dagoelako aplikazio egokirik instalatuta. Instalatu fitxategi-kudeatzaile aplikazio bat eta saiatu berriro.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Aukeratu kolorea</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editatu arrastoa</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ez dago kokapena ireki dezakeen aplikaziorik instalatuta</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Nabigazioan automatikoa</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Jarraitu sistemari</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Partekatu arrastoa</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Ezabatu %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Zailtasun maila</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Erraza</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderatua</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Zaila</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Eguneratzen</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Eguneratu deskargatutako mapak</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Maparen freskatzeak objektuen informazioa eguneratuta mantentzen du</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Eguneratu (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Eguneratu geroago eskuz</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Ezabatu arrastoa</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ziur pista hau ezabatu nahi duzula?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Arrastoaren izena</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mugitu</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Arrastoa</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Kolorea aldatu</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Akatsen txostena bidali nahi diezu garatzaileei?
+Gure erabiltzaileengan oinarritzen gara Organic Maps-ek ez baitu automatikoki akatsen informaziorik biltzen. Eskerrik asko aldez aurretik Organic Maps laguntzeagatik!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Gaitu iCloud sinkronizazioa</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud sinkronizazioa garatzen ari den ezaugarri esperimental bat da. Ziurtatu zure laster-marka eta ibilbide guztien babeskopia egin duzula.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud desgaituta dago</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Mesedez, gaitu iCloud zure gailuaren ezarpenetan eginbide hau erabiltzeko.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Gaitu</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Babeskopia</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud sinkronizazioaren hutsegitea</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Errorea: Ezin izan da sinkronizatu konexio-errore baten ondorioz</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Errorea: Ezin izan da sinkronizatu iCloud kuota gainditu delako</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Errorea: iCloud ez dago erabilgarri</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Duela gutxi ezabatutako zerrendak</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Garbitu</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Ezabatu guztiak</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Berreskuratu</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Guztia berreskuratu</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Lagundu OpenStreetMap-en</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Gehitu lekua</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Eguneratu mapa laguntzeko</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap datuetan lagundu ahal izateko, %1 mapa azken bertsiora eguneratu behar duzu</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Nire kokapena</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Nire tokiak</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Barne biltegiratze pribatua</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Barne biltegiratze partekatua</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD txartela</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Kanpoko biltegiratze partekatua</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Posta kodea</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Maparen puntua</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>oin</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Arrastoak ikusteko mapak eguneratu behar dira.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Irten</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Sarrera</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metroaren mapa ez dago erabilgarri</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Zuk</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Deskargatutako eskualde moreak</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ibilbidea</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Beharrezkoa da inguruneko egungo kokapena definitzea aplikazioaren funtzionaltasunaz guztiz gozatzeko. Ibilbidea jarraitu eta duela gutxi egindako bidea gordetzeko aukeretan erabiltzen da.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Uneko kokapenaren definizioa ibilbidea jarraitu eta duela gutxi egindako bidea gordetzeko aukeretan erabiltzen da.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Sartu pasahitzarekin</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>arakatzailea erabiliz saioa hasi</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Orain dela gutxi erabilitakoa</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Markagailuen kolorea aldatu da</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Ibilbideen kolorea aldatu da</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espektroa</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Irristagailuak</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>GORRIA</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>BERDEA</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>URDIN</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex kolorea #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Sarea</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/fa/omim.ts
+++ b/qt/translations/fa/omim.ts
@@ -1,0 +1,3929 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="fa">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>بازگشت</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>لغو</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>حذف</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>دانلود نقشه‌ها</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>دانلود ناموفق بود. برای تلاش مجدد لمس کنید.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>در حال دانلود…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>کیلومتر</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>مایل</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>بعداً</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>جست‌وجو</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>جست‌وجوی نقشه</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>سرویس موقعیت مکانی شما غیر فعال است. لطفا جهت کارکرد صحیح نرم افزار آن را فعال کنید.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>دقت محدود</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>برای اطمینان از دقیق ناوبری ، موقعیت مکانی دقیق را در تنظیمات فعال کنید.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>بر روی نقشه نمایش بده</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>دانلود با شکست مواجه شد</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>تلاش مجدد</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>درباره‌ی Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>رایگان برای همه ، ساخته شده با عشق</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• بدون تبلیغات، ردیابی، جمع‌آوری داده‌ها</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• بدون تخلیه باتری، آفلاین کار می کند</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• سریع، ساده‌گرایی، توسعه‌یافته توسط اجتماع</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>برنامه منبع باز ایجاد شده توسط علاقه مندان و داوطلبان.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>تنظیمات مکان</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>بستن</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>این برنامه به OpenGL با شتاب سخت‌افزاری نیاز دارد. متاسفانه دستگاه شما پشتیبانی نمی‌شود.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>دانلود</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>لطفا کابل USB را جدا کنید یا کارت حافظه وارد کنید تا بتوانید از Organic Maps استفاده کنید</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>لطفا مقداری از فضای ذخیره‌سازی را آزاد نمایید</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>قبل از استفاده از برنامه، اجازه دهید تا ما نقشه جهانی را بر روی موبایل شما دانلود کنیم.&#32;
+مقدار %1 از حافظه شما اشغال می‌شود.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>برو به نقشه</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>درحال دانلود %1. شما اکنون می توانید
+به نقشه بروید.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>دانلود %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>به‌روزرسانی %1؟</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>مکث</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>ادامه</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 دانلود با شکست مواجه شد</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>افزودن فهرست جدید</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>نام فهرست نشانک</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>نشانک‌ها</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>نشانک‌ها و مسیرها</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>نام</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>نشانی</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>فهرست</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>تنظیمات</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>ذخیره نقشه‌ها در</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>پوشه‌ای را برای دانلود نقشه‌ها انتخاب کنید.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>نقشه‌ها</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 خالی از %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>آیا نقشه‌ها جابه‌جا شود؟</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>خطا در جابجایی پرونده‌های نقشه</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>ممکن است چند دقیقه طول بکشد.
+لطفا صبر کنید…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>واحد اندازه‌گیری</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>بین مایل و کیلومتر انتخاب کنید</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>لغو دانلود</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>نظر خود را بیان کنید</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>بله</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>دانلود نقشه</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>فهرست‌های نشانک‌ها</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>کجا غذا بخوریم</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>عطاری</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>حمل و نقل</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>سوخت</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>پارکینگ</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>خرید کردن</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>دست دوم</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>هتل</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>منظره</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>سرگرمی</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>خود‌پرداز</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>تفریحات شبانه</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>تعطیلات خانوادگی</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>بانک</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>داروخانه</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>بیمارستان</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>توالت</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>پست</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>پلیس</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>بازیافت</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>آب</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>امکانات ماشین کاروان</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>یادداشت‌ها</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>نشانک‌های Organic Maps با شما هم‌رسانی شده‌اند</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>سلام!
+
+نشانک‌های من ضمیمه شده‌اند؛ لطفا آن‌ها را در Organic Maps باز کنید. اگر برنامه نصب نشده است، می‌توانید آن را از اینجا دانلود کنید: https://omaps.app/get?kmz&#32;
+
+از سفر با Organic Maps لذت ببرید!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>در حال بارگیری نشانک‌ها</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>نشانک‌ها با موفقیت بارگیری شدند! می‌توانید آن‌ها را روی نقشه یا در صفحه مدیریت نشانک‌ها پیدا کنید.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>بارگیری نشانک‌ها ناموفق بود. ممکن است پرونده خراب یا ناقص باشد.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>نوع فایل توسط برنامه تشخیص داده نمی شود:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>فایل باز نشد %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>ویرایش</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>مکان شما هنوز مشخص نشده است</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>متأسفیم، تنظیمات ذخیره‌سازی نقشه در حال حاضر غیرفعال است.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>دانلود نقشه در حال انجام است.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>مکان فعلی من را در Organic Maps بررسی کنید! %1 یا %2 نقشه‌های آفلاین ندارید؟ از اینجا دانلود کنید: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>سلام، مکان من را در Organic Maps بررسی کن!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>سلام، مکان فعلی من را روی نقشه Organic Maps بررسی کن!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>سلام،&#32;
+&#32;
+من الان اینجا هستم: %1. این پیوند را کلیک کنید %2 یا این یکی %3 تا مکان را روی نقشه ببینید.&#32;
+&#32;
+سپاسگزارم.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>هم‌رسانی</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>ایمیل</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>کپی در کلیپ‌برد: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>انجام شد</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>داده‌های OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>آیا مطمئن هستید که می خواهید از حساب OpenStreetMap خود خارج شوید؟</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>مسیرها</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>طول</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>هم‌رسانی موقعیت مکانی من</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>تنظیمات عمومی</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>اطلاعات</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>مسیریابی</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>دکمه‌های + و - روی نقشه</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>نمایش بر روی نقشه</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>سبک شب هنگام ناوبری در تاریکی</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>حالت شب</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>خاموش</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>روشن</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>خودکار</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>نمای چشم انداز</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>ساختمان‌های سه بعدی</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>ساختمان های سه بعدی در حالت صرفه جویی در مصرف برق خاموش می شوند</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>دستور العمل صوتی</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>نام خیابان ها را اعلام کنید</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>وقتی فعال باشد، نام خیابان یا خروجی که باید به آن بپیچید با صدای بلند گفته می شود.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>زبان صوت</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>برای دانلود صدای باکیفیت‌تر، برنامه تنظیمات را باز کنید و به دسترس‌پذیری → VoiceOver → گفتار → صدا بروید.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>تست مسیرهای صوتی (TTS، تبدیل متن به گفتار)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>اگر اکنون صدا را نمی شنوید، میزان صدا یا تنظیمات تبدیل متن به گفتار سیستم را بررسی کنید.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>موجود نیست</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>بزرگنمایی خودکار</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>مسافت</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>مشاهده بر روی نقشه</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>منو</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>وبگاه</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>اخبار</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>بازخورد</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>به برنامه امتیاز دهید</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>کمک</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>سوالات متداول</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>حمایت مالی</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>قبلاً اهدا شده</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>بعداً یادآوری کن</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>پشتیبانی از Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>از پروژه حمایت کنید</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>حق نشر و کپی رایت</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>گزارش خطا</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>برای کالیبره کردن قطب نما، جهت پیکان را با حرکت دادن تلفن در یک حرکت شکل هشت بهبود دهید.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>تلفن را به شکل هشت حرکت دهید تا قطب نما را کالیبره کنید و جهت پیکان را روی نقشه ثابت کنید.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>دوباره روی نقشه ضربه طولانی بزنید تا رابط کاربری را ببینید</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>به‌روزرسانی همه</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>لغو همه</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>دانلود شده</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>صف</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>نزدیک من</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>نقشه‌ها</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>دانلود همه</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>درحال دانلود:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>برای حذف نقشه، لطفا مسیریابی را متوقف کنید.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>تنها مسیر‌هایی می توانند ایجاد شوند که به طور کامل در یک نقشه از یک منطقه واحد قرار داشته باشند.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>دانلود نقشه</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>تلاش مجدد</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>حذف نقشه</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>به‌روزرسانی نقشه</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>خدمات مکان Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>به سرعت مکان تقریبی خود را با استفاده از بلوتوث، WiFi یا شبکه تلفن همراه تعیین کنید</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>دانلود تمامی نقشه‌ها در طول مسیر‌تان</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>به منظور ایجاد مسیر ما نیاز داریم تا تمامی نقشه‌های شما از مبدا تا مقصد را به‌روزرسانی کنیم.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>فضای کافی موجود نیست</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>لطفا خدمات مکان‌یابی را فعال کنید</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>ذخیره</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>ایجاد</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>قرمز</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>زرد</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>آبی</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>سبز</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>بنفش</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>نارنجی</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>قهوای</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>صورتی</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>ارغوانی سیر</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>آبی کمرنگ</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>فیروزه‌ای</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>آبی سیر</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>زرد لیمویی</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>نارنجی سیر</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>خاکستری</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>خاکستری کبود</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>اطلاعات</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>نسخه Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>ظاهری</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>روشن</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>تیره</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>روشن از سپیده‌دم تا غروب</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>بیشتر</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>نقشه‌های رایگان و بدون تبلیغات را به میلیون‌ها کاربر هدیه دهید!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>داده های نقشه نادرست را گزارش یا اصلاح کنید</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>داوطلب شدن</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>دنبال کنید و با ما تماس بگیرید:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>کلاینت ایمیل شما پیکربندی نشده است.لطفا آن را پیکربندی کنید یا از طریق دیگر با ما تماس بگیرید %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>خطا در ارسال ایمیل</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>تنظیم کردن قطب نما</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>موجود</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>یافت شد</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>به‌روزرسانی</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>ناموفق</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>نشانک</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>زمانی که مسیری را دنبال می کنید لطفا به یاد داشته باشید:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— شرایط جاده، قوانین راهنمایی و رانندگی و علائم جاده‌ای همیشه نسبت به راهنمایی‌های مسیریابی اولویت دارند؛</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>—نقشه ممکن است اشتباه باشد و مسیر پیشنهادی همیشه بهترین مسیر برای رسید به مقصد شما نباشد;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— مسیرهای پیشنهادی تنها به عنوان توصیه در نظر گرفته شوند؛</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>—در مسیرهایی که از مناطق مرزی میگذرد احتیاط کنید:مسیر‌هایی که بوسیله اپلیکیشن ما ایجاد می شود گاهی اوقات ممکن است مرز‌های کشور‌ها را رد کند که این در بعضی مناطق غیر مجاز است.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>لطفا هوشیار و ایمن در جاده بمانید!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>سیگنال GPS را چک کنید</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>امکان ایجاد مسیر وجود ندارد. مختصات GPS فعلی قابل شناسایی نیست.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>لطفا سیگنال GPS موبایتان راچک کنید.و WiFi موبایلتان را جهت دقت بیشتر در موقعیت‌یابی فعال کنید.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>فعال کردن سرویس موقعیت مکانی (GPS)</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>ناتوان از مشخص کردن موقعیت مکانی شما.لطفا سرویس موقعیت مکانی خود را فعال کنید.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>ناتوان در تعیین مسیر</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>امکان ایجاد مسیر وجود ندارد.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>لطفا مبدا یا مقصد خود را تنظیم کنید.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>مبدا خود را تنظیم کنید</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>مسیر ایجاد نشد. امکان پیدا کردن مبدا برای شروع وجود ندارد.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>لطفا نقطه شروع را نزدیک‌تر به جاده انتخاب کنید.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>تنظیم مقصد</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>مسیر ایجاد نشد.ناتوان در تعیین مقصد.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>لطفا مقصد تعیین شده را نزدیک‌تر به جاده انتخاب نمایید.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>ناتوان در تعیین نقطه میانی.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>لطفا نقطه میانی را تنظیم کنید.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>خطای سیستم</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>ناتوان در ایجاد مسیر به علت خطای برنامه.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>لطفا دوباره تلاش کنید</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>اکنون خیر</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>ایا مایل به دانلود نقشه و ایجاد مسیر‌های بهینه بیشتری که نقشه‌های بیشتری را پوشش میدهد هستید؟</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>دانلود نقشه‌های اضافی برای ایجاد مسیری بهتر که حاشیه‌های این نقشه را رد می کند.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>دانلود فایل‌های مورد نیاز</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>برای محاسبه مسیر، همه نقشه‌های مسیر پیش‌بینی‌شده را دانلود یا به‌روزرسانی کنید.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>برای شروع جستجو و مسیر‌یابی لطفا نقشه رادانلود کنید بعد از آن دیگر نیازی به اتصال به اینترنت ندارید و برنامه کاملا آفلاین اجرا می شود.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>انتخاب نقشه</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>نمایش</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>مخفی کردن</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>دسته‌بندی‌ها</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>تاریخچه</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>اوه، نتیجه‌ای یافت نشد.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>منطقه ای را که در آن جستجو می کنید دانلود کنید یا نام شهر/ روستای اطراف را اضافه کنید.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>سوابق جستجو</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>جستجوهای اخیر خود را مشاهده کنید.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>پاک کردن سابقه جستجوها</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>ویکی پدیا</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>مقاله‌ای از wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>ویکی‌انبار</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>موقعیت شما</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>شروع</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>مسیر از</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>مسیر به</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>مسیر‌یابی فقط از موقعیت کنونی شما قابل انجام است.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>آیا می خواهید یک مسیر را از موقعیت فعلیتان برنامه ریزی کنیم؟</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>بعدی</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>از ساعت</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>الی</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>اضافه کردن برنامه ریزی</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>حذف کردن برنامه ریزی</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>شبانه روزی (24 ساعته)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>باز</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>بسته</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>اضافه کردن ساعات غیر کاری</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>ساعات کاری</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>حالت پیشرفته</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>حالت ساده</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>ساعات غیر کاری</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>مقادیر پیش فرض</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>تصحیح خطا</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>مکان را انتخاب کنید</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>لطفا مشکلتان را با جزئیات توضیح دهید بطوری که انجمن OSM بتوانند آن را برطرف کنند.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>یا خودتان آن را انجام دهید در وبسایت https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>ارسال</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>مشکل</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>مکان وجود ندارد</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>به علت تعمیرات بسته است</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>مکان تکراری</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>دانلود خودکار</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>روزانه</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>شبانه روزی</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>امروز تعطیل است</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>تعطیل است</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>امروز</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>در %1 باز می‌شود</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>در %1 بسته می‌شود</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>تعطیل</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>ویرایش ساعت کاری</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>آیا حساب OpenStreetMap ندارید؟</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>نام‌نویسی در OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>ورود</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>وارد نشده‌اید</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>ورود به OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>رمز عبور</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>رمز عبور خود را فراموش کردید؟</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>خروج از حساب</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>ویرایش مکان</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>افزودن یک زبان</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>خیابان</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>شماره ساختمان</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>جزئیات</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>رسانه های اجتماعی</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>ساختمان</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>اضافه کردن خیابان</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>نام خیابان را وارد کنید</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>انتخاب یک زبان</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>انتخاب یک خیابان</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>غذا‌خوری</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>انتخاب غذاخوری</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>ایمیل یا نام کاربری</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>افزودن تلفن</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>طبقه</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>سطح: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>تمام ویرایش‌های که بر روی نقشه انجام داده اید به همراه نقشه حذف شد.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>به‌روزرسانی نقشه‌ها</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>برای ایجاد مسیر، باید تمام نقشه‌ها را به‌روزرسانی کنید و سپس دوباره مسیر را برنامه‌ریزی کنید.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>یافتن نقشه</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>لطفا تنظیمات خود را بازبینی کنید و مطمئن شوید که ابزار شما به اینترنت متصل است.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>فظای کافی موجود نیست</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>لطفا داده‌های غیر ضروری را از دستگاه خود حذف کنید</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>خطای ورود.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>تغییرات تایید شد</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>نقشه را بکشید تا صلیب را در محل مکان یا کسب و کار قرار دهید.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>درحال ویرایش</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>درحال افزودن</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>نام مکان</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>همانطور که به زبان محلی نوشته شده است</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>دسته بندی</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>توضیح مفصل در مورد مشکل</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>مشکلی دیگر</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>اضافه کردن یک تجارت</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>نمی توان شی ای در این مکان باشد</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>داده های OpenStreetMap ایجاد شده توسط انجمن از %1. درباره نحوه ویرایش و به روز رسانی نقشه در OpenStreetMap.org بیشتر بیاموزید</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) یک پروژهٔ اجتماعی برای ساختن نقشه‌ای آزاد و باز است. این منبع اصلی داده‌های نقشه در Organic Maps است و به‌طور مشابهی با ویکی‌پدیا کار می‌کند. شما می‌توانید مکان‌ها را اضافه یا ویرایش کنید و آن‌ها در اختیار میلیون‌ها کاربر در سراسر جهان قرار می‌گیرند. به جامعه بپیوندید و به ساختن نقشه‌ای بهتر برای همه کمک کنید!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>یک حساب OpenStreetMap ایجاد کنید یا وارد شوید تا ویرایش های نقشه خود را در جهان منتشر کنید.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 از %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>دانلود بر روی یک شبکه دیتای موبایل؟</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>این کار می تواند برای شما در بعضی طرح‌ها و یا حالت رومینگ هزینه اضافی در بر داشته باشد.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>وارد کردن شماره ساختمان معتبر</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>تعداد طبقات ( حداکثر %1 )</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>تعداد طبقات نباید بیش از %1 باشد</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>کدپستی</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>یک کد‌ پستی معتبر وارد کنید</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>توجه به داوطلبان OpenStreetMap (اختیاری)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>خطاهای روی نقشه یا مواردی را که قابل ویرایش نیستند با Organic Maps توصیف کنید</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>ویرایش های شما در پایگاه داده عمومی &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; آپلود می شود. لطفا اطلاعات شخصی یا دارای حق چاپ را اضافه نکنید.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>در مورد OpenStreetMap بیشتر بدانید</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>سابقه ویرایش شما</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>یادداشت های داده های نقشه شما</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>اپراتور</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>اپراتور: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>آیا نمی توانید یک دسته بندی مناسب پیدا کنید؟</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps اجازه میu200cدهد فقط دستهu200cهای نقطهu200cای ساده را اضافه کند، یعنی هیچ شهر، جاده، دریاچه، طرح کلی ساختمان و غیره وجود ندارد. لطفاً این دستهu200cها را مستقیماً به &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; اضافه کنید. برای دستورالعملu200cهای گام به گام، &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;راهنمای&lt;/a&gt; ما را بررسی کنید.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>شما هیچ نقشه دانلود شده ای ندارید</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>برای جست وجو یک مکان و استفاده از قابلیت ناوبری، نقشه‌ها را دانلود کنید.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>مکان فعلیتان ناشناس است.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>کیلومتربرساعت (km/h)</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>مایل بر ساعت (mph)</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ساعت</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>دقیقه</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>روز</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>ثانیه</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>بیشتر</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>ویرایش نشانک‌ها</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>یادداشت های شخصی (متن یا html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>دیدگاه…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>آیا تغییرات محلی را نادیده می گیرید؟</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>نادیده گرفتن</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>آیا مکان ثبت شده حذف شود؟</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>حذف</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>مکان وجود ندارد</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>لطفا دلیل حذف مکان را مشخص کنید</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>شماره تلفن معتبری وارد نمایید</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>ادرس وب معتبری وارد نمایید</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>ایمیل معتبری وارد نمایید</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>یک نشانی وب معتبر فیسبوک، حساب کاربری یا نام صفحه وارد کنید</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>یک نام کاربری معتبر اینستاگرام یا نشانی وب وارد کنید</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>یک نام کاربری معتبر توییتر یا نشانی وب وارد کنید</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>یک نام کاربری معتبر VK یا نشانی وب وارد کنید</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>یک شناسه معتبر LINE یا نشانی وب وارد کنید</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>مکان را به OpenStreetMap اضافه کنید</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>یا، به عنوان یک راه حل جایگزین، برای انجمن OpenStreetMap یادداشت بگذارید تا شخص دیگری بتواند مکانی را به اینجا اضافه یا اصلاح کند.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>یادداشت به OpenStreetMap ارسال خواهد شد</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>آیا می خواهید آن را برای دیگر کاربران ارسال کنید؟</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>مطمئن شوید که هیچ اطلاعات شخصی وارد نکرده باشد.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>ویرایشگران OpenStreetMap ﺗﻐﯿﯿﺮﺍﺕ ﺭﺍ ﺑﺮﺭﺳﯽ ﮐﺮﺩﻩ ﻭ ﺩﺭ ﺻﻮﺭﺕ ﺩﺍﺷﺘﻦ ﻫﺮﮔﻮﻧﻪ ﺳﻮﺍﻝ ﺑﺎ ﺷﻤﺎ ﺗﻤﺎﺱ ﺧﻮﺍﻫﻨﺪ ﮔﺮﻓﺖ.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>توقف</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>در حال ضبط مسیر</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>موافقم</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>کاهش</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>از دیتای موبایل برای نمایش اطلاعات بیشتر استفاده شود؟</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>همیشه استفاده کن</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>فقط امروز</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>امروز استفاده نکنید</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>دیتای موبایل</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>برای آگاهی از به‌روزرسانی نقشه و ارسال ویرایش‌ها، اینترنت موبایل مورد نیاز است.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>هرگز</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>همیشه بپرس</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>برای نمایش ترافیک، نقشه می بایستی بروزرسانی شود.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>افزایش اندازه متن بر روی نقشه</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>لطفا Organic Maps را بروزرسانی کنید</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>اطلاعات ترافیکی موجود نیست</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>ورود به سیستم را فعال کنید</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>&quot;تنظیمات: دکمه &quot;ارسال بازخورد کلی</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>ما از TTS سیستم برای دستورالعمل‌های صوتی استفاده می کنیم. بسیاری از دستگاه‌های Android از Google TTS استفاده می کنند، شما می توانید آن را از Google Play دانلود کنید</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>برای برخی زبان‌ها، باید یک موتور تبدیل متن به گفتار یا بسته زبان اضافی را از فروشگاه برنامه (Google Play، Galaxy Store، App Gallery، FDroid) نصب کنید.&#32;
+به تنظیمات دستگاه خود بروید ← زبان و ورودی ← گفتار ← خروجی تبدیل متن به گفتار.&#32;
+در اینجا می‌توانید تنظیمات مربوط به تبدیل متن به گفتار را مدیریت کنید (به عنوان مثال، بسته زبان را برای استفاده آفلاین دانلود کنید) و یک موتور تبدیل متن به گفتار دیگر را انتخاب کنید.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>برای اطلاعات بیشتر لطفا این راهنما را بررسی کنید.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>ترجمه به الفبای لاتین</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>بیشتر بدانید</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>برای افزودن نقطه شروع مسیر، از جستجو استفاده کنید یا روی نقشه ضربه بزنید</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>برای افزودن نقطه مقصد، از جستجو استفاده کنید یا روی نقشه ضربه بزنید</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>مدیریت مسیر</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>برنامه</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>توقف را حذف کنید</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>اضافه کردن توقف</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>ذخیره شد</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>لطفاً به OpenStreetMap وارد شوید تا به طور خودکار تمام ویرایش های نقشه خود را آپلود کنید. &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;اینجا&lt;/a&gt; بیشتر بیاموزید.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>مشکل دسترسی به ذخیره‌سازی</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>حافظه خارجی قابل دسترسی نیست. ممکن است کارت SD برداشته شده، آسیب دیده باشد، یا سیستم پرونده فقط خواندنی باشد. لطفا کارت SD خود را بررسی کنید یا با ما در support@organicmaps.app تماس بگیرید</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>شبیه سازی ذخیره سازی بد</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>لطفا نام صحیح را وارد کنید</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>فهرست‌ها</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>پنهان کردن همه</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>نمایش همه</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n نشانه‌ها</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>ایجاد فهرست جدید</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>وارد کردن نشانک‌ها و مسیرها</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>با توجه به خطای برنامه، امکان هم‌رسانی وجود ندارد</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>خطای هم‌رسانی</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>یک فهرست خالی را نمی‌توان هم‌رسانی کرد</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>نام نمی‌تواند خالی باشد</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>لطفا نام فهرست را وارد کنید</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>فهرست جدید</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>این اسم قبلا انتخاب شده است</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>لطفا نام دیگری را انتخاب کنید</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>لطفا صبر کنید…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>شماره تلفن</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>نمایه OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n فایل پیدا شد. بعد از تبدیل آنها را خواهید دید.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>بازیابی</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n رد</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>حریم شخصی</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>سیاست حریم خصوصی</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>شرایط استفاده</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>ترافیک</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>پیاده‌گردی</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>دوچرخه‌سواری</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>مترو</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>سبک ها و لایه های نقشه</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>این فهرست خالی است</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>برای افزودن یک نشانک، روی یک مکان روی نقشه ضربه بزنید و سپس روی نماد ستاره ضربه بزنید</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>تغییر رنگ همه نشانک‌ها</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>تغییر رنگ همه مسیرها</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…بیشتر</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>صادرات KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>صادرات GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>صادرات GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>حذف فهرست</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>دوربین‌های سرعت</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>توضیحات محل</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>دانلود کننده نقشه</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>هشدار در مورد سرعت غیر مجاز</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>همیشه هشدار دهد</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>هرگز هشدار ندهد</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>حالت ذخیره انرژی</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>سعی کنید مصرف انرژی را کاهش دهید، حتی اگر برخی از قابلیت‌ها محدود شوند.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>هرگز</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>خودکار</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>حداکثر ذخیره انرژی</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>نام‌ها را روی نقشه نشانه‌گذاری کنید</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>اگر نشانک‌ها زیاد باشند، نمایش نام آن‌ها روی نقشه ممکن است باعث کند شدن برنامه شود.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>نمایش به سمت راست</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>در پایین نمایش دهید</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>این گزینه ثبت گزارش را برای اهداف تشخیصی فعال می‌کند. برای کارکنان بخش پشتیبانی که مشکلات برنامه را عیب یابی می‌کنند، مفید باشد. این گزینه را تنها در صورت درخواست پشتیبانی Organic Maps فعال کنید.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>گزینه‌های رانندگی</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>از جاده های عوارضی خودداری کنید</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>اجتناب از جاده‌های آسفالت نشده</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>اجتناب از گذرگاه‌های کشتی</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>از بزرگراه دوری کنید</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>امکان محاسبه مسیر نیست</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>مسیر یافت نشد. این مشکل ممکن است به دلیل تنظیمات مسیر‌یابی شما یا داده‌های ناقص OpenStreetMap باشد. لطفا تنظیمات مسیر‌یابی خود را تغییر دهید و دوباره امتحان کنید.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>جاده‌های لغو شده را تعریف نمایید</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>گزینه‌های مسیریابی فعال شد</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>جاده دارای عوارض</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>جاده آسفالت نشده</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>گذرگاه جاده‌ای</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>بله</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>خیر</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>بلی</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>خیر</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>ظرفیت: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>شبکه: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>شما به مقصد رسیدید!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>موافقت کردن</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>مرتب سازی…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>مرتب‌سازی نشانک‌ها</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>به صورت پیش فرض</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>بر اساس تاریخ</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>بر اساس فاصله</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>بر اساس تاریخ</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>بر اساس اسم</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>یک هفته قبل</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>یک ماه قبل</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>بیش از یک ماه قبل</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>بیش از یک سال قبل</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>نزدیک من</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>دیگران</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>برنامه ریزی مسیر ناموفق</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>ورود به: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>برای محاسبه مسیر، همه نقشه‌های مسیر پیش‌بینی‌شده را دانلود و به‌روزرسانی کنید.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>شما نقشه جهان را تغییر دادید.این افتخار را پیش خود نگه ندارید!به دوستانتان درموردش بگویید و با یکدیگر ویرایش کنید.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>هم‌رسانی با دوستان</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>اکنون تعطیل است</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>فردا در %1 باز می‌شود</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>باز می‌شود %1 در %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>در %1 باز می‌شود</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>در %1 بسته می‌شود</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>اضافه کردن ساعت بازگشایی</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>رمز عبور (حداقل 8 عدد یا حرف)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>نام کاربری یا رمز عبور نامعتبر است.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>حساب OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>آخرین به‌روزرسانی</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>متشکریم</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>نام مکان</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>تلفن</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>لطفا توجه داشته باشد</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>خطا در دانلود</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>انتخاب دسته بندی</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>پرطرفدار</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>همه دسته‌بندی‌ها</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>اضافه کردن مکان به نقشه و ویرایش آن مستقیما از طریق این اپلیکیشن.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>تغییر موقعیت</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>برای دانلود، شما نیازمند فضای ذخیره سازی بیشتری هستید.لطفا داده‌های غیر ضروری خود را حذف کنید.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>من نقشه‌های Organic Maps را بهبود بخشیدم</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>اظهار نظر بیشتر</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>شما یک سری تغییرات در نقشه را برای انجمن OpenStreetMap ارسال کردید.جزئیات اضافی را که نتوانستید در Organic Maps ویرایش کنید را برایشان بنویسید.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>خطایی در هنگام جست وجوی مکان شمارخ داده است.بررسی کنیید دستگاهتان به درستی کار می کند و دوباره تلاش کنید.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>سرویس موقعیت مکانی شما غیرفعال است</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>دسترسی به موقعیت جغرافیایی را در تنظیمات دستگاه فعال کنید</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. بازکردن تنظیمات</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>۲. روی «مکان» ضربه بزنید</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>۳. گزینه «هنگام استفاده از برنامه» را انتخاب کنید</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Privacy را انتخاب کنید</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Location Services را انتخاب کنید</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Location Services را روشن کنید</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>یا به استفاده از Organic Maps بدون موقعیت مکانی ادامه دهید</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>رزرو</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>تماس</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>نام نشانک</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>حذف نشانه</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>یادداشت شما به OpenStreetMap ارسال خواهد شد</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…بیشتر</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>به‌روزرسانی</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>ضبط مسیر طی‌شده اخیر، غیرفعال شود؟</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>غیرفعال</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>بررسی کنید</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps از اطلاعات موقعیت مکانی شما در پس ضمینه برای ذخیره مسیر‌هایی که اخیرا سفر کرده اید استفاده می کند.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>تنظیمات عمومی</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>برای نمایش ترافیک باید اپلیکیشن را بروزرسانی کنید.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>اندازه فایل گزارش: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>برای حذف اینجا بکشید</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>جایگزین Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>شروع از</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>لطفا به OpenStreetMap وارد شوید تا تمامی ویرایش‌های نقشه شما به‌ صورت خودکار به‌روزرسانی شوند. بیشتر بدانید</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>اینجا</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>پنهان کردن صفحه</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 از %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>در حال دانلود %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>اعمال %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>این نام خیلی طولانی است</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>فایل‌های جدید پیدا شد</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>تبدیل</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>خطا</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>بعضی از فایل‌ها تبدیل نشد.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>خطایی رخ داد</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>مشهور</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>پنهان کردن از نقشه</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>هنگام بارگذاری برچسب خطایی رخ داد، لطفا دوباره امتحان کنید</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>درست</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>پایین</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>برویم</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>مقصد</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>نشان دادن مجدد در مرکز</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>نتایج جستجو</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>سپس</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>آیا می خواهید مسیر را دوباره ایجاد کنید?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>صفحه کلید در هنگام رانندگی در دسترس نیست</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>امکان ایجاد مسیر از مکان فعلی شما نیست</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>امکان ایجاد مسیر به مقصد شما نیست. لطفاً نقطه دیگری را انتخاب کنید</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>سیگنال GPS وجود ندارد. لطفاً به فضای باز بروید</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>امکان ایجاد مسیر نیست. لطفاً نقاط مسیر دیگری را مشخص کنید</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>برای ایجاد مسیر، نقشه‌های ناقص را روی دستگاه خود را دانلود کنید</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>خطایی رخ داد. لطفاً برنامه را دوباره اجرا کنید</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>مسیر از مکان فعلی شما بازسازی خواهد شد</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>مسیر به مسیر خودرویی تغییر خواهد کرد</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>همه نشانک ها نشان داده نمی شوند</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>برای دیدن همه نشانکu200cها به تلفن بروید</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>دوربین سرعت</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>هشدارهای سرعت</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>لطفا نقشه‌ها را در نرم افزار Organic Maps روی دستگاه خود دانلود کنید</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>خروجی %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>مرتب سازی بر اساس پیش فرض</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>مرتب سازی بر اساس نوع</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>مرتب سازی بر اساس فاصله</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>مرتب سازی بر اساس تاریخ</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>به ترتیب نام</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>غذا</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>مناظر</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>موزه‌ها</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>پارک‌ها</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>شنا</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>کوه‌ها</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>حیوانات</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>هتل‌ها</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>ساختمان‌ها</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>پول</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>مراکز خرید</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>پارکینگ‌ها</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>پمپ بنزین</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>پزشکی</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>جستجو در فهرست</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>اماکن مقدس</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>انتخاب فهرست</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>راهنمای مترو در این منطقه هنوز دردسترس نیست</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>مسیر مترو یافت نشد</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>لطفا نقطه آغاز و پایان نزدیک تری به ایستگاه مترو انتخاب کنید</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>خط تراز</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>برای فعال سازی و استفاده از لایه توپوگرافی نقشه منطقه را به روزرسانی یا دانلود کنید</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>لایه توپوگرافی هنوز برای این منطقه در دسترس نیست</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>بالا رفتن</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>پایین آمدن</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>کم ارتفاع</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>بیش ارتفاع</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>دشواری</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>فاصله:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>زمان:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>برای بررسی خطوط تراز زوم کنید</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>در حال دانلود</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>نقشه نمای کلی جهان را دانلود کنید</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>امکان ایجاد پوشه و انتقال پرونده‌ها در حافظه داخلی دستگاه یا کارت SD وجود ندارد</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>خطای دیسک</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>ارتباط با سرور موفقیت آمیز نبود</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>کابل USB را جدا کنید</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>صفحه نمایش را روشن بگذارید</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>وقتی فعال باشد، هنگام نمایش نقشه، صفحه همیشه روشن خواهد بود.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>نمایش روی صفحه قفل</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>وقتی فعال باشد، برنامه حتی زمانی که دستگاه قفل است روی صفحه قفل کار خواهد کرد.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>زبان نقشه</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap داده‌های نقشه از</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/fa-IR/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/fa-IR/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1، %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>از شما برای استفاده از نقشه های ساخته شده توسط جامعه سپاسگزاریم!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>با کمک های مالی و حمایت شما، ما می توانیم بهترین نقشه های جهان را ایجاد کنیم!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>آیا برنامه ما را دوست دارید؟ لطفا برای حمایت از توسعه کمک مالی کنید! هنوز آن را دوست ندارید؟ لطفا به ما اطلاع دهید، و ما آن را تعمیر خواهیم کرد!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>اگر یک توسعه‌دهنده نرم‌افزار را می‌شناسید، می‌توانید از او بخواهید ویژگی مورد نیاز خود را پیاده‌سازی کند.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>برای انتخاب هر چیزی روی هر نقطه از نقشه ضربه بزنید. برای مخفی کردن و نشان دادن رابط، ضربه طولانی بزنید.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>آیا می دانید که می توانید مکان فعلی خود را روی نقشه انتخاب کنید؟</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>شما می توانید به ترجمه برنامه ما به زبان خود کمک کنید.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>برنامه ما توسط تعدادی از علاقه مندان و جامعه توسعه یافته است.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>شما به راحتی می توانید داده های نقشه را اصلاح و بهبود دهید.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>هدف اصلی ما ساختن نقشه هایی سریع، متمرکز بر حریم خصوصی و با کاربری آسان است که شما عاشق آن خواهید شد.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>شما اکنون در حال استفاده از Organic Maps بر روی صفحهٔ تلفن همراه هستید</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>شما اکنون در حال استفاده از Organic Maps بر روی صفحهٔ خودرو هستید</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>شما به Android Auto متصل هستید</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>با تلفن ادامه دهید</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>به صفحه ماشین</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps به دسترسی به مکان نیاز دارد. وقتی ایمن است، اعلان گوشی خود را بررسی کنید.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>این برنامه به اجازه شما نیاز دارد</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps در Android Auto برای عملکرد بهتر به مجوزهای مکان نیاز دارد</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>اعطای مجوزها</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>پیاده روی</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>مرورگر وب در دسترس نیست</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>میزان صدا</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>صادر کردن همه نشانک‌ها و مسیرها</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>تنظیمات سنتز گفتار سیستم</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>تنظیمات Speech Synthesis پیدا نشد، آیا مطمئن هستید که دستگاه شما از آن پشتیبانی می کند؟</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>رانندگی از طریق</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>جستجو را پاک کنید</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>بزرگنمایی</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>کوچک نمایی</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>لینک منو</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>مشاهده منو</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>در یک برنامه دیگر باز کنید</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>سلف سرویس</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>گزینه را انتخاب کنید</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>نشستن در فضای باز</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>برای دقیقu200cترین ناوبری، توصیه میu200cکنیم حالت صرفهu200cجویی در مصرف انرژی را در تنظیمات باتری گوشی غیرفعال کنید.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>ضبط مسیر</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>توقف ضبط مسیر</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>ضبط مسیر</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>توقف بدون ذخیره</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>ادامه ضبط</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>ذخیره‌سازی در نشانک‌ها و مسیرها؟</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>مسیر خالی است - چیزی برای ذخیره کردن وجود ندارد</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>امکان نمایش کادر انتخاب پوشه وجود ندارد زیرا هیچ برنامه مناسبی روی دستگاه شما نصب نشده است. لطفا یک برنامه مدیریت پرونده نصب کنید و دوباره امتحان کنید.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>انتخاب رنگ</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>ویرایش مسیر</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>هیچ برنامه‌ای نصب نشده است که بتواند مکان را باز کند</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>مسیریابی خودکار</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>تابع سیستم</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>اشتراک‌گذاری مسیر</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>حذف %1؟</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>سطح دشواری</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>آسان</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>متوسط</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>دشوار</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>در حال به‌روزرسانی</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>نقشه‌های دانلود شده خود را به روز کنید</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>به‌روزرسانی نقشه‌ها اطلاعات مربوط به اشیا را به روز نگه می‌دارد</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>به‌روزرسانی (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>بعدا به صورت دستی به‌روزرسانی کنید</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>حذف مسیر</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>آیا مطمئن هستید که می خواهید این آهنگ را حذف کنید؟</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>نام مسیر</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>انتقال</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>مسیر</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>تغییر رنگ</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>نقشه</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>آیا مایلید گزارش باگ را برای توسعه‌دهندگان ارسال کنید؟ ما به کاربران خود اتکا می‌کنیم زیرا Organic Maps هیچ‌گونه اطلاعات خطایی را به‌طور خودکار جمع‌آوری نمی‌کند. پیشاپیش از حمایت شما از Organic Maps سپاسگزاریم!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>همگام سازی iCloud را فعال کنید</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>همگام سازی iCloud یک ویژگی آزمایشی در دست توسعه است. مطمئن شوید که از تمام نشانکu200cها و آهنگu200cهای خود یک نسخه پشتیبان تهیه کردهu200cاید.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud غیرفعال است</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>لطفاً iCloud را در تنظیمات دستگاه خود فعال کنید تا از این ویژگی استفاده کنید.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>فعال کردن</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>پشتیبان گیری</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>همگام سازی iCloud شکست خورده است</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>خطا: به دلیل خطای اتصال همگام سازی نشد</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>خطا: به دلیل فراتر رفتن از سهمیه iCloud، همگام سازی انجام نشد</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>خطا: iCloud در دسترس نیست</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>لیست های اخیرا حذف شده</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>پاک کردن</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>حذف همه</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>بازیابی</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>بازیابی همه</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>مشارکت در OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>افزودن مکان</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>برای مشارکت نقشه را به‌روزرسانی کنید</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>برای مشارکت در داده‌های OpenStreetMap باید نقشه %1 را به آخرین نسخه به‌روزرسانی کنید</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>مگابایت</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>گیگابایت</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>مکان من</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>مکان من</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>ذخیره‌سازی خصوصی داخلی</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>ذخیره‌سازی اشتراکی داخلی</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>کارت حافظه</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>ذخیره‌سازی اشتراکی خارجی</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>وای فای</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>کد پستی</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>نقطه نقشه</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>متر</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>کیلومتر</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>مایل</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>فوت</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>برای نمایش مسیرها، نقشه‌ها باید به‌روزرسانی شوند.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>خروج</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>ورودی</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>نقشه مترو موجود نیست</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>شما</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>مناطق دانلود شده بنفش</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>مسیر</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>تشخیص مکان در پس زمینه برای لذت بردن کامل از عملکرد برنامه ضروری است. برای ناوبری و ذخیره مسیرهای اخیر سفر شده شما استفاده می شود.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>تعیین موقعیت مکانی شما برای ناوبری و ذخیره مسیرهای اخیر سفر شده ضروری است.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>ورود با رمز عبور</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ورود با استفاده از مرورگر</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>به‌تازگی استفاده شده</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>رنگ نشانک‌ها تغییر کرد</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>رنگ مسیرها تغییر کرد</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>طیف</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>اسلایدرها</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>قرمز</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>سبز</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>آبی</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>رنگ هگز sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>شبکه</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/fi/omim.ts
+++ b/qt/translations/fi/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="fi">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Takaisin</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Poista</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Lataa karttoja</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Lataus epäonnistui. Napauta yrittääksesi uudelleen.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Ladataan…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometrit</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mailit</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Myöhemmin</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Haku</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Hae kartalta</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Laitteen tai sovelluksen kaikki sijaintipalvelut ovat tällä hetkellä poissa käytöstä. Ota ne käyttöön Asetukset-valikossa.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Rajoitettu tarkkuus</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Tarkan navigoinnin varmistamiseksi ota Tarkka sijainti käyttöön asetuksissa.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Näytä kartalla</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Lataus epäonnistui</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Yritä uudelleen</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Tietoa Organic Maps:stä</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Ilmainen kaikille, tehty rakkaudella</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Ei mainoksia, ei seurantaa, ei tiedonkeruuta</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Ei akun tyhjenemistä, toimii offline-tilassa</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Nopea, minimalistinen, yhteisön kehittämä</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Harrastajien ja vapaaehtoisten luoma avoimen lähdekoodin sovellus.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Sijaintiasetukset</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Sulje</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Laitteistokiihdytetty OpenGL vaaditaan. Valitettavasti laitteesi ei ole tuettu.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Lataa</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Irrota USB-kaapeli tai syötä muistikortti käyttääksesi Organic Maps -sovellusta</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Vapauta ensin tilaa SD-kortilta/USB-massamuistilta käyttääksesi sovellusta</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Ennen aloitusta laitteelle tulee ladata yleinen maailmankartta.
+Se tarvitsee yhteensä %1 tilaa.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Siirry karttaan</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Ladataan %1. Voit nyt jatkaa&#32;
+kartalle.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Ladataanko %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Päivitetäänkö %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pysäytä</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Jatka</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 lataus epäonnistui</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Lisää uusi valikoima</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Kirjanmerkkivalikoiman nimi</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Kirjanmerkit</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Kirjanmerkit ja reitit</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nimi</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Osoite</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Luettelo</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Asetukset</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Tallenna kartat kohteeseen</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Valitse karttojen latauskohde.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Ladatut kartat</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1/%2 vapaana</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Siirrä karttoja?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Karttatiedostojen siirtovirhe</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Tämä voi kestää useita minuutteja.
+Odota hetki…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mittayksiköt</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Valitse mailit tai kilometrit</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Peruuta lataus</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Jätä arviointi</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Kyllä</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Lataa kartta</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Kirjanmerkkivalikoimat</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Missä syödä</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Elintarvikkeet</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Liikenne</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Huoltoasema</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkkipaikka</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Ostokset</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Käytetyt tavarat</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotelli</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Nähtävyydet</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Viihde</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Pankkiautomaatti</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Yöelämä</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Vapaa-aikaa lasten kanssa</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Pankki</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apteekki</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Sairaala</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>WC</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posti</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Poliisi</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Jätteiden kierrätys</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vesi</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Karavaanaritilat</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Muistiinpanot</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Jaetut Organic Maps-kirjanmerkit</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hei!&#32;
+
+Liitteenä ovat kirjamerkkini; Avaa ne Organic Maps -sovelluksessa. Mikäli sinulla ei ole vielä sovellusta asennettuna, voit ladata sen osoitteesta: https://omaps.app/get?kmz&#32;
+
+Nauti matkustamisesta Organic Maps:n kanssa!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Ladataan kirjanmerkkejä</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Kirjanmerkkien lataaminen onnistui! Löydät ne joko kartalta tai kirjanmerkkien hallinnasta.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Kirjanmerkkien lataus epäonnistui. Tiedosto saattaa olla vioittunut.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Sovellus ei tunnista tiedostotyyppiä:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Tiedostoa ei onnistuttu avaamaan %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Muokkaa</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Sijaintiasi ei ole vielä määritetty</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Valitettavasti karttatallennusasetukset ovat pois päältä.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Karttaa ladataan parhaillaan.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hei, katso sijaintini Organic Maps-sovelluksessa! %1 tai %2 Eikö sinulla ole vielä offline-karttoja? Lataa ne täältä: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hei, katso merkintäni Organic Maps-kartalla!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hei, kurkkaa tämänhetkinen sijaintini Organic Maps:n kartalla!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hei,
+
+Olen nyt täällä: %1. Klikkaa linkkiä %2 tai %3 nähdäksesi paikan kartalla.
+
+Kiitos.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Jaa</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Sähköposti</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopioitu leikepöydälle: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Valmis</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-tiedot: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Haluatko varmasti kirjautua ulos OpenStreetMap-tililtäsi?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Reitit</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Pituus</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Jaa sijaintini</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Yleiset asetukset</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Tietoja</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigointi</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Painikkeet ”+” ja ”-” kartalla</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Näytä kartalla</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Yötyyli, kun navigoidaan pimeässä</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Yötila</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Pois päältä</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Päällä</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automaattinen</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektiivinäkymä</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-rakennukset</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-rakennukset ovat poissa päältä virransäästötilassa</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Ääniohjeistukset</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Ilmoita kadunnimet</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Kun tämä on käytössä, sen kadun tai liittymän nimi, jolle käännytään, puhutaan ääneen.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Äänen kieli</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Voit ladata laadukkaamman äänen avaamalla Asetukset-apin ja siirtymällä kohtaan Käyttöapu → VoiceOver → Puhe → Ääni.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testaa puheohjeita (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Tarkista äänenvoimakkuus tai järjestelmän tekstistä puheeksi -asetukset, jos ääni ei kuulu nyt.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ei saatavilla</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automaattinen zoomaus</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Etäisyys</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Näytä kartalla</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Kotisivut</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Uutiset</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Palaute</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Arvioi sovellus</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ohje</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Usein kysytyt kysymykset</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Lahjoita</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Jo lahjoitettu</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Muistuta myöhemmin</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Tue Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Tue projektia</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Tekijänoikeudet</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Ilmoita virheestä</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Paranna nuolien suuntaa liikuttamalla puhelinta kahdeksikon suuntaisesti kompassin kalibroimiseksi.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Liikuta puhelinta kahdeksikon suuntaisella liikkeellä kompassin kalibroimiseksi ja nuolen suunnan määrittämiseksi kartalla.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Paina karttaa pitkään uudelleen nähdäksesi käyttöliittymän</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Päivitä kaikki</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Peruuta kaikki</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Ladatut</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Jonossa</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Lähelläni</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kartat</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Lataa kaikki</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Ladataan:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Pysäytä navigointi poistaaksesi kartan.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Vain kokonaisuudessaan yhdelle kartalle mahtuvia reittejä voidaan luoda.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Lataa kartta</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Yritä uudelleen</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Poista kartta</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Päivitä kartta</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Sijaintipalvelut</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Määritä nopeasti likimääräinen sijaintisi Bluetoothin, WiFin tai matkapuhelinverkon kautta</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Lataa karttoja matkalla</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Reitin luominen vaatii karttojen lataamisen ja päivityksen oman sijaintisi ja kohteeen väliltä.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ei tarpeeksi tilaa</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Ota sijaintipalvelut käyttöön</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Tallenna</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>luo</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Punainen</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Keltainen</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Sininen</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Vihreä</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violetti</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranssi</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Ruskea</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pinkki</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tumman purppuranpunainen</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Vaaleansininen</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Sinivihreä</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smaragdinvihreä</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limen värinen</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tumman oranssi</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Harmaa</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Siniharmaa</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Tietoa</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps versio: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Ulkoasu</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Vaalea</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tumma</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Vaalea aamusta iltaan</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Muu</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Lahjoita ilmaiset ja mainoksettomat kartat miljoonille käyttäjille!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Ilmoita tai korjaa virheelliset karttatiedot</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Vapaaehtoiseksi</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Seuraa ja ota meihin yhteyttä:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Sähköpostisovellusta ei ole asetettu. Ole hyvä ja määritä sähköpostiasetukset tai ota meihin yhteyttä toista kautta osoitteessa %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Virhe lähetettäessä viestiä</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompassin kalibrointi</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Saatavilla</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Löytyi</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Päivitä</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Epäonnistunut</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>kirjanmerkki</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Muista seuraavat asiat seuratessasi reittiä:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Tien kunnon, liikennesääntöjen ja tiekylttien noudattaminen on aina ensisijaista verrattuna navigointisovelluksen ohjeisiin;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Kartta saattaa olla epätarkka, joten ehdotettu reitti ei välttämättä ole paras mahdollinen tapa päästä määränpäähän;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Ehdotettuja reittejä tulee pitää vain suosituksina;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Ole varovainen reittien kanssa raja-alueilla: sovelluksemme luomat reitit voivat joskus ylittää maiden rajoja luvattomissa paikoissa.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Pysy tarkkana ja liiku turvallisesti!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Tarkista GPS-signaali</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Reittiä ei voi luoda. Tämänhetkisiä GPS-koordinaatteja ei löydy.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Tarkista GPS-signaali. Wi-Fi-signaalin käyttöönotto parantaa sijainnin tarkkuutta.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Ota sijaintipalvelut käyttöön</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Tämänhetkisiä GPS-koordinaatteja ei löydy. Ota sijaintipalvelut käyttöön reitin laskemista varten.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Reitin paikannus ei onnistu</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Reitin luonti ei onnistu.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Muuta aloituskohtaa tai määränpäätä.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Muuta aloituskohtaa</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Reittiä ei luotu. Aloituskohdan paikannus ei onnistu.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Valitse lähempänä tietä oleva aloituskohta.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Muuta määränpäätä</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Reittiä ei luotu. Määränpään paikannus ei onnistu.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Valitse lähempänä tietä oleva määränpää.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Välipisteen paikallistaminen ei onnistunut.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Siirrä välipistettä.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Järjestelmävirhe</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Reittiä ei voi luoda sovellusvirheen vuoksi.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Yritä uudelleen</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ei nyt</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Haluatko ladata kartan ja luoda paremman reitin, joka ulottuu usealle kartalle?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Lataa kartta ja luo parempi reitti, joka ylittää tämän kartan reunan.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Lataa tarvittavat tiedostot</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Lataa ja päivitä kaikki suunnitellun reitin kartta- ja reititystiedot, jotta reitin voi laskea.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Lataa kartta jotta voit käyttää hakua ja luoda reittejä. Tämän jälkeen et tarvitse enää Internet-yhteyttä.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Valitse kartta</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Näytä</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Piilota</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Luokat</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historia</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Pahoittelut, hakutuloksia ei ole.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Lataa alue, jolta etsit, tai yritä lisätä läheisen kaupungin tai kylän nimi.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Hakuhistoria</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Näytä viimeaikaiset hakusi.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Poista hakuhistoria</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikkeli osoitteesta wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Sijaintisi</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Aloita</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Lähtöpaikka</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Reitin loppupiste</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigointi onnistuu vain nykyisestä sijainnistasi.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Haluatko valita vaihtoehtoisen reitin?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Seuraava</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Alkaen</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Asti</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Lisää aikataulu</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Poista aikataulu</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Koko päivän (24 tuntia)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Avoinna</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Suljettu</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Lisää suljettuna tunnit</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Aukioloajat</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Edistynyt tila</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Yksinkertainen tila</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Suljettuna tunnit</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Esimerkkiarvot</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Korjaa virhe</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Valitse sijainti</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Kuvaile ongelmaa yksityiskohtaisesti, jotta OpenStreetMap-yhteisö voi korjata vian.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Tai tee se itse osoitteessa https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Lähetä</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Ongelma</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Paikkaa ei ole olemassa</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Suljettu huoltoa varten</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Paikan kaksoiskappale</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Lataa kartat automaattisesti</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Päivittäin</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Päivin ja öin</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Suljettu tänään</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Suljettu</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Tänään</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Avautuu %1 kuluttua</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Sulkeutuu %1 kuluttua</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Suljettu</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Muokkaa aukioloaikoja</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Eikö sinulla ole OpenStreetMap-tiliä?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Rekisteröidy</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Kirjaudu sisään</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Et ole kirjautunut sisään</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Kirjaudu OpenStreetMapiin</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Salasana</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Unohtuiko salasana?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Kirjaudu ulos</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Muokkaa kohdetta</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Lisää kieli</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Katu</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Talon numero</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Lisätiedot</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sosiaalinen media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Rakennus</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Lisää katu</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Lisää kadun nimi</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Valitse kieli</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Valitse katu</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Ruokalaji</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Valitse ruokalaji</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Sähköposti tai käyttäjätunnus</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Lisää puhelinnumero</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Kerros</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Kerros: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Kaikki karttaan tehdyt muutokset poistetaan kartan mukana.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Päivitä kartat</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Sinun täytyy päivittää kaikki kartat ja suunnitella reitti uudelleen luodaksesi uuden reitin.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Etsi kartta</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Varmista, että laitteesi on yhteydessä Internetiin.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ei tarpeeksi tilaa</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Poista tarpeeton data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Kirjautumisvirhe.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Vahvistetut karttamuutokset</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Aseta risti paikan tai yrityksen sijaintiin vetämällä karttaa.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Muokkaus</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Lisääminen</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Paikan nimi</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Paikallisella kielellä kirjoitettuna</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Ongelman tarkka kuvaus</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Eri ongelma</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Lisää organisaatio</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Kohdetta ei voida asettaa tänne</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Yhteisön luomat OpenStreetMap-tiedot %1:sta alkaen. Lisätietoja kartan muokkaamisesta ja päivittämisestä osoitteessa OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) on yhteisöprojekti, jonka tarkoituksena on rakentaa ilmainen ja avoin kartta. Se on Organic Mapsin tärkein karttatietojen lähde ja toimii samalla tavalla kuin Wikipedia. Voit lisätä tai muokata paikkoja, ja ne tulevat miljoonien käyttäjien saataville kaikkialla maailmassa.
+Liity yhteisöön ja auta tekemään parempi kartta kaikille!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Luo OpenStreetMap-tili tai kirjaudu sisään, jotta voit julkaista karttamuokkauksesi maailmalle.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Lataa käyttämällä puhelinverkkoyhteyttä?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Tämä vaihtoehto saattaa olla huomattavasti kalliimpi tietyillä sopimuksilla tai roaming-yhteydellä.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Syötä oikea talon numero</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Kerrosten määrä (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Kerrosten määrä saa olla korkeintaan %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postinumero</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Anna kelvollinen postinumero</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Huomautus OpenStreetMapin vapaaehtoisille (valinnainen)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Kuvaile kartassa olevia virheitä tai asioita, joita ei voi muokata Organic Mapsilla.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Muokkauksesi ladataan julkiseen &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-tietokantaan. Älä lisää henkilökohtaisia tai tekijänoikeudella suojattuja tietoja.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Lisätietoja OpenStreetMap:sta</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Muokkaushistoriasi</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Karttatietosi muistiinpanot</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operaattori</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operaattori: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Etkö löydä sopivaa luokkaa?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps mahdollistaa vain yksinkertaisten pisteluokkien lisäämisen, eli ei kaupunkeja, teitä, järviä, rakennusten ääriviivoja jne. Lisää tällaiset luokat suoraan &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Tarkista &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;oppaastamme&lt;/a&gt; yksityiskohtaiset ohjeet vaihe vaiheelta.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Et ole ladannut yhtään karttaa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Lataa karttoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Nykyinen sijainti on tuntematon.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>t</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>pv</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Lisää</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Muokkaa kirjanmerkkiä</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Henkilökohtaiset merkinnät (teksti tai html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentti…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Nollataanko kaikki paikalliset muutokset?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Nollaa</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Poistetaanko lisätty paikka?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Poista</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Paikkaa ei ole olemassa</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Anna syy paikan poistamiselle</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Syötä kelvollinen puhelinnumero</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Syötä kelvollinen verkko-osoite</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Syötä kelvollinen sähköpostiosoite</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Syötä kelvollinen Facebook verkko-osoite, tili, tai sivun nimi</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Syötä kelvollinen Instagram-käyttäjätunnus tai verkko-osoite</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Syötä kelvollinen Twitter-käyttäjätunnus tai verkko-osoite</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Syötä kelvollinen VK-käyttäjätunnus tai verkko-osoite</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Syötä kelvollinen LINE ID tai verkko-osoite</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Lisää paikka OpenStreetMapiin</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Vaihtoehtoisesti voit jättää ilmoituksen OpenStreetMap-yhteisölle, jotta joku muu voi lisätä tai korjata paikan tänne.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Huomautus lähetetään OpenStreetMapille.</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Haluatko lähettää sen kaikille käyttäjille?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Varmista, ettet syöttänyt henkilökohtaisia tietojasi.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-editorit tarkistavat muutokset ja ottavat sinuun yhteyttä, jos heillä on kysyttävää.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Lopeta</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Reitin kirjaaminen</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Hyväksy</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Hylkää</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Näytetäänkö lisätiedot mobiili-internetillä?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Käytä aina</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Vain tänään</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Älä käytä tänään</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiili-internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobiili-internet vaaditaan paikkojen lisätietojen, kuten valokuvien, hintojen ja arvioiden näyttämiseen.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Älä käytä koskaan</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Kysy aina</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Liikennetietojen näyttämiseksi kartat on päivitettävä.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Suurenna fonttikokoa kartalla</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Päivitä Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Liikennetietoja ei ole saatavilla</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Ota loki käyttöön</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Yleinen palaute</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Käytämme ääniohjeisiin tekstistä puheeksi -järjestelmää. Monet Android-laitteet käyttävät Googlen tekstistä puheeksi -sovellusta, jonka voit ladata tai päivittää Google Playssä</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Joidenkin kielten kohdalla sinun täytyy asentaa puhesyntetisaattori tai ylimääräinen kielipaketti sovelluskaupasta (Google Play, Galaxy Store, App Gallery, FDroid).
+Avaa laitteesi asetukset → Kieli ja syöttö → Puhe → Tekstistä puheeksi.
+Täällä voit hallita puhesynteesiasetuksia (esimerkiksi ladata kielipaketin offline-käyttöä varten) ja valita toisen tekstistä puheeksi -moottorin.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Lisätietoja saat tästä oppaasta.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translitterointi latinalaisiksi aakkosiksi</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Lisätietoja</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Käytä hakua, valitse kirjanmerkki tai napauta karttaa lisätäksesi reitin lähtöpisteen</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Käytä hakua, valitse kirjanmerkki tai napauta karttaa lisätäksesi reitin määränpään</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Hallitse reittiä</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Suunnittele</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Poista pysähdys</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Lisää pysähdys</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Tallennettu</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Kirjaudu sisään OpenStreetMapiin, jotta voit ladata kaikki karttamuutoksesi automaattisesti. Lisätietoja &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;täältä&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Ongelma tallennustilan käyttämisessä</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ulkoinen tallennustila ei ole käytettävissä, SD-kortti on luultavasti poistettu tai vahingoittunut tai tiedostojärjestelmä on vain luku -tilassa. Tarkista SD-kortin toiminta tai ota yhteyttä osoitteeseen support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Jäljittele virheellistä tallennustilaa</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Anna oikea nimi</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Luettelot</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Piilota kaikki</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Näytä kaikki</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n kirjanmerkki</numerusform>
+<numerusform>%n kirjanmerkkiä</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Luo uusi luettelo</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Kirjanmerkkien ja reittien tuominen</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Ei voitu jakaa sovellusvirheen vuoksi</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Jakamisvirhe</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Tyhjää luetteloa ei voi jakaa</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Nimi ei voi olla tyhjä</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Anna luettelon nimi</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Uusi luettelo</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Nimi on jo käytössä</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Valitse toinen nimi</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Odota…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Puhelinnumero</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap-profiili</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n tiedosto löydettiin. Näet sen muunnoksen jälkeen.</numerusform>
+<numerusform>%n tiedostoa löydettiin. Näet ne muunnoksen jälkeen.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Palauta</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n reitti</numerusform>
+<numerusform>%n reittiä</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Yksityisyys</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Yksityisyyskäytäntö</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Käyttöehdot</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Liikenne</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Vaellus</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Pyöräily</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Karttatyylit ja tasot</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Luettelo on tyhjä</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Lisätäksesi kirjanmerkin, paina kartasta ja sitten paina tähden kuvaa</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Vaihda kaikkien kirjanmerkkien väri</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Vaihda kaikkien reittien väri</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…lisää</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Vie KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Vie GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Vie GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Poista luettelo</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Nopeuskamerat</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Paikan kuvaus</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Karttojen lataaminen</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Varoittaa sinua ylinopeudesta</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Varoita aina</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Älä koskaan varoita</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Virransäästötila</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Kun olet valinnut automaattisen tilan, sovellus alkaa sammuttamaan virtaa vieviä ominaisuuksia riippuen kulloisestakin akun latauksesta.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Ei koskaan</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automaattinen</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Täysi virransäästö</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Kirjanmerkin nimet kartalla</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Jos kirjanmerkkejä on liikaa, niiden nimien näyttäminen kartalla voi hidastaa sovelluksen toimintaa.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Näytä oikealle</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Näytä alareunassa</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Valinta ottaa käyttöön lokikirjaukset diagnostiikkaa varten. Se voi auttaa tukihenkilöstöämme, kun he korjaavat sovelluksen ongelmia. Ota tämä ominaisuus käyttöön vain, jos Organic Maps:n tuki pyytää.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Reititysvalinnat</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vältä maksullisia teitä</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vältä päällystämättömiä teitä</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vältä lautan käyttöä</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vältä moottoritietä</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Reittiä ei voi luoda</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Valitettavasti emme voineet luoda reittiä valituilla vaihtoehdoilla. Vaihda asetuksia ja yritä uudelleen</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Määritä vältettävät tiet</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Reititysvalinnat ovat päällä</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Maksullinen tie</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Päällystämätön tie</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Lauttaliikenne</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Kyllä</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ei</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Kyllä</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ei</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapasiteetti: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Verkko: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Olet perillä!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Järjestä…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Järjestä kirjanmerkit</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Oletuksena</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Tyyppi</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Etäisyys</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Päivämäärä</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Nimen mukaan</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Viikko sitten</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Kuukausi sitten</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Yli kuukausi sitten</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Yli vuosi sitten</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Lähelläni</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Muut</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Reitin suunnittelu epäonnistui</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Saavut: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Olet muuttanut maailmankarttaa. Älä piilota tätä! Kerro ystävillesi ja muokatkaa sitä yhdessä.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Jaa kavereille</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Suljettu nyt</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Aukeaa huomenna kello %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Aukeaa %1 kello %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Aukeaa kello %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Sulkeutuu kello %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Lisää aukioloajat</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Salasana (vähintään 8 merkkiä)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Virheellinen käyttäjätunnus tai salasana.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-tili</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Viimeisin lisäys</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Kiitos</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Paikan nimi</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Puhelinnumero</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Huomaathan, että</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Latausvirhe</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Valitse kategoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Suositut</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kaikki kategoriat</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Lisää karttaan uusia paikkoja ja muokkaa sovelluksessa olevia karttoja suoraan sovelluksessa.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Vaihda sijaintia</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Tarvitset lisää tilaa ladataksesi. Poista tarpeeton data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Paransin Organic Maps-karttoja</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Yksityiskohtainen kommentti</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Ehdottamasi muutokset lähetetään OpenStreetMap-yhteisöön. Kuvaa tiedot, joita ei voi muokata Organic Maps:ssä.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Tapahtui virhe määritettäessä sijaintiasi. Tarkista laitteesi ja yritä myöhemmin uudelleen.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Sijaintipalvelut on poistettu käytöstä</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Salli sijaintipalveluiden käyttö laitteen asetuksissa</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Avaa asetukset</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Valitse sijainti</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Valitse sovellusta käytettäessä</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Valitse Tietosuoja</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Valitse Sijaintipalvelut</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ota Sijaintipalvelut käyttöön</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Tai jatka Organic Maps käyttöä ilman sijaintia</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Varaa</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Soita</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Kirjanmerkin nimi</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Poista kirjanmerkki</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Huomautus lähetetään OpenStreetMapille</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…lisää</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Päivitä</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Poistetaanko viimeisen matkareitin tallennus?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Poista</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Tarkastele</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps käyttää sijaintipalveluita taustalla viimeisimmän reittisi tallentamiseksi.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Yleiset asetukset</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Liikennetietojen näyttämiseksi sovellus on päivitettävä.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Lokitiedoston koko: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Vedä tähän poistaaksesi</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Vaihda Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Aloita kohdasta</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Kirjaudu sisään OpenStreetMapiin, jotta voit ladata kaikki karttamuutoksesi automaattisesti. Lisätietoja</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>täältä</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Piilota näyttö</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Ladataan %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 otetaan käyttöön…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Tämä nimi on liian pitkä</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Uusia tiedostoja havaittiin</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Muunna</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Virhe</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Joitakin tiedostoja ei muunnettu.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Tapahtui virhe</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Suosittu</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Piilota kartalta</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Tunnisteiden lataamisen aikana tapahtui virhe, yritä uudelleen</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Oikea</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Pohja</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Mennään</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Määränpää</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Kohdista</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Hakutulokset</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Sitten</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Haluatko luoda reitin uudelleen?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Näppäimistö ei ole käytettävissä ajon aikana</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Reittiä ei ole mahdollista luoda nykyisestä sijainnistasi</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Reittiä ei ole mahdollista luoda loppupisteeseen. Valitse toinen</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ei GPS-signaalia. Siirry avoimelle alueelle</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Reittiä ei ole mahdollista luoda. Valitse muut reittipisteet</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Luodaksesi reitin lataa puuttuvat kartat</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>On tapahtunut virhe. Käynnistä sovellus uudelleen</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Reitti luodaan nykyisestä sijainnista</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Reitti muutetaan autoilijan reitiksi</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Kaikkia kirjanmerkkejä ei näytetä</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Siirry puhelimeen nähdäksesi kaikki kirjanmerkit</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Nopeuskamerat</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Nopeusvaroitukset</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Lataa kartat laitteesi Organic Maps-sovelluksessa</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Poistumisramppi %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Oletusjärjestys</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Järjestä tyypin mukaan</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Järjestä etäisyyden mukaan</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Järjestä päivämäärän mukaan</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Lajittele nimen mukaan</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Ruoka</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Nähtävyydet</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museot</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Puistot</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Uimapaikat</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Vuoret</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Eläimet</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotellit</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Rakennukset</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Raha</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Kaupat</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Pysäköinti</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Huoltoasemat</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Apteekki</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Etsi luettelosta</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Uskonnolliset paikat</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Valitse luettelo</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metron reittiohjeet eivät ole vielä saatavilla tällä alueella</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metroreittiä ei löytynyt</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Valitse reitin aloitus- tai loppupiste lähemmäksi metroasemaa</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Maasto</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Päivitä tai lataa haluamasi alueen kartta käyttääksesi korkeuskäyriä</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Korkeuskäyrät eivät ole vielä saatavilla tällä alueella</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Nousua</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Laskua</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. korkeus</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. korkeus</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Vaikeus</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Etäisyys:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Aika:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Suurenna kartta nähdäksesi korkeuskäyrät</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Ladataan</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Lataa maailmankartta</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Kansion luonti ja tiedoston siirto ei onnistu laitteen muistissa tai SD-koritlla</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Tallennusvirhe</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Yhteysvirhe</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Irrota USB-kaapeli</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Pidä näyttö päällä</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Kun tämä on käytössä, näyttö on aina päällä, kun kartta näytetään.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Näytä lukitusnäytöllä</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Kun käytössä, sovellus toimii lukitusnäytöllä vaikka laite olisi lukittuna.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Karttakieli</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMapin karttatiedot</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Kiitos, että käytät yhteisön laatimia karttojamme!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Lahjoituksellasi ja tuellasi voimme luoda maailman parhaat kartat!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Pidätkö sovelluksestamme? Lahjoita tukemaan kehitystä! Etkö pidä siitä vielä? Kerro meille, niin korjaamme asian!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Jos tunnet ohjelmistokehittäjän, voit pyytää häntä ottamaan käyttöön tarvitsemasi ominaisuuden.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Voit valita mitä tahansa napauttamalla mitä tahansa kohtaa kartalla. Piilota ja näytä käyttöliittymä takaisin pitkällä napautuksella.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Tiesitkö, että voit valita nykyisen sijaintisi kartalta?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Voit auttaa kääntämään sovelluksemme kielellesi.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Sovelluksemme on muutaman harrastajan ja yhteisön kehittämä.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Voit helposti korjata ja parantaa karttatietoja.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Päätavoitteemme on rakentaa nopeita, yksityisyyteen keskittyviä, helppokäyttöisiä karttoja, joista pidät.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Käytät nyt puhelimen näytöllä Organic Maps -palvelua.</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Käytät nyt Organic Maps auton näytöllä</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Olet yhteydessä Android Autoon</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Jatka puhelimessa</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Auton näyttöön</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps tarvitsee sijaintitietoja. Kun se on turvallista, tarkista puhelimesi ilmoitus.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Tämä sovellus tarvitsee lupasi</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps tarvitsee luvan käyttää sijantia toimiakseen tehokkaasti Android Autossa</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Lupien myöntäminen</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Vaellus</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Verkkoselain ei ole käytettävissä</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Äänenvoimakkuus</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Vie kaikki kirjanmerkit ja kappaleet</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Puhesynteesijärjestelmän asetukset</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Puhesynteesin asetuksia ei löytynyt, oletko varma, että laitteesi tukee sitä?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Ajaa läpi</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Tyhjennä haku</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Suurenna</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Pienennä</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Valikkolinkki</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Näytä valikko</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Avaa toisessa sovelluksessa</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Itsepalvelu</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Valitse vaihtoehto</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Ulkona istuminen</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Jotta navigointi olisi mahdollisimman tarkkaa, suosittelemme virransäästötilan poistamista käytöstä puhelimen akkuasetuksista.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Reitin tallennus</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Lopeta reitin tallennus</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Reitin tallennus</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Lopeta tallentamatta</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Jatka tallennusta</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Tallenna kirjanmerkkeihin ja reitteihin?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Reitti on tyhjä - ei mitään tallennettavaa</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kansiovalintaikkunaa ei voida näyttää, koska laitteeseen ei ole asennettu sopivaa sovellusta. Asenna tiedostonhallintasovellus ja yritä uudelleen</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Valitse väri</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Muokkaa reittiä</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ei asennettua sovellusta, joka voi avata sijainnin</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automaattinen navigointi</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Järjestelmän oletus</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Jaa reitti</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Poista %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Vaikeustaso</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Helppo</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Kohtuullinen</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Vaikea</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Päivitetään</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Päivitä ladatut kartat</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Karttojen päivittäminen pitää kohteita koskevat tiedot ajan tasalla</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Päivitä (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Päivitä manuaalisesti myöhemmin</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Poista reitti</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Haluatko varmasti poistaa tämän reitin?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Reitin nimi</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Siirrä</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Reitti</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Vaihda väri</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kartta</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Haluatko lähettää vikailmoituksen kehittäjille?
+Luotamme käyttäjiin, sillä Organic Maps ei kerää virhetietoja automaattisesti. Kiitos etukäteen Organic Mapsin tukemisesta!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Ota iCloud-synkronointi käyttöön</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-synkronointi on kehitteillä oleva kokeellinen ominaisuus. Varmista, että olet tehnyt varmuuskopion kaikista kirjanmerkeistäsi ja kappaleistasi.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud on poissa käytöstä</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ota iCloud käyttöön laitteesi asetuksissa, jotta voit käyttää tätä ominaisuutta.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Ota käyttöön</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Varmuuskopiointi</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-synkronoinnin epäonnistuminen</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Virhe: Synkronointi epäonnistui yhteysvirheen vuoksi.</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Virhe: iCloud-kiintiön ylittymisen vuoksi synkronointi epäonnistui.</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Virhe: iCloud ei ole käytettävissä</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Äskettäin poistetut luettelot</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Tyhjennä</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Poista kaikki</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Palauta</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Palauta kaikki</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Osallistu OpenStreetMapiin</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Lisää paikka</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Päivitä kartta osallistuaksesi</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Sinun täytyy päivittää %1-kartta uusimpaan versioon ennen kuin voit osallistua OpenStreetMapin tietoihin</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>Mt</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>Gt</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Sijaintini</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Omat paikat</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Sisäinen yksityinen tallennustila</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Sisäinen jaettu tallennustila</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kortti</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ulkoinen jaettu tallennustila</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postinumero</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Karttapiste</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Reittien näyttämiseksi kartat on päivitettävä.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Poistu</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Sisäänkäynti</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metrokartta ei ole saatavilla</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Sinä</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Violetit ladatut alueet</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Reitti</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Tämänhetkisen sijainnin selvittäminen sovellusta ajettaessa taustalla on tärkeää sovelluksen täydellisen toiminnan takaamiseksi. Sijaintitietoja käytetään reittiopastukseen sekä kuljetun reitin tallennukseen.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Sijaintitietojasi käytetään reittivalintoihin ja viimeaikaisten matkojesi tallentamiseen.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Kirjaudu sisään salasanalla</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Sisäänkirjautuminen selaimella</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Äskettäin käytetty</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Kirjanmerkkien väri vaihdettu</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Reittien väri vaihdettu</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektri</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Liukusäätimet</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>PUNAINEN</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VIHREÄ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex-väri #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Ruudukko</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/fr-CA/omim.ts
+++ b/qt/translations/fr-CA/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="fr-CA">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Retour</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Supprimer</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Télécharger des cartes</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Échec lors du téléchargement. Appuyer pour réessayer.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Téléchargement…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilomètres</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Plus tard</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Recherche</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Rechercher sur la carte</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Tous les services de localisation de cet appareil sont désactivés, ou ils le sont pour cette application. Veuillez les activer dans les paramètres.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Précision limitée</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Pour garantir une navigation précise, activez l&#x27;option Position Exacte dans les paramètres.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Voir sur la carte</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Échec lors du téléchargement</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Réessayer</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>À propos de Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratuit pour tout le monde, fait avec amour</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Pas de pub, pas de suivi, pas de collecte de données</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Préserve la batterie, fonctionne hors ligne</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rapide, minimaliste, développé par la communauté</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Application open source créée par des amateurs et des bénévoles.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Paramètres de localisation</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Fermer</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>L&#x27;accélération OpenGL matérielle est exigée. Malheureusement, votre appareil n&#x27;est pas pris en charge.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Télécharger</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Veuillez débrancher le câble USB ou insérer la carte SD pour utiliser Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Veuillez d&#x27;abord libérer de l&#x27;espace sur la carte SD/le stockage USB afin d&#x27;utiliser l&#x27;appli</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Avant d&#x27;utiliser l&#x27;application, veuillez télécharger la carte du monde sur votre appareil.
+Elle utilisera %1 d&#x27;espace de stockage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Aller sur la carte</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 en téléchargement. Vous pouvez
+maintenant aller sur la carte.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Télécharger %1 ?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Mettre %1 à jour ?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuer</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1, échec lors du téléchargement</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Créer une nouvelle liste</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nom du groupe de signets</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Signets</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Signets et parcours</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nom</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresse</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Paramètres</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Enregistrer les cartes dans</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Sélectionner l&#x27;emplacement où les cartes seront téléchargées.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Cartes téléchargées</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 libres sur %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Déplacer les cartes ?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Erreur lors du déplacement des cartes</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ceci peut prendre plusieurs minutes.
+Veuillez patienter…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unités de mesure</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choisir entre miles et kilomètres</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Annuler le téléchargement</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Laisser un avis</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Téléchargez la carte</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Groupes de signets</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Un endroit pour manger</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Epiceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Stations-service</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Stationnement</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Achats</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>D&#x27;occasion</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hôtel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sites touristiques</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Divertissement</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>DAB</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vie nocturne</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Vacances en famille</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banque</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacie</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hôpital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilettes</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Poste</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recyclage</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Eau</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Aménagements pour camping-car</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Signets Organic Maps partagés</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Bonjour !
+
+Vous trouverez ci-joint mes signets de l&#x27;appli Organic Maps. Veuillez les ouvrir si vous avez installé Organic Maps. Si vous ne l&#x27;avez pas, téléchargez l&#x27;application pour votre appareil iOS ou Android en suivant ce lien : https://omaps.app/get?kmz
+
+Bon voyage avec Organic Maps !</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Chargement des signets</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Les signets ont été chargés avec succès ! Vous pouvez les trouver sur la carte ou sur l&#x27;écran du Gestionnaire de signets.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Échec lors du chargement des signets. Le fichier peut être corrompu ou défectueux.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Le type de fichier n&#x27;est pas reconnu par l&#x27;appli :
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Échec de l&#x27;ouverture du fichier %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Modifier</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Votre position n&#x27;a pas encore été déterminée</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Désolé, les paramètres de stockage des cartes sont présentement désactivés.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Le téléchargement de la carte est en cours.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hé, regardez ma position actuelle sur Organic Maps ! %1 ou %2. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hé, regardez mon signet sur la carte Organic Maps !</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hé, regardez ma position actuelle sur la carte Organic Maps !</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Bonjour,
+
+Je suis actuellement ici : %1. Cliquez sur ce lien %2 ou sur celui-ci %3 pour voir l&#x27;endroit sur la carte.
+
+Merci.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Partager</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Courriel</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copié dans le presse-papiers : %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Terminé</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Données OpenStreetMap : %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Êtes-vous sûr de vouloir vous déconnecter de votre compte OpenStreetMap ?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Parcours</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Longueur</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Partager ma position</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Paramètres généraux</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Boutons « + » et « - » sur la carte</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Afficher à l&#x27;écran</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Style nocturne lorsque vous naviguez dans l&#x27;obscurité</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Mode nuit</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Désactivé</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activé</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatique</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vue en perspective</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Bâtiments en 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Les bâtiments 3D sont désactivés en mode d&#x27;économie d&#x27;énergie</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instructions vocales</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Annoncer les noms de rue</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Lorsqu&#x27;il est activé, le nom de la rue ou de la sortie vers laquelle tourner sera prononcé à haute voix.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Langue vocale</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Pour télécharger une voix de meilleure qualité, ouvrez l’app Réglages et allez dans Accessibilité → VoiceOver → Parole → Voix.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Teste les instructions vocales (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Vérifie le volume ou les paramètres de synthèse vocale du système si tu n&#x27;entends pas la voix maintenant.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Non disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automatique</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Voir sur la carte</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Site internet</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nouvelles</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Retour d&#x27;information</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Évaluer l&#x27;appli</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Aide</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Foire aux questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Faire un don</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Déjà donné</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Rappeler plus tard</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Soutenir Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Soutenir le projet</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Tous droits réservés</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Signaler un bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Améliorez la direction de la flèche en déplaçant le téléphone en huit pour calibrer la boussole.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Déplacez le téléphone en huit pour calibrer la boussole et fixer la direction de la flèche sur la carte.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Appuyer à nouveau longuement sur la carte pour afficher l&#x27;interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Tout mettre à jour</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Tout annuler</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Téléchargé</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En file d&#x27;attente</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Près de moi</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Cartes</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Tout télécharger</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Téléchargement en cours :</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Veuillez arrêter la navigation pour supprimer la carte.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Les itinéraires ne peuvent être créés que s&#x27;ils sont entièrement contenus dans la carte d&#x27;une seule région.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Télécharger la carte</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Réessayer</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Supprimer carte</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Mise à jour carte</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Services de localisation de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Détermine rapidement ta position approximative via Bluetooth, WiFi ou le réseau mobile</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Téléchargez toutes les cartes le long de votre itinéraire</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>La création d&#x27;un itinéraire nécessite que toutes les cartes de votre localisation vers votre destination soient téléchargées et actualisées.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Pas assez d&#x27;espace</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Veuillez activer les services de localisation</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Sauvegarder</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>créer</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rouge</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Jaune</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Bleu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Vert</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violet</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marron</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rose</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Pourpre foncé</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Bleu ciel</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Émeraude</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Vert citron</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Orange foncé</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris-bleu</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Infos</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Version d&#x27;Organic Maps : %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Apparence</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Claire</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Sombre</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Clair de l&#x27;aube au crépuscule</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Autre</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Offrez des cartes gratuites et sans pub à des millions d&#x27;utilisateurs !</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Signaler ou corriger des données cartographiques incorrectes</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Se porter volontaire</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Suis et contacte-nous :</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Le client de courriel n&#x27;a pas été configuré. Veuillez le configurer ou nous contacter à %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Erreur d&#x27;envoi de courriel</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Étalonnage de la boussole</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponible</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Trouvé</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Mettre à jour</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Echec</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>signet</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Lorsque vous suivez l&#x27;itinéraire, gardez à l&#x27;esprit les points suivants :</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Les conditions de circulation, le code de la route et les panneaux de signalisation ont la priorité sur l&#x27;appareil de navigation ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— La carte peut être imprécise et l&#x27;itinéraire proposé n&#x27;est pas forcément le plus direct pour arriver à destination ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— L&#x27;itinéraire proposé doit être considéré comme une simple recommandation ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Faites attention aux itinéraires traversant des zones frontalières : les itinéraires générés par l&#x27;application peuvent parfois franchir des frontières étatiques dans des zones interdites.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Restez vigilant et soyez prudent sur la route !</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Vérifiez le signal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Impossible de créer l&#x27;itinéraire. Les coordonnées GPS actuelles n&#x27;ont pas pu être identifiées.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Vérifiez le signal GPS. Activez le Wi-Fi pour améliorer la précision de votre localisation.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activez les services de localisation</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Impossible d&#x27;identifier les coordonnées GPS actuelles. Activez les services de localisation pour calculer l&#x27;itinéraire.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Impossible de localiser l&#x27;itinéraire</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Impossible de créer l&#x27;itinéraire.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Modifiez votre point de départ ou votre destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Modifiez votre point de départ</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Impossible de localiser le point de départ. L&#x27;itinéraire n&#x27;a pas pu être créé.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Choisissez un point de départ à proximité d&#x27;une route.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajustez la destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Impossible de localiser la destination. L&#x27;itinéraire n&#x27;a pas pu être créé.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Choisissez un lieu de destination à proximité d&#x27;une route.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Impossible de localiser le point intermédiaire.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Veuillez modifier votre point intermédiaire.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Erreur système</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Impossible de créer l&#x27;itinéraire à cause d&#x27;une erreur dans l&#x27;application.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Veuillez réessayer</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Pas maintenant</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Voulez-vous télécharger la carte et créer un itinéraire plus direct s&#x27;étendant sur plus d&#x27;une carte ?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Téléchargez des cartes pour créer un itinéraire plus direct sortant des limites de cette carte.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Téléchargez les fichiers requis</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Téléchargez et mettez à jour les informations de carte et d&#x27;itinéraire de votre trajet pour calculer l&#x27;itinéraire.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Pour commencer à rechercher et à créer des itinéraires, veuillez télécharger la carte. Après cela, vous n&#x27;aurez plus besoin d&#x27;une connexion Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Sélectionner la carte</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Afficher</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Masquer</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Catégories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historique</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Désolé, je n&#x27;ai rien trouvé.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Téléchargez la région dans laquelle vous effectuez votre recherche ou essayez d&#x27;ajouter le nom d&#x27;une ville ou d&#x27;un village proche.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historique de recherche</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Accédez rapidement aux dernières recherches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Effacer l&#x27;historique de recherche</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Votre emplacement</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Démarrer</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Depuis</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Itinéraire vers</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navigation est uniquement disponible à partir de votre emplacement actuel.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Souhaitez-vous que nous planifiions un itinéraire à partir de votre emplacement actuel ?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Suivant</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>À</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Ajouter un horaire d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Supprimer un horaire d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Toute la journée (24 heures)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Ouvert</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Ajouter les heures de fermeture</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Heures d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mode avancé</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mode simplifié</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Heures de fermeture</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Exemple de valeurs</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corriger l&#x27;erreur</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Sélectionnez un lieu</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Veuillez décrire le problème en détail pour permettre à la communauté OpenStreetMap de réparer l&#x27;erreur.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ou faites-le vous-même sur https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Envoyer</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problème</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Le lieu n&#x27;existe pas</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Fermé pour cause de maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lieu en doublon</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Téléchargement automatique</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Quotidien</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/24 et 7/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Fermé aujourd&#x27;hui</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Aujourd&#x27;hui</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Ouvert dans %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Fermé dans %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Modifier les heures d&#x27;ouverture</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Vous n&#x27;avez pas de compte sur OpenStreetMap ?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>S&#x27;inscrire sur OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Connexion</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Non connecté•e</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Se connecter à OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Mot de passe</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Mot de passe oublié ?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Déconnexion</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Modifier le lieu</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Ajouter une langue</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rue</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numéro de la maison</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Détails</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Réseaux sociaux</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bâtiment</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Ajouter une rue</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Veuillez entrer un nom de rue</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choisir une langue</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choisir une rue</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Sélectionner une cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ou nom d&#x27;utilisateur</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Ajouter un numéro de téléphone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Étage</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Niveau : %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Toutes vos modifications de la carte seront supprimées avec elle.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Mettre à jour les cartes</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Pour créer un itinéraire, vous devez mettre à jour toutes les cartes puis reprogrammer l&#x27;itinéraire.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Trouver la carte</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Veuillez vérifier vos paramètres et vous assurer que votre appareil est bien connecté à Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Espace insuffisant</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Veuillez supprimer les données inutiles</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Erreur de connexion.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Modifications vérifiées</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Déplacer la carte pour placer la croix à l&#x27;emplacement du lieu ou de l&#x27;entreprise.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Modification</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Ajout</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nom du lieu</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Comme c&#x27;est écrit dans la langue locale</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Catégorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Description détaillée du problème</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Autre problème</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Ajouter une entreprise</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Aucun objet ne peut être localisé ici</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Données OpenStreetMap créées par la communauté en date du %1. Pour en savoir plus sur la façon de modifier et de mettre à jour la carte, consulte le site OpenStreetMap.org.</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) est un projet communautaire visant à créer une carte libre et ouverte. C&#x27;est la principale source de données cartographiques d&#x27;Organic Maps et son fonctionnement est similaire à celui de Wikipédia. Vous pouvez ajouter ou modifier des lieux et ils deviennent accessibles à des millions d&#x27;utilisateurs dans le monde entier.
+Rejoignez la communauté et aidez-nous à créer une meilleure carte pour tout le monde !</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Créez un compte OpenStreetMap ou connectez-vous pour publier vos modifications de cartes dans le monde entier.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Téléchargement avec une connexion réseau cellulaire ?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Cela pourrait être très cher avec certains abonnements ou si vous êtes en déplacement.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Saisir un numéro de maison correct</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Nombre d&#x27;étages (max %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Le nombre d&#x27;étages ne doit pas dépasser %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Code postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Entrer un code postal correct</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note aux volontaires OpenStreetMap (facultatif)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Décrivez les erreurs sur la carte ou les éléments qui ne peuvent pas être modifiés avec Organic Maps.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vos modifications sont téléchargées dans la base de données publique &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/FR:About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Veuillez ne pas ajouter d&#x27;informations personnelles ou protégées par le droit d&#x27;auteur.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>En savoir plus sur OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Votre historique d&#x27;édition</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vos notes sur les données cartographiques</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Opérateur</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Opérateur : %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Tu ne trouves pas de catégorie appropriée ?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps ne permet d&#x27;ajouter que des catégories de points simples, c&#x27;est-à-dire pas de villes, de routes, de lacs, de contours de bâtiments, etc. Merci d&#x27;ajouter ces catégories directement sur &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte notre &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; pour obtenir des instructions détaillées étape par étape.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Vous n&#x27;avez téléchargé aucune carte</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Téléchargez des cartes pour rechercher un lieu et utiliser la navigation hors ligne</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>L&#x27;emplacement actuel est inconnu.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>j</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Plus</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Éditer le signet</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Remarques personnelles (texte ou html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Commentaire…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Abandonner toutes les modifications locales ?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Réinitialiser</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Supprimer le lieu ajouté ?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Supprimer</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Ce lieu n&#x27;existe pas</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Veuillez indiquer la raison pour laquelle vous supprimez cet endroit</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Saisissez un numéro de téléphone valide</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Saisissez une adresse Internet valide</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Saisissez un email valide</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Saisissez une adresse web, un compte ou un nom de page Facebook valide</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte Instagram valide</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte Twitter valide</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte VK valide</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Entrez une adresse web ou un ID de LINE valide</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Ajouter un lieu sur OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ou alors laissez une note à la communauté OpenStreetMap pour que quelqu&#x27;un d&#x27;autre puisse ajouter ou réparer un endroit ici.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Votre note sera envoyée à OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Souhaitez-vous l’envoyer à tous les utilisateurs ?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Assurez-vous de n’avoir pas saisi de données personnelles.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Les contributeurs d&#x27;OpenStreetMap vérifieront vos modifications et vous contacteront s&#x27;ils ont des questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Arrêter</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Enregistreur de traces</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accepter</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Refuser</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Utiliser l&#x27;Internet mobile pour afficher les informations détaillées ?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Toujours utiliser</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Aujourd&#x27;hui seulement</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ne pas utiliser aujourd&#x27;hui</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mobile</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>L&#x27;Internet mobile est nécessaire pour afficher des informations détaillées sur les lieux, telles que les photos, les prix et les avis.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ne jamais utiliser</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Toujours demander</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Pour afficher les données de circulation, les cartes doivent être actualisées.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Augmenter la taille de police sur la carte</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Veuillez mettre à jour Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Les données de circulation ne sont pas disponibles</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activer le journal</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Feedback général</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Nous utilisons le système TTS pour les instructions vocales. De nombreux appareils Android utilisent Google TTS, vous pouvez le télécharger ou le mettre à jour depuis Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Pour certaines langues, vous devrez installer un synthétiseur vocal ou un pack de langue supplémentaire depuis une boutique d&#x27;applications (Google Play, Galaxy Store, App Gallery, F-Droid).
+Ouvrez les paramètres de votre appareil → Langue et saisie → Parole → Synthèse vocale.
+Vous pourrez alors gérer les paramètres de synthèse vocale (par exemple, télécharger un pack de langue pour une utilisation hors ligne) et sélectionner un autre moteur de synthèse vocale.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Pour plus d’informations, veuillez consulter ce guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translittération vers l&#x27;alphabet latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>En savoir plus</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilisez la recherche, sélectionnez un signet ou appuyez sur la carte pour ajouter un point de départ d&#x27;itinéraire</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utilisez la recherche, sélectionnez un signet ou appuyez sur la carte pour ajouter un point de destination</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gérer l’itinéraire</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifier</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Supprimer l&#x27;arrêt</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Ajouter un arrêt</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Sauvé</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Connecte-toi à OpenStreetMap pour télécharger automatiquement toutes tes modifications de cartes. En savoir plus &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ici&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problème d&#x27;accès au stockage</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Le stockage externe n&#x27;est pas disponible. La carte SD a probablement été enlevée, endommagée ou le système est en lecture seule. Veuillez vérifier votre carte SD ou nous contacter via support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Émuler le mauvais stockage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Veuillez entrer un nom correct</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listes</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Tout masquer</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Tout afficher</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Créer une nouvelle liste</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importer des signets et des parcours</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Impossible de partager en raison d&#x27;une erreur d&#x27;application</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Erreur de partage</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Impossible de partager une liste vide</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Le nom ne peut pas être vide</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Veuillez entrer le nom de la liste</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nouvelle liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ce nom est déjà pris</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Merci de choisir un autre nom</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Veuillez patienter…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numéro de téléphone</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurer</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Vie privée</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politique de confidentialité</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Conditions d&#x27;utilisation</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Itinéraires de randonnée</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cyclisme</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Métro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Styles et couches de cartes</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Cette liste est vide</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Pour ajouter un signet, appuyez sur un lieu sur la carte, puis appuyez sur l&#x27;icône étoile</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Changer la couleur de tous les signets</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Changer la couleur de tous les tracés</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…plus</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exporter KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exporter GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exporter GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Supprimer la liste</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radars de vitesse</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Description d&#x27;endroit</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Téléchargeur carte</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avertir en cas de dépassement de la limite de vitesse</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Toujours avertir</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Jamais avertir</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mode économie d&#x27;énergie</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Si le mode d&#x27;économie d&#x27;énergie est activé, l&#x27;application désactive les fonctions consommant de l&#x27;énergie en fonction de la charge actuelle du téléphone</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Jamais</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automatique</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Économie d&#x27;énergie maximale</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Marquer les noms sur la carte</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>S&#x27;il y a trop de signets, l&#x27;affichage de leurs noms sur la carte peut ralentir l&#x27;application.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Afficher à droite</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Afficher en bas</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Cette option est activée pour l&#x27;identification des actions à des fins de diagnostic. Cela aide l’équipe à identifier les problèmes liés à l’application. Activez cette option uniquement à la demande du support Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Paramètres des itinéraires</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Éviter les routes à péage</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Éviter les routes non pavées</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Éviter les ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Éviter les autoroutes</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Impossible de calculer l&#x27;itinéraire</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Un tracé n&#x27;a pu être établi. Cela peut être causé par les options choisies ou des données OpenStreetMap incomplètes. Merci de modifier vos options et de réessayer.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Définissez les routes à éviter</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Paramètres d&#x27;itinéraire activés</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Route à péage</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Routes non revêtues</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Traversées en ferry</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacité : %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Réseau : %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Vous êtes arrivé !</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Trier…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Trier les signets</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Par défaut</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Par type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Par distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Par date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Par nom</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Il y a une semaine</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Il y a un mois</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Il y a plus d&#x27;un mois</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Il y a plus d&#x27;un an</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Près de moi</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Autres</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>La planification de l&#x27;itinéraire a échoué</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrivée : %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Vous avez modifié la carte du monde ! Ne le cachez pas ! Dites-le à vos amis, et modifiez-la ensemble.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Partagez avec vos amis</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Fermé actuellement</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Ouvre demain à %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Ouvre le %1 à %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Ouvre à %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Ferme à %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Ajouter les heures d&#x27;ouverture</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Mot de passe (8 caractères minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nom d&#x27;utilisateur ou mot de passe invalide.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Compte OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Dernier envoi</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Merci</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nom du lieu</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Numéro de téléphone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>À noter</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Erreur de téléchargement</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Sélectionner une catégorie</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populaire</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Toutes les catégories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Ajoutez de nouveaux lieux sur la carte et modifiez les lieux existants directement depuis l&#x27;appli.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Modifier l&#x27;emplacement</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Pour télécharger, vous avez besoin de plus d&#x27;espace. Veuillez supprimer les données non nécessaires.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>J&#x27;ai amélioré les cartes de Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Commentaire détaillé</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vos modifications suggérées seront envoyées à la communauté OpenStreetMap. Décrivez les détails qui ne peuvent pas être modifiés dans Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Une erreur est survenue lors de la recherche de votre emplacement. Vérifiez que votre appareil fonctionne correctement et réessayez ultérieurement.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>L&#x27;identification de la localisation est désactivée</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Permettre l&#x27;accès à la géolocalisation dans les paramètres de l&#x27;appareil</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ouvrir les paramètres</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Appuyer sur Localisation</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Sélectionner tout en utilisant l&#x27;app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Sélectionne Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Sélectionne les services de localisation</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Active les services de localisation</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ou continuer à utiliser Organic Maps sans Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Réserver</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Appeler</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nom du signet</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Supprimer le signet</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ta note sera envoyée à OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…plus</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Mettre à jour</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Souhaitez-vous désactiver l&#x27;enregistrement de vos itinéraires récents ?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Désactiver</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Consultez</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps utilise votre géolocalisation en arrière-plan pour enregistrer vos itinéraires récents.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Paramètres généraux</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Pour afficher les données de circulation, l&#x27;application doit être actualisée.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Taille du fichier journal : %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Faire glisser ici pour supprimer</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Remplacer l&#x27;arrêt</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Commencer à partir de</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Connecte-toi à OpenStreetMap pour télécharger automatiquement toutes tes modifications de cartes. En savoir plus</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ici</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Masquer l’écran</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Téléchargement de %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Application de %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ce nom est trop long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nouveaux fichiers détectés</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convertir</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Erreur</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Certains fichiers n&#x27;ont pas été convertis.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Une erreur est survenue</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populaire</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Masquer sur la carte</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Une erreur s&#x27;est produite lors du chargement des tags, veuillez réessayer</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Droite</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bas</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>On y va</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Point d&#x27;arrivée</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Recentrer</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Résultats de la recherche</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Ensuite</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Voulez-vous reconstruire l&#x27;itinéraire ?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Clavier non disponible en conduisant</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Impossible de créer un itinéraire à partir de votre position actuelle</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Impossible de créer un itinéraire jusqu&#x27;au point final. Choisissez-en un autre</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Pas de signal GPS. Veuillez vous déplacer vers une zone dégagée</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Impossible de calculer l&#x27;itinéraire. Sélectionnez d&#x27;autres points d&#x27;itinéraire</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Pour créer l&#x27;itinéraire, téléchargez les cartes manquantes sur votre appareil</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Une erreur est survenue. Redémarrez l&#x27;application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>L&#x27;itinéraire sera reconstruit à partir de votre position actuelle</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>L&#x27;itinéraire sera changé en mode Voiture</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Tous les signets ne sont pas affichés</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Passe au téléphone pour voir tous les signets</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radars de vitesse</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Avertissements radars de vitesse</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Téléchargez des cartes dans l&#x27;application Organic Maps sur votre appareil</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 sortie</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Trier par défaut</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Trier par type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Trier par distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Classer par date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Trier par nom</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Aliments</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Choses à voir</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Musées</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parcs</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natation</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montagnes</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animaux</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hôtels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Bâtiments</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Argent</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Magasins</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkings</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Stations-service</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Médicament</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Chercher dans la liste</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Lieux saints</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Sélectionner une liste</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navigation en métro n&#x27;est pas encore disponible dans la région</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Itinéraire de métro non trouvé</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Choisissez un point de départ ou d&#x27;arrivée plus proche d&#x27;une station de métro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terrain</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Pour activer et utiliser la couche topographique, mettez à jour ou téléchargez la carte de l&#x27;endroit désiré</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Les lignes d&#x27;élévation ne sont pas encore disponibles dans cette région</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Montée</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descente</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. élévation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. élévation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulté</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distance :</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Temps :</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoomez pour voir les courbes de niveaux</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Téléchargement</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Télécharger la carte générale du monde</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Impossible de créer un dossier et de déplacer les fichiers vers la mémoire interne de l&#x27;appareil ou la carte SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Erreur disque</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Erreur de connexion</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Déconnectez le câble USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Laisser l&#x27;écran allumé</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Lorsque cette option est activée, l&#x27;écran sera toujours allumé lors de l&#x27;affichage de la carte.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Afficher sur l&#x27;écran de verrouillage</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Lorsqu&#x27;il est activé, vous n&#x27;avez pas besoin de déverrouiller votre appareil à chaque fois que l&#x27;application est en fonctionnement.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Langue de la carte</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Données cartographiques d&#x27;OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/fr/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/fr/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/FR:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Merci d&#x27;utiliser nos cartes créées par la communauté !</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Avec vos dons et votre soutien, nous pouvons créer les meilleures cartes du monde !</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Aimez-vous notre application ? Veuillez faire un don pour soutenir le développement ! Vous ne l&#x27;aimez pas encore ? S&#x27;il vous plaît laissez-nous savoir et nous y remédierons !</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Si vous connaissez un développeur de logiciels, vous pouvez lui demander d&#x27;implémenter une fonctionnalité dont vous avez besoin.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tapez n&#x27;importe où sur la carte pour sélectionner quelque chose. Touchez longuement pour masquer et réafficher l&#x27;interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Savez-vous que vous pouvez sélectionner votre position actuelle sur la carte ?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Vous pouvez nous aider à traduire notre application dans votre langue.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Notre application est développée par quelques passionnés et la communauté.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Vous pouvez facilement corriger et améliorer les données cartographiques.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Notre objectif principal est de créer des cartes rapides, axées sur la confidentialité et faciles à utiliser que vous allez adorer.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Vous utilisez maintenant Organic Maps sur le téléphone</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Vous utilisez maintenant Organic Maps dans la voiture</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Vous êtes connecté à Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Aller sur le téléphone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Afficher dans la voiture</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps a besoin d&#x27;un accès à la localisation. Lorsque c&#x27;est sûr, vérifie la notification sur ton téléphone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Cette application a besoin de ta permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps dans Android Auto a besoin des permissions de localisation pour fonctionner efficacement</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Accorder l&#x27;accès</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Plein air</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Le navigateur Web n&#x27;est pas disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exporter tous les signets et toutes les pistes</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Paramètres du système de synthèse vocale</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Les paramètres de la synthèse vocale n&#x27;ont pas été trouvés, es-tu sûr que ton appareil la prend en charge ?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Au volant</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Efface la recherche</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom avant</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom arrière</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Lien vers le menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Voir le menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Ouvrir dans une autre application</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Libre-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Sélectionner une option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Places en terrasse</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Pour une navigation plus précise, nous te recommandons de désactiver le mode d&#x27;économie d&#x27;énergie dans les paramètres de la batterie du téléphone.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Enregistrer la trace</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Arrêter l&#x27;enregistrement de la trace</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Enregistrement de la trace</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Arrêter sans enregistrer</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuer l&#x27;enregistrement</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Sauvegarder dans les signets et parcours ?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>L&#x27;itinéraire est vide - il n&#x27;y a rien à sauvegarder</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Impossible d&#x27;afficher la boîte de dialogue de sélection des dossiers car aucune application appropriée n&#x27;est installée sur votre appareil. Veuillez installer une application de gestion de fichiers et réessayer.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choisir la couleur</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Modifier le trace</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Aucune application installée ne permet d&#x27;ouvrir l&#x27;emplacement</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto pendant la navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Suivre le système</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Partager la piste</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Supprimer %1 ?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Niveau de difficulté</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Facile</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moyen</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difficile</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Mise à jour</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Mettez à jour vos cartes téléchargées</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Actualiser les cartes permet d&#x27;actualiser également les informations sur les objets</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Mettre à jour (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Mettre à jour manuellement plus tard</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Supprimer la route</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Êtes-vous sûr de vouloir supprimer ce tracé ?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nom du tracé</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Déplacer</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Route</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change de couleur</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Carte</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Veux-tu envoyer un rapport de bogue aux développeurs ?
+Nous comptons sur nos utilisateurs, car Organic Maps ne recueille pas automatiquement d&#x27;informations sur les erreurs. Merci d&#x27;avance de soutenir Organic Maps !</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activer la synchronisation iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La synchronisation iCloud est une fonctionnalité expérimentale en cours de développement. Assure-toi d&#x27;avoir fait une sauvegarde de tous tes signets et pistes.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud est désactivé</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Active iCloud dans les paramètres de ton appareil pour utiliser cette fonctionnalité.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activer</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sauvegarde</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Échec de la synchronisation iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Erreur : La synchronisation a échoué en raison d&#x27;une erreur de connexion</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Erreur : Échec de la synchronisation en raison du dépassement du quota iCloud.</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Erreur : iCloud n&#x27;est pas disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listes récemment supprimées</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Effacer</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Supprimer tout</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Récupérer</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Tout récupérer</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuer à OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Ajouter un lieu</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Mettre à jour la carte pour contribuer</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Vous devez mettre à jour la carte %1 vers la dernière version avant de pouvoir contribuer aux données OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>Mo</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>Go</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Ma position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mes lieux</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Stockage privé interne</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Stockage interne partagé</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Carte SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Stockage partagé externe</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Code postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Point sur la carte</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Pour afficher les itinéraires, les cartes doivent être mises à jour.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Sortie</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrée</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Le plan du métro n&#x27;est pas disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Vous</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Régions téléchargées en violet</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Itinéraire</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>La détection de votre position en arrière-plan est nécessaire pour profiter pleinement de toutes les fonctionnalités de l&#x27;application. Elle est utilisée pour la navigation et pour enregistrer votre trajet récent.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>La détection de votre position est nécessaire pour la navigation et pour enregistrer votre trajet récent.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Connexion avec mot de passe</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Se connecter à l&#x27;aide d&#x27;un navigateur</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Récemment utilisées</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Couleur des signets modifiée</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Couleur des tracés modifiée</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectre</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Glissières</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROUGE</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERT</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLEU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Couleur hexagonale sRGB</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grille</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/fr/omim.ts
+++ b/qt/translations/fr/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="fr">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Retour</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Supprimer</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Télécharger des cartes</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Échec lors du téléchargement. Appuyer pour réessayer.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Téléchargement…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilomètres</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Plus tard</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Recherche</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Rechercher sur la carte</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Tous les services de localisation de cet appareil sont désactivés, ou ils le sont pour cette application. Veuillez les activer dans les paramètres.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Précision limitée</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Pour garantir une navigation précise, activez l&#x27;option Position Exacte dans les paramètres.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Voir sur la carte</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Échec lors du téléchargement</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Réessayer</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>À propos de Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratuit pour tout le monde, fait avec amour</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Pas de pub, pas de suivi, pas de collecte de données</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Préserve la batterie, fonctionne hors ligne</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rapide, minimaliste, développé par la communauté</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Application open source créée par des amateurs et des bénévoles.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Paramètres de localisation</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Fermer</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>L&#x27;accélération OpenGL matérielle est exigée. Malheureusement, votre appareil n&#x27;est pas pris en charge.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Télécharger</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Veuillez débrancher le câble USB ou insérer la carte SD pour utiliser Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Veuillez d&#x27;abord libérer de l&#x27;espace sur la carte SD/le stockage USB afin d&#x27;utiliser l&#x27;appli</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Avant d&#x27;utiliser l&#x27;application, veuillez télécharger la carte du monde sur votre appareil.
+Elle utilisera %1 d&#x27;espace de stockage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Aller sur la carte</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 en téléchargement. Vous pouvez
+maintenant aller sur la carte.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Télécharger %1 ?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Mettre %1 à jour ?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuer</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1, échec lors du téléchargement</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Créer une nouvelle liste</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nom du groupe de signets</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Signets</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Signets et parcours</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nom</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresse</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Paramètres</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Enregistrer les cartes dans</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Sélectionner l&#x27;emplacement où les cartes seront téléchargées.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Cartes téléchargées</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 libres sur %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Déplacer les cartes ?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Erreur lors du déplacement des cartes</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ceci peut prendre plusieurs minutes.
+Veuillez patienter…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unités de mesure</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choisir entre miles et kilomètres</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Annuler le téléchargement</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Laisser un avis</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Téléchargez la carte</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Groupes de signets</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Un endroit pour manger</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Epiceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Stations-service</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Stationnement</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Achats</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>D&#x27;occasion</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hôtel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sites touristiques</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Divertissement</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>DAB</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vie nocturne</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Vacances en famille</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banque</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacie</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hôpital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilettes</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Poste</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recyclage</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Eau</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Aménagements pour camping-car</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Signets Organic Maps partagés</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Bonjour !
+
+Vous trouverez ci-joint mes signets de l&#x27;appli Organic Maps. Veuillez les ouvrir si vous avez installé Organic Maps. Si vous ne l&#x27;avez pas, téléchargez l&#x27;application pour votre appareil iOS ou Android en suivant ce lien : https://omaps.app/get?kmz
+
+Bon voyage avec Organic Maps !</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Chargement des signets</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Les signets ont été chargés avec succès ! Vous pouvez les trouver sur la carte ou sur l&#x27;écran du Gestionnaire de signets.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Échec lors du chargement des signets. Le fichier peut être corrompu ou défectueux.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Le type de fichier n&#x27;est pas reconnu par l&#x27;appli :
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Échec de l&#x27;ouverture du fichier %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Modifier</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Votre position n&#x27;a pas encore été déterminée</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Désolé, les paramètres de stockage des cartes sont présentement désactivés.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Le téléchargement de la carte est en cours.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hé, regardez ma position actuelle sur Organic Maps ! %1 ou %2. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hé, regardez mon signet sur la carte Organic Maps !</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hé, regardez ma position actuelle sur la carte Organic Maps !</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Bonjour,
+
+Je suis actuellement ici : %1. Cliquez sur ce lien %2 ou sur celui-ci %3 pour voir l&#x27;endroit sur la carte.
+
+Merci.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Partager</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Courriel</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copié dans le presse-papiers : %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Terminé</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Données OpenStreetMap : %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Êtes-vous sûr de vouloir vous déconnecter de votre compte OpenStreetMap ?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Parcours</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Longueur</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Partager ma position</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Paramètres généraux</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Boutons « + » et « - » sur la carte</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Afficher à l&#x27;écran</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Style nocturne lorsque vous naviguez dans l&#x27;obscurité</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Mode nuit</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Désactivé</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activé</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatique</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vue en perspective</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Bâtiments en 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Les bâtiments 3D sont désactivés en mode d&#x27;économie d&#x27;énergie</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instructions vocales</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Annoncer les noms de rue</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Lorsqu&#x27;il est activé, le nom de la rue ou de la sortie vers laquelle tourner sera prononcé à haute voix.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Langue vocale</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Pour télécharger une voix de meilleure qualité, ouvrez l’app Réglages et allez dans Accessibilité → VoiceOver → Parole → Voix.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Teste les instructions vocales (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Vérifie le volume ou les paramètres de synthèse vocale du système si tu n&#x27;entends pas la voix maintenant.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Non disponible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automatique</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Voir sur la carte</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Site internet</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nouvelles</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Retour d&#x27;information</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Évaluer l&#x27;appli</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Aide</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Foire aux questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Faire un don</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Déjà donné</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Rappeler plus tard</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Soutenir Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Soutenir le projet</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Tous droits réservés</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Signaler un bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Améliorez la direction de la flèche en déplaçant le téléphone en huit pour calibrer la boussole.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Déplacez le téléphone en huit pour calibrer la boussole et fixer la direction de la flèche sur la carte.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Appuyer à nouveau longuement sur la carte pour afficher l&#x27;interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Tout mettre à jour</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Tout annuler</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Téléchargé</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En file d&#x27;attente</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Près de moi</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Cartes</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Tout télécharger</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Téléchargement en cours :</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Veuillez arrêter la navigation pour supprimer la carte.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Les itinéraires ne peuvent être créés que s&#x27;ils sont entièrement contenus dans la carte d&#x27;une seule région.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Télécharger la carte</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Réessayer</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Supprimer carte</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Mise à jour carte</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Services de localisation de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Détermine rapidement ta position approximative via Bluetooth, WiFi ou le réseau mobile</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Téléchargez toutes les cartes le long de votre itinéraire</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>La création d&#x27;un itinéraire nécessite que toutes les cartes de votre localisation vers votre destination soient téléchargées et actualisées.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Pas assez d&#x27;espace</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Veuillez activer les services de localisation</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Sauvegarder</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>créer</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rouge</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Jaune</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Bleu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Vert</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violet</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marron</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rose</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Pourpre foncé</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Bleu ciel</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Émeraude</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Vert citron</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Orange foncé</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris-bleu</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Infos</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Version d&#x27;Organic Maps : %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Apparence</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Claire</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Sombre</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Clair de l&#x27;aube au crépuscule</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Autre</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Offrez des cartes gratuites et sans pub à des millions d&#x27;utilisateurs !</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Signaler ou corriger des données cartographiques incorrectes</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Se porter volontaire</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Suis et contacte-nous :</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Le client de courriel n&#x27;a pas été configuré. Veuillez le configurer ou nous contacter à %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Erreur d&#x27;envoi de courriel</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Étalonnage de la boussole</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponible</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Trouvé</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Mettre à jour</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Echec</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>signet</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Lorsque vous suivez l&#x27;itinéraire, gardez à l&#x27;esprit les points suivants :</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Les conditions de circulation, le code de la route et les panneaux de signalisation ont la priorité sur l&#x27;appareil de navigation ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— La carte peut être imprécise et l&#x27;itinéraire proposé n&#x27;est pas forcément le plus direct pour arriver à destination ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— L&#x27;itinéraire proposé doit être considéré comme une simple recommandation ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Faites attention aux itinéraires traversant des zones frontalières : les itinéraires générés par l&#x27;application peuvent parfois franchir des frontières étatiques dans des zones interdites.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Restez vigilant et soyez prudent sur la route !</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Vérifiez le signal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Impossible de créer l&#x27;itinéraire. Les coordonnées GPS actuelles n&#x27;ont pas pu être identifiées.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Vérifiez le signal GPS. Activez le Wi-Fi pour améliorer la précision de votre localisation.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activez les services de localisation</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Impossible d&#x27;identifier les coordonnées GPS actuelles. Activez les services de localisation pour calculer l&#x27;itinéraire.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Impossible de localiser l&#x27;itinéraire</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Impossible de créer l&#x27;itinéraire.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Modifiez votre point de départ ou votre destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Modifiez votre point de départ</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Impossible de localiser le point de départ. L&#x27;itinéraire n&#x27;a pas pu être créé.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Choisissez un point de départ à proximité d&#x27;une route.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajustez la destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Impossible de localiser la destination. L&#x27;itinéraire n&#x27;a pas pu être créé.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Choisissez un lieu de destination à proximité d&#x27;une route.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Impossible de localiser le point intermédiaire.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Veuillez modifier votre point intermédiaire.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Erreur système</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Impossible de créer l&#x27;itinéraire à cause d&#x27;une erreur dans l&#x27;application.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Veuillez réessayer</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Pas maintenant</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Voulez-vous télécharger la carte et créer un itinéraire plus direct s&#x27;étendant sur plus d&#x27;une carte ?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Téléchargez des cartes pour créer un itinéraire plus direct sortant des limites de cette carte.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Téléchargez les fichiers requis</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Téléchargez et mettez à jour les informations de carte et d&#x27;itinéraire de votre trajet pour calculer l&#x27;itinéraire.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Pour commencer à rechercher et à créer des itinéraires, veuillez télécharger la carte. Après cela, vous n&#x27;aurez plus besoin d&#x27;une connexion Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Sélectionner la carte</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Afficher</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Masquer</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Catégories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historique</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Désolé, je n&#x27;ai rien trouvé.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Téléchargez la région dans laquelle vous effectuez votre recherche ou essayez d&#x27;ajouter le nom d&#x27;une ville ou d&#x27;un village proche.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historique de recherche</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Accédez rapidement aux dernières recherches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Effacer l&#x27;historique de recherche</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Votre emplacement</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Démarrer</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Depuis</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Itinéraire vers</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navigation est uniquement disponible à partir de votre emplacement actuel.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Souhaitez-vous que nous planifiions un itinéraire à partir de votre emplacement actuel ?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Suivant</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>À</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Ajouter un horaire d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Supprimer un horaire d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Toute la journée (24 heures)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Ouvert</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Ajouter les heures de fermeture</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Heures d&#x27;ouverture</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mode avancé</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mode simplifié</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Heures de fermeture</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Exemple de valeurs</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corriger l&#x27;erreur</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Sélectionnez un lieu</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Veuillez décrire le problème en détail pour permettre à la communauté OpenStreetMap de réparer l&#x27;erreur.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ou faites-le vous-même sur https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Envoyer</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problème</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Le lieu n&#x27;existe pas</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Fermé pour cause de maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lieu en doublon</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Téléchargement automatique</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Quotidien</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/24 et 7/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Fermé aujourd&#x27;hui</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Aujourd&#x27;hui</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Ouvert dans %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Fermé dans %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Fermé</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Modifier les heures d&#x27;ouverture</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Vous n&#x27;avez pas de compte sur OpenStreetMap ?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>S&#x27;inscrire sur OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Connexion</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Non connecté•e</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Se connecter à OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Mot de passe</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Mot de passe oublié ?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Déconnexion</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Modifier le lieu</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Ajouter une langue</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rue</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numéro de la maison</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Détails</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Réseaux sociaux</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bâtiment</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Ajouter une rue</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Veuillez entrer un nom de rue</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choisir une langue</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choisir une rue</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Sélectionner une cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ou nom d&#x27;utilisateur</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Ajouter un numéro de téléphone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Étage</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Niveau : %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Toutes vos modifications de la carte seront supprimées avec elle.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Mettre à jour les cartes</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Pour créer un itinéraire, vous devez mettre à jour toutes les cartes puis reprogrammer l&#x27;itinéraire.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Trouver la carte</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Veuillez vérifier vos paramètres et vous assurer que votre appareil est bien connecté à Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Espace insuffisant</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Veuillez supprimer les données inutiles</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Erreur de connexion.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Modifications vérifiées</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Déplacer la carte pour placer la croix à l&#x27;emplacement du lieu ou de l&#x27;entreprise.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Modification</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Ajout</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nom du lieu</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Comme c&#x27;est écrit dans la langue locale</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Catégorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Description détaillée du problème</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Autre problème</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Ajouter une entreprise</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Aucun objet ne peut être localisé ici</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Données OpenStreetMap créées par la communauté en date du %1. Pour en savoir plus sur la façon de modifier et de mettre à jour la carte, consulte le site OpenStreetMap.org.</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) est un projet communautaire visant à créer une carte libre et ouverte. C&#x27;est la principale source de données cartographiques d&#x27;Organic Maps et son fonctionnement est similaire à celui de Wikipédia. Vous pouvez ajouter ou modifier des lieux et ils deviennent accessibles à des millions d&#x27;utilisateurs dans le monde entier.
+Rejoignez la communauté et aidez-nous à créer une meilleure carte pour tout le monde !</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Créez un compte OpenStreetMap ou connectez-vous pour publier vos modifications de cartes dans le monde entier.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Téléchargement avec une connexion réseau cellulaire ?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Cela pourrait être très cher avec certains abonnements ou si vous êtes en déplacement.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Saisir un numéro de maison correct</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Nombre d&#x27;étages (max %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Le nombre d&#x27;étages ne doit pas dépasser %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Code postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Entrer un code postal correct</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note aux volontaires OpenStreetMap (facultatif)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Décrivez les erreurs sur la carte ou les éléments qui ne peuvent pas être modifiés avec Organic Maps.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vos modifications sont téléchargées dans la base de données publique &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/FR:About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Veuillez ne pas ajouter d&#x27;informations personnelles ou protégées par le droit d&#x27;auteur.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>En savoir plus sur OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Votre historique d&#x27;édition</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vos notes sur les données cartographiques</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Opérateur</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Opérateur : %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Tu ne trouves pas de catégorie appropriée ?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps ne permet d&#x27;ajouter que des catégories de points simples, c&#x27;est-à-dire pas de villes, de routes, de lacs, de contours de bâtiments, etc. Merci d&#x27;ajouter ces catégories directement sur &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte notre &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; pour obtenir des instructions détaillées étape par étape.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Vous n&#x27;avez téléchargé aucune carte</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Téléchargez des cartes pour rechercher un lieu et utiliser la navigation hors ligne</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>L&#x27;emplacement actuel est inconnu.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>j</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Plus</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Éditer le signet</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Remarques personnelles (texte ou html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Commentaire…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Abandonner toutes les modifications locales ?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Réinitialiser</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Supprimer le lieu ajouté ?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Supprimer</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Ce lieu n&#x27;existe pas</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Veuillez indiquer la raison pour laquelle vous supprimez cet endroit</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Saisissez un numéro de téléphone valide</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Saisissez une adresse Internet valide</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Saisissez un email valide</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Saisissez une adresse web, un compte ou un nom de page Facebook valide</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte Instagram valide</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte Twitter valide</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Saisissez une adresse web, un nom de compte VK valide</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Entrez une adresse web ou un ID de LINE valide</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Ajouter un lieu sur OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ou alors laissez une note à la communauté OpenStreetMap pour que quelqu&#x27;un d&#x27;autre puisse ajouter ou réparer un endroit ici.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Votre note sera envoyée à OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Souhaitez-vous l’envoyer à tous les utilisateurs ?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Assurez-vous de n’avoir pas saisi de données personnelles.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Les contributeurs d&#x27;OpenStreetMap vérifieront vos modifications et vous contacteront s&#x27;ils ont des questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Arrêter</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Enregistreur de traces</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accepter</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Refuser</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Utiliser l&#x27;Internet mobile pour afficher les informations détaillées ?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Toujours utiliser</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Aujourd&#x27;hui seulement</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ne pas utiliser aujourd&#x27;hui</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mobile</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>L&#x27;Internet mobile est nécessaire pour afficher des informations détaillées sur les lieux, telles que les photos, les prix et les avis.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ne jamais utiliser</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Toujours demander</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Pour afficher les données de circulation, les cartes doivent être actualisées.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Augmenter la taille de police sur la carte</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Veuillez mettre à jour Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Les données de circulation ne sont pas disponibles</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activer le journal</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Feedback général</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Nous utilisons le système TTS pour les instructions vocales. De nombreux appareils Android utilisent Google TTS, vous pouvez le télécharger ou le mettre à jour depuis Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Pour certaines langues, vous devrez installer un synthétiseur vocal ou un pack de langue supplémentaire depuis une boutique d&#x27;applications (Google Play, Galaxy Store, App Gallery, F-Droid).
+Ouvrez les paramètres de votre appareil → Langue et saisie → Parole → Synthèse vocale.
+Vous pourrez alors gérer les paramètres de synthèse vocale (par exemple, télécharger un pack de langue pour une utilisation hors ligne) et sélectionner un autre moteur de synthèse vocale.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Pour plus d’informations, veuillez consulter ce guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translittéré en alphabet latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>En savoir plus</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilisez la recherche, sélectionnez un signet ou appuyez sur la carte pour ajouter un point de départ d&#x27;itinéraire</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utilisez la recherche, sélectionnez un signet ou appuyez sur la carte pour ajouter un point de destination</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gérer l’itinéraire</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifier</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Supprimer l&#x27;arrêt</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Ajouter un arrêt</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Sauvé</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Connecte-toi à OpenStreetMap pour télécharger automatiquement toutes tes modifications de cartes. En savoir plus &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ici&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problème d&#x27;accès au stockage</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Le stockage externe n&#x27;est pas disponible. La carte SD a probablement été enlevée, endommagée ou le système est en lecture seule. Veuillez vérifier votre carte SD ou nous contacter via support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Émuler le mauvais stockage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Veuillez entrer un nom correct</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listes</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Tout masquer</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Tout afficher</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n signet</numerusform>
+<numerusform>%n signets</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Créer une nouvelle liste</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importer des signets et des parcours</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Impossible de partager en raison d&#x27;une erreur d&#x27;application</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Erreur de partage</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Impossible de partager une liste vide</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Le nom ne peut pas être vide</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Veuillez entrer le nom de la liste</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nouvelle liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ce nom est déjà pris</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Merci de choisir un autre nom</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Veuillez patienter…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numéro de téléphone</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fichier a été trouvé. Vous le verrez après la conversion.</numerusform>
+<numerusform>%n fichiers ont été trouvés. Vous les verrez après la conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurer</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n voie</numerusform>
+<numerusform>%n voies</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Vie privée</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politique de confidentialité</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Conditions d&#x27;utilisation</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Itinéraires de randonnée</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cyclisme</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Métro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Styles et couches de cartes</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Cette liste est vide</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Pour ajouter un signet, appuyez sur un lieu sur la carte, puis appuyez sur l&#x27;icône étoile</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Changer la couleur de tous les signets</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Changer la couleur de tous les tracés</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…plus</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exporter KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exporter GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exporter GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Supprimer la liste</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radars de vitesse</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Description d&#x27;endroit</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Téléchargeur carte</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avertir en cas de dépassement de la limite de vitesse</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Toujours avertir</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Jamais avertir</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mode économie d&#x27;énergie</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Si le mode d&#x27;économie d&#x27;énergie est activé, l&#x27;application désactive les fonctions consommant de l&#x27;énergie en fonction de la charge actuelle du téléphone</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Jamais</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automatique</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Économie d&#x27;énergie maximale</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Marquer les noms sur la carte</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>S&#x27;il y a trop de signets, l&#x27;affichage de leurs noms sur la carte peut ralentir l&#x27;application.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Afficher à droite</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Afficher en bas</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Cette option est activée pour l&#x27;identification des actions à des fins de diagnostic. Cela aide l’équipe à identifier les problèmes liés à l’application. Activez cette option uniquement à la demande du support Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Paramètres des itinéraires</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Éviter les routes à péage</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Éviter les routes non pavées</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Éviter les ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Éviter les autoroutes</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Impossible de calculer l&#x27;itinéraire</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Un tracé n&#x27;a pu être établi. Cela peut être causé par les options choisies ou des données OpenStreetMap incomplètes. Merci de modifier vos options et de réessayer.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Définissez les routes à éviter</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Paramètres d&#x27;itinéraire activés</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Route à péage</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Routes non revêtues</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Traversées en ferry</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Oui</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacité : %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Réseau : %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Vous êtes arrivé !</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Trier…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Trier les signets</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Par défaut</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Par type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Par distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Par date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Par nom</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Il y a une semaine</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Il y a un mois</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Il y a plus d&#x27;un mois</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Il y a plus d&#x27;un an</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Près de moi</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Autres</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>La planification de l&#x27;itinéraire a échoué</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrivée : %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Vous avez modifié la carte du monde ! Ne le cachez pas ! Dites-le à vos amis, et modifiez-la ensemble.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Partagez avec vos amis</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Fermé actuellement</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Ouvre demain à %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Ouvre le %1 à %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Ouvre à %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Ferme à %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Ajouter les heures d&#x27;ouverture</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Mot de passe (8 caractères minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nom d&#x27;utilisateur ou mot de passe invalide.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Compte OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Dernier envoi</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Merci</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nom du lieu</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Numéro de téléphone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>À noter</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Erreur de téléchargement</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Sélectionner une catégorie</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populaire</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Toutes les catégories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Ajoutez de nouveaux lieux sur la carte et modifiez les lieux existants directement depuis l&#x27;appli.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Modifier l&#x27;emplacement</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Pour télécharger, vous avez besoin de plus d&#x27;espace. Veuillez supprimer les données non nécessaires.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>J&#x27;ai amélioré les cartes de Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Commentaire détaillé</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vos modifications suggérées seront envoyées à la communauté OpenStreetMap. Décrivez les détails qui ne peuvent pas être modifiés dans Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Une erreur est survenue lors de la recherche de votre emplacement. Vérifiez que votre appareil fonctionne correctement et réessayez ultérieurement.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>L&#x27;identification de la localisation est désactivée</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Permettre l&#x27;accès à la géolocalisation dans les paramètres de l&#x27;appareil</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ouvrir les paramètres</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Appuyer sur Localisation</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Sélectionner tout en utilisant l&#x27;app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Sélectionne Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Sélectionne les services de localisation</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Active les services de localisation</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ou continuer à utiliser Organic Maps sans Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Réserver</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Appeler</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nom du signet</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Supprimer le signet</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ta note sera envoyée à OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…plus</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Mettre à jour</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Souhaitez-vous désactiver l&#x27;enregistrement de vos itinéraires récents ?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Désactiver</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Consultez</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps utilise votre géolocalisation en arrière-plan pour enregistrer vos itinéraires récents.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Paramètres généraux</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Pour afficher les données de circulation, l&#x27;application doit être actualisée.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Taille du fichier journal : %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Faire glisser ici pour supprimer</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Remplacer l&#x27;arrêt</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Commencer à partir de</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Connecte-toi à OpenStreetMap pour télécharger automatiquement toutes tes modifications de cartes. En savoir plus</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ici</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Masquer l’écran</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Téléchargement de %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Application de %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ce nom est trop long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nouveaux fichiers détectés</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convertir</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Erreur</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Certains fichiers n&#x27;ont pas été convertis.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Une erreur est survenue</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populaire</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Masquer sur la carte</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Une erreur s&#x27;est produite lors du chargement des tags, veuillez réessayer</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Droite</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bas</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>On y va</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Point d&#x27;arrivée</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Recentrer</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Résultats de la recherche</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Ensuite</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Voulez-vous reconstruire l&#x27;itinéraire ?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Clavier non disponible en conduisant</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Impossible de créer un itinéraire à partir de votre position actuelle</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Impossible de créer un itinéraire jusqu&#x27;au point final. Choisissez-en un autre</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Pas de signal GPS. Veuillez vous déplacer vers une zone dégagée</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Impossible de calculer l&#x27;itinéraire. Sélectionnez d&#x27;autres points d&#x27;itinéraire</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Pour créer l&#x27;itinéraire, téléchargez les cartes manquantes sur votre appareil</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Une erreur est survenue. Redémarrez l&#x27;application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>L&#x27;itinéraire sera reconstruit à partir de votre position actuelle</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>L&#x27;itinéraire sera changé en mode Voiture</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Tous les signets ne sont pas affichés</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Passe au téléphone pour voir tous les signets</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radars de vitesse</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Avertissements radars de vitesse</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Téléchargez des cartes dans l&#x27;application Organic Maps sur votre appareil</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 sortie</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Trier par défaut</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Trier par type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Trier par distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Classer par date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Trier par nom</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Aliments</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Choses à voir</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Musées</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parcs</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natation</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montagnes</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animaux</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hôtels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Bâtiments</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Argent</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Magasins</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkings</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Stations-service</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Médicament</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Chercher dans la liste</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Lieux saints</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Sélectionner une liste</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navigation en métro n&#x27;est pas encore disponible dans la région</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Itinéraire de métro non trouvé</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Choisissez un point de départ ou d&#x27;arrivée plus proche d&#x27;une station de métro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terrain</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Pour activer et utiliser la couche topographique, mettez à jour ou téléchargez la carte de l&#x27;endroit désiré</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Les lignes d&#x27;élévation ne sont pas encore disponibles dans cette région</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Montée</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descente</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. élévation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. élévation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulté</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distance :</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Temps :</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoomez pour voir les courbes de niveaux</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Téléchargement</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Télécharger la carte générale du monde</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Impossible de créer un dossier et de déplacer les fichiers vers la mémoire interne de l&#x27;appareil ou la carte SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Erreur disque</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Erreur de connexion</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Déconnectez le câble USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Laisser l&#x27;écran allumé</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Lorsque cette option est activée, l&#x27;écran sera toujours allumé lors de l&#x27;affichage de la carte.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Afficher sur l&#x27;écran de verrouillage</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Lorsqu&#x27;il est activé, vous n&#x27;avez pas besoin de déverrouiller votre appareil à chaque fois que l&#x27;application est en fonctionnement.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Langue de la carte</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Données cartographiques d&#x27;OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/fr/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/fr/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/FR:About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Merci d&#x27;utiliser nos cartes créées par la communauté !</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Avec vos dons et votre soutien, nous pouvons créer les meilleures cartes du monde !</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Aimez-vous notre application ? Veuillez faire un don pour soutenir le développement ! Vous ne l&#x27;aimez pas encore ? S&#x27;il vous plaît laissez-nous savoir et nous y remédierons !</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Si vous connaissez un développeur de logiciels, vous pouvez lui demander d&#x27;implémenter une fonctionnalité dont vous avez besoin.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tapez n&#x27;importe où sur la carte pour sélectionner quelque chose. Touchez longuement pour masquer et réafficher l&#x27;interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Savez-vous que vous pouvez sélectionner votre position actuelle sur la carte ?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Vous pouvez nous aider à traduire notre application dans votre langue.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Notre application est développée par quelques passionnés et la communauté.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Vous pouvez facilement corriger et améliorer les données cartographiques.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Notre objectif principal est de créer des cartes rapides, axées sur la confidentialité et faciles à utiliser que vous allez adorer.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Vous utilisez maintenant Organic Maps sur le téléphone</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Vous utilisez maintenant Organic Maps dans la voiture</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Vous êtes connecté à Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Aller sur le téléphone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Afficher dans la voiture</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps a besoin d&#x27;un accès à la localisation. Lorsque c&#x27;est sûr, vérifie la notification sur ton téléphone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Cette application a besoin de ta permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps dans Android Auto a besoin des permissions de localisation pour fonctionner efficacement</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Accorder l&#x27;accès</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Plein air</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Le navigateur Web n&#x27;est pas disponible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exporter tous les signets et toutes les pistes</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Paramètres du système de synthèse vocale</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Les paramètres de la synthèse vocale n&#x27;ont pas été trouvés, es-tu sûr que ton appareil la prend en charge ?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Au volant</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Efface la recherche</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom avant</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom arrière</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Lien vers le menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Voir le menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Ouvrir dans une autre application</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Libre-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Sélectionner une option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Places en terrasse</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Pour une navigation plus précise, nous te recommandons de désactiver le mode d&#x27;économie d&#x27;énergie dans les paramètres de la batterie du téléphone.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Enregistrer la trace</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Arrêter l&#x27;enregistrement de la trace</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Enregistrement de la trace</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Arrêter sans enregistrer</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuer l&#x27;enregistrement</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Sauvegarder dans les signets et parcours ?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>L&#x27;itinéraire est vide - il n&#x27;y a rien à sauvegarder</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Impossible d&#x27;afficher la boîte de dialogue de sélection des dossiers car aucune application appropriée n&#x27;est installée sur votre appareil. Veuillez installer une application de gestion de fichiers et réessayer.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choisir la couleur</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Modifier le trace</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Aucune application installée ne permet d&#x27;ouvrir l&#x27;emplacement</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto pendant la navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Suivre le système</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Partager la piste</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Supprimer %1 ?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Niveau de difficulté</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Facile</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moyen</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difficile</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Mise à jour</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Mettez à jour vos cartes téléchargées</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Actualiser les cartes permet d&#x27;actualiser également les informations sur les objets</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Mettre à jour (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Mettre à jour manuellement plus tard</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Supprimer la route</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Êtes-vous sûr de vouloir supprimer ce tracé ?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nom du tracé</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Déplacer</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Route</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change de couleur</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Carte</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Veux-tu envoyer un rapport de bogue aux développeurs ?
+Nous comptons sur nos utilisateurs, car Organic Maps ne recueille pas automatiquement d&#x27;informations sur les erreurs. Merci d&#x27;avance de soutenir Organic Maps !</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activer la synchronisation iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La synchronisation iCloud est une fonctionnalité expérimentale en cours de développement. Assure-toi d&#x27;avoir fait une sauvegarde de tous tes signets et pistes.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud est désactivé</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Active iCloud dans les paramètres de ton appareil pour utiliser cette fonctionnalité.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activer</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sauvegarde</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Échec de la synchronisation iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Erreur : La synchronisation a échoué en raison d&#x27;une erreur de connexion</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Erreur : Échec de la synchronisation en raison du dépassement du quota iCloud.</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Erreur : iCloud n&#x27;est pas disponible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listes récemment supprimées</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Effacer</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Supprimer tout</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Récupérer</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Tout récupérer</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuer à OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Ajouter un lieu</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Mettre à jour la carte pour contribuer</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Vous devez mettre à jour la carte %1 vers la dernière version avant de pouvoir contribuer aux données OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>Mo</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>Go</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Ma position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mes lieux</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Stockage privé interne</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Stockage interne partagé</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Carte SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Stockage partagé externe</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Code postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Point sur la carte</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Pour afficher les itinéraires, les cartes doivent être mises à jour.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Sortie</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrée</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Le plan du métro n&#x27;est pas disponible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Vous</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Régions téléchargées en violet</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Itinéraire</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>La détection de votre position en arrière-plan est nécessaire pour profiter pleinement de toutes les fonctionnalités de l&#x27;application. Elle est utilisée pour la navigation et pour enregistrer votre trajet récent.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>La détection de votre position est nécessaire pour la navigation et pour enregistrer votre trajet récent.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Connexion avec mot de passe</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Se connecter à l&#x27;aide d&#x27;un navigateur</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Récemment utilisées</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Couleur des signets modifiée</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Couleur des tracés modifiée</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectre</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Glissières</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROUGE</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERT</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLEU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Couleur hexagonale sRGB</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grille</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/gl/omim.ts
+++ b/qt/translations/gl/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="gl">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Atrás</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Descargar mapas</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Erro durante a descarga. Toque para tentalo de novo.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>A descargar…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Quilómetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Millas</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Máis tarde</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Buscar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Buscar no mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Non se pode acceder aos servizos de localización neste dispositivo ou aplicación. Actíveos na configuración.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisión limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Para garantir unha navegación máis exacta, active a Precisión da localización nos axustes.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Amosar no mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Erro durante a descarga</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Tentar de novo</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Acerca de Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis para todos, feito con amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sen anuncios, sen rastrexo, sen recompilación de datos</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Consumo de batería mínimo, funciona sen conexión</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rápido, minimalista, desenvolto pola comunidade</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicación de código aberto creada por entusiastas e voluntarios.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Axustes de localización</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Pechar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>A aplicación require OpenGL acelerado por hardware. Lamentablemente, o seu dispositivo non é compatible.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Descargar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>por favor, desconecte o cable USB ou insira unha tarxeta de memoria SD para usar Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Libere espazo na memoria SD ou almacenamento USB para usar a aplicación</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Antes de comezar, permita que descarguemos no seu dispositivo un mapamundi xeral.&#32;
+Requírense %1 de almacenamento.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ir ao mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Descargando %1. Pode agora&#32;
+proceder ao mapa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Descargar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Actualizar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausar</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuar</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Non se puido descargar %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Agregar un grupo novo</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nome do grupo de marcadores</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadores</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Marcadores e traxectos</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nome</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Enderezo</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Configuración</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Gardar mapas en</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Seleccione o cartafol onde deben descargarse os mapas.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapas descargados</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 libres de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Mover mapas?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Erro ao mover os arquivos de mapas</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Isto podería tardar varios minutos.&#32;
+Agarde un momento…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidades de medida</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Elixir entre millas e quilómetros</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancelar descarga</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Deixar unha reseña</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Si</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Descargar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Grupos de marcadores</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Onde comer</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Tendas de comestibles</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gasolineira</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Aparcamento</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compras</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Segunda man</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Atraccións turísticas</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretemento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Caixeiro automático</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida nocturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Lecer en familia</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banco</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Baño</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Oficina de correos</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policía</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclaxe</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Auga</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Instalacións para autocaravanas</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notas</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Marcadores de Organic Maps compartidos con vostede</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Ola!
+
+Adxunto os meus marcadores. Por favor, ábraos en Organic Maps. Se non o tes instalado podes descargalo aquí:: https://omaps.app/get?kmz
+
+Gozar viaxando con Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Cargando marcadores</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Os marcadores cargáronse con éxito! Pode atopalos no mapa ou na pantalla de Xestión de marcadores.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Non se puideron cargar os marcadores. O arquivo podería ter danos ou defectos.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>A aplicación non recoñece o tipo de arquivo:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Non se puido abrir o arquivo %1&#32;
+&#32;
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Aínda non se determinou a súa localización</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sentímolo, a configuración do almacenamento de mapas está desactivada.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>A descarga do mapa está en curso.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Olla a miña localización actual en Organic Maps! %1 ou %2 Non ten mapas offline? Descárgueos aquí: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Mira o meu marcador no mapa de Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Mira a miña localización actual no mapa en Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Ola:&#32;
+
+Agora estou aquí: %1. Fai clic nesta ligazón %2 ou esta %3 para velo no mapa.&#32;
+
+Grazas.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Compartir</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Correo electrónico</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiado ao portapapeles: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Feito</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Datos de OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Quere saír da súa conta de OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Traxectos</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lonxitude</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Compartir a miña localización</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Axustes xerais</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Información</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegación</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botóns «+» e «-» no mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Mostrar no mapa</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estilo nocturno ao navegar en escuro</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo nocturno</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desactivado</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Activado</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automático</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vista en perspectiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edificios en 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Os edificios 3D desactívanse no modo de aforro de enerxía</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instrucións de voz</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar nomes de rúas</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Cando se activa, o nome da rúa ou a saída para virar pronunciarase en voz alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Idioma de voz</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Para descargar unha voz de maior calidade, abre a app Axustes e vai a Accesibilidade → VoiceOver → Fala → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Probar indicacións de voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Comprobe o volume ou a configuración de texto a voz do sistema se agora non oe a voz.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Non dispoñible</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zum automático</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distancia</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver no mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menú</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Sitio web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Noticias</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Comentarios</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Valore a aplicación</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Axuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Preguntas frecuentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doar</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Xa doei</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Lembrar máis tarde</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Apoiar Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Apoie o proxecto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Dereitos de autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Informar dun fallo</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Mellore a dirección da frecha movendo o teléfono en forma de oito para calibrar o compás.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mova o teléfono en forma de oito para calibrar o compás e fixar a dirección da frecha no mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Volva pulsar prolongadamente sobre o mapa para ver a interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Actualizar todos</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancelar todo</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Descargado</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>En cola</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Preto de min</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Descargar todos</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Descargando:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Para eliminar o mapa, deteña a navegación.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Só se poden crear rutas que estean totalmente contidas nun mapa dunha soa rexión.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Descargar mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Reintentar</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Eliminar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Actualizar mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servizos de localización de Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determine rapidamente a súa localización aproximada mediante Bluetooth, Wifi ou rede móbil</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Descargue todos os mapas do seu roteiro</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Para crear unha ruta é necesario descargar e actualizar todos os mapas desde a súa localización ao seu destino.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Non hai suficiente espazo</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Por favor, active os servizos de localización</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Gardar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crear</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Vermello</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Amarelo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Morado</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Laranxa</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marrón</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Morado escuro</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Azul Claro</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cian</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Verde azulado</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Laranxa escuro</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gris</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gris azulado</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Información</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versión de Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspecto</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Claro</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Escuro</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Claro desde o amencer ata o solpor</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Outro</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Regala mapas gratuítos e sen anuncios a millóns de usuarios!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Informar ou corrixir datos de mapa incorrectos</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Voluntariado</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Síganos e póñase en contacto connosco:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Non se configurou o cliente de correo electrónico. Configúreo ou @contáctar en %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Erro de envío de correo</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibración do compás</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Dispoñible</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Atopado</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Actualizar</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fallo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>marcador</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Ao seguir a ruta, teña en conta:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— As condicións do camiño, as regras de tránsito e as sinalizacións sempre teñen prioridade sobre as suxestións de navegación;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— O mapa pode ser impreciso e suxerir unha ruta que non sempre pode ser o mellor camiño para chegar ao destino;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— As rutas suxeridas deben entenderse só como recomendacións;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Actúe con cautela nas rutas con zonas fronteirizas: as rutas creadas pola nosa aplicación en ocasións poden atravesar as fronteiras de países en lugares non autorizados.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Mantéñase alerta e a salvo durante a viaxe!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Verificar o sinal do GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Non se pode crear a ruta. Non se puideron identificar as coordenadas actuais do GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifique o sinal do GPS. Activar a Wi-fi mellorará a precisión da súa localización.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activar servizos de localización</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Non se poden atopar as coordenadas do GPS. Active os servizos de localización para calcular a ruta.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Imposible de atopar unha ruta</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Non se pode crear unha ruta.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Axuste o seu punto de inicio ou o seu destino.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Axustar o punto de inicio</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>A ruta non se creou. Non se puido atopar o punto de inicio.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Seleccione un punto de inicio próximo a unha estrada.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Axustar destino</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>A ruta non se creou. Non se puido atopar o destino.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Seleccione un punto de destino próximo a unha estrada.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Non se puido situar a parada intermedia.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Por favor, axuste a parada intermedia.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Erro do sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Non se puido crear a ruta debido a un erro na aplicación.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Tentar novamente</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Non agora</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Desexa descargar o mapa e crear unha ruta mellor que abarque máis dun mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Descargue mapas adicionais para crear unha ruta mellor que cruce os límites deste mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Descargar arquivos requiridos</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Descargue e actualice toda a información de mapas e rutas xunto co traxecto proxectado para calcular a ruta.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Para empezar a buscar e crear rutas, descargue o mapa. Despois diso, xa non necesitará unha conexión a Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Seleccionar mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Amosar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ocultar</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorías</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historial</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Non se atopou ningún resultado.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Descargue a rexión na que está a buscar ou probe a engadir o nome dunha cidade/poboo próximo.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historial de procuras</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ver procuras recentes.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Baleirar historial de procuras</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artigo de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>A súa localización</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Empezar</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Ruta desde</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Ruta á</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>navegación só está dispoñible desde a súa localización actual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Quere planificar unha ruta desde a súa localización actual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Seguinte</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Á</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Engadir horario</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Eliminar horario</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Todo o día (24 horas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Aberto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Pechado</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Engadir horas de peche</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horario de apertura</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modo avanzado</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modo sinxelo</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horas de peche</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valores de exemplo</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corrixir erro</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Seleccione a localización</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Por favor, describa o problema en detalle para que a comunidade de OpenStreetMap poida corrixir o erro.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ou fágao vostede mesmo en https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Enviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Este lugar non existe</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Pechado por mantemento</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lugar duplicado</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Descarga automática</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diario</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Pechado hoxe</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Pechado</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hoxe</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Abre en %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Pecha en %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Pechado</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editar os horarios de apertura</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Non ten conta en OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Rexistrarse en OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Acceder</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Non se iniciou sesión</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Acceder a OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Contrasinal</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Esqueceu o seu contrasinal?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Pechar sesión</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar o lugar</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Engadir un idioma</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rúa</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Número de casa</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalles</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Redes sociais</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edificio</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Engadir unha rúa</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Por favor, introduza un nome de rúa</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Elixir un idioma</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Elixa unha cale</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cociña</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Seleccionar cociña</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Correo electrónico ou usuario</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Engadir teléfono</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Piso</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivel: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Todas as edicións feitas ao mapa eliminaranse xunto con leste.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Actualizar mapas</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Para crear unha ruta, é necesario actualizar todos os mapas e volver planificar a ruta.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Buscar o mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Revise a configuración e asegúrese de que o seu dispositivo estea conectado a Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Non hai suficiente espazo</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Elimine os datos innecesarios</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Erro de inicio de sesión.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Cambios verificados</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arrastre o mapa para colocar a cruz na localización do lugar ou negocio.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Engadir</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nome do lugar</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Como está escrito na lingua local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoría</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descrición detallada do problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Un problema diferente</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Engadir organización</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Non se pode situar ningún obxecto aquí</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Datos de OpenStreetMap creados pola comunidade a data de %1. Máis información sobre como editar e actualizar o mapa en OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) é un proxecto comunitario para construír un mapa libre e aberto. É a principal fonte de datos cartográficos de Organic Maps e funciona de forma similar a Wikipedia. Vostede pode engadir ou editar lugares e estes pasan a estar dispoñibles para millóns de usuarios de todo o mundo.&#32;
+Únase á comunidade e axude a crear un mapa mellor para todos!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Cre unha conta OpenStreetMap ou inicie sesión para publicar as súas edicións de mapas en todo o mundo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Descargar con conexión de rede móbil?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Podería ser moi caro con certos plans ou con itinerancia de datos.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introducir o número de domicilio correcto</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Número de plantas (máx. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>O número de plantas non debe superar %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introduza un código postal válido</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota para os voluntarios de OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describa os erros no mapa ou as cousas que non se poden editar con Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>As súas edicións cárganse na base de datos pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Por favor, non engada información persoal ou protexida por dereitos de autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Más acerca de OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>O seu historial de edicións</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>As miñas notas de datos do mapa</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Non acha unha categoría adecuada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps permite engadir unicamente categorías de puntos sinxelos, é dicir, non cidades, estradas, lagos, contornos de edificios, etc. Por favor, anada ditas categorías directamente &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte nosa &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guía&lt;/a&gt; para obter instrucións detalladas paso a paso.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Non descargou ningún mapa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Descargue mapas para atopar a localización e navegar sen conexión.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Descoñécese a localización actual.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Más</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notas persoais (texto ou html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentario…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Restablecer todos os cambios locais?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Restablecer</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Eliminar o lugar engadido?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>O lugar non existe</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Por favor, indique a razón para eliminar o lugar</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introduza un número de teléfono válido</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Introduza unha dirección web válida</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Introduza un correo válido</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introducir unha dirección web, unha conta ou un nome de páxina de Facebook válidos</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introducir unha dirección web ou un nome de conta de Instagram válidos</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introducir unha dirección web ou un nome de usuario válido de Twitter</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introducir unha dirección web ou un nome de conta de VK válidos</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introducir unha dirección web ou IDE de LINE válidos</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Engadir lugar a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ou, alternativamente, deixa unha nota á comunidade de OpenStreetMap para que alguén poida engadir ou corrixir un lugar aquí.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>A nota enviarase a OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Quere envialo a todos os usuarios?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Confírmese de que non introduciu ningún dato privado ou persoal.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Os editores de OpenStreetMap comprobarán os cambios e poñeranse en contacto con vostede se teñen algunha pregunta.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Deter</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Gravando o traxecto</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aceptar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Declinar</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Usar Internet móbil para amosar información detallada?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usar sempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Só hoxe</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Non usar hoxe</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet móbil</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Necesítase Internet móbil para mostrar información detallada dos lugares, como fotografías, prezos e recensións.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Non usar nunca</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Preguntar sempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Para mostrar os datos de tráfico, deben actualizarse os mapas.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumentar tamaño do texto no mapa</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Por favor, actualice Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Os datos de tráfico non están dispoñibles</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activar rexistros</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Opinión xeral</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Utilizamos o sistema TTS para as instrucións de voz. Moitos dispositivos de Android usan Google TTS. Pode descargar ou actualizalo desde Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Para algúns idiomas, debe instalar outro sintetizador de voz ou un paquete de idioma adicional desde a tenda de aplicacións (Google Play, Galaxy Store, App Gallery, FDroid).&#32;
+Abra os Axustes do seu dispositivo → Idioma e entrada de texto → Voz → Opcións texto a voz.
+Aquí pode administrar a configuración de síntese de voz (por exemplo, descargar un paquete de idioma para poder usalo sen conexión) ou seleccionar outro motor de texto a voz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Para obter máis información, consulte esta guía.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteración ao alfabeto latino</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Coñecer máis</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Busca ou toca no mapa para engadir a orixe da ruta</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Busca ou toca no mapa para engadir o destino</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Administrar roteiro</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planificar</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Eliminar parada</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Engadir parada</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Gardado</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Por favor, Inicia sesión en OpenStreetMap para cargar automaticamente todas as túas edicións de mapas. Más información &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aquí&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema de acceso ao almacenamento</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Non se pode acceder ao almacenamento externo. É posible que a tarxeta SD fose eliminada, danada ou que o sistema de ficheiros sexa só de lectura. Comprobe a súa tarxeta SD ou póñase en contacto connosco en support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emular almacenamento danado</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Por favor, introduza o nome correcto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listas</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ocultar todo</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Amosar todo</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcador</numerusform>
+<numerusform>%n marcadores</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Crear nova lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar marcadores e traxectos</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Non se pode compartir debido a un erro da aplicación</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Erro ao compartir</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Non se pode compartir unha lista baleira</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>O nome non pode quedar baleiro</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Proporcione o nome da lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Lista nova</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Este nome xa existe</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Por favor, escolle outro nome</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Por favor, espere…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de teléfono</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil de OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Atopouse %n arquivo. Podes velo despois da conversión.</numerusform>
+<numerusform>Atopáronse %n arquivos. Podes velos despois da conversión.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurar</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n traxecto</numerusform>
+<numerusform>%n traxectos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidade</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Normativa de privacidade</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Condiciones de uso</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráfico</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Sendeirismo</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos e capas do mapa</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta lista está baleira</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Para engadir un marcador, toque un lugar no mapa e despois toque a icona da estrela</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Cambiar a cor de todos os marcadores</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Cambiar a cor de todos os traxectos</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…máis</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Eliminar lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Cámaras de velocidade</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descrición do lugar</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Descargador de mapas</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Alertar ao exceder velocidade límite</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Alertar sempre</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Non alertar nunca</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modo de aforro de enerxía</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Tratarase de reducir o consumo de enerxía a expensas de certas funcionalidades.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Cando queda pouca enerxía</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nomes de marcadores no mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Se hai demasiados marcadores, amosar os seus nomes no mapa pode ralentizar a aplicación.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostrar á dereita</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostrar na parte inferior</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Active esta opción temporalmente para gravar e enviar de forma manual rexistros para diagnosticar defectos enviados mediante a opción «Informar dun fallo» no diálogo Axuda. Os rexistros poden incluír localizacións.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opcións de encamiñamento</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evitar peaxes</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evitar camiños sen pavimentar</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evitar ferris</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evitar autoestradas</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Non se pode calcular a ruta</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Non se puido atopar unha ruta. Quizá se deba ás opcións de encamiñamento ou a datos faltantes en OpenStreetMap. Revise as súas opcións de encamiñamento e volva tentalo.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Defina os camiños para evitar</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opcións de encamiñamento activadas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Estrada de peaxe</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Camiño sen pavimentar</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Cruzamento de ferri</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Si</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Si</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidade: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rede: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Chegou!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Aceptar</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenar…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordenar marcadores</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Por defecto</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Por tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Por distancia</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Por data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Por nome</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Hai unha semana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Hai un mes</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Fai máis dun mes</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Fai máis dun ano</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Preto de min</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Outros</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Erro ao planificar a ruta</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Chegado: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Descargue e actualice todos os mapas ao longo do camiño proxectado para calcular a ruta.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Compartir con amigos</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Pechado agora</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Abre mañá a Ábreas %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>o %1 ás %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Abre a Ábreas %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Pecha ás %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Engadir horarios de apertura</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Contrasinal (mínimo 8 caracteres)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Usuario ou contrasinal incorrectos.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Conta OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Última carga</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Grazas</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nomee do lugar</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Teléfono</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Atención</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Erro de descarga</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Seleccionar categoría</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Todas as categorías</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Engada lugares novos ao mapa e edite os existentes directamente desde a aplicación.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Cambiar localización</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Necesita máis espazo para descargar. Elimine os datos innecesarios.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Mellorei os mapas de Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentario detallado</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Os cambios que suxeriu enviaranse á comunidade de OpenStreetMap. Describa os detalles que non poden editarse en Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Produciuse un erro ao buscar a súa localización. Comprobe que o seu dispositivo funciona correctamente e ténteo máis tarde.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Os servizos de localización están desactivados</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Active o acceso á xeolocalización nos axustes do dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Abra Axustes</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Pulse Localización</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Seleccione Cando se use a app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Seleccione Privacidade</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Seleccione Localización</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Active a Localización</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ou seguir utilizando Organic Maps sen localización</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reservar</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Chamar</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nomee do marcador</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Eliminar marcador</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>A súa nota enviarase a OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>… máis</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Actualizar</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Quere deixar de gravar o traxecto recentemente percorrido?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desactivar</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Comproba</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps usa a súa localización en segundo plano para gravar a ruta recentemente percorrido.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Configuración xeral</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Para mostrar os datos de tráfico, debe actualizar a aplicación.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Tamaño do arquivo de rexistro: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arrastre aquí para eliminar</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Substituír Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Empezar desde</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Inicia sesión en OpenStreetMap para cargar automaticamente todas as túas edicións de mapas. Más información</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aquí</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ocultar pantalla</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Descargando %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Aplicando %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Este nome é demasiado longo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Novos arquivos detectados</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Converter</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Erro</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Non se converteron algúns arquivos.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Produciuse un erro</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ocultar do mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Produciuse un erro ao cargar as etiquetas</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Dereito</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Parte inferior</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Imos</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destino</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrar</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultados de procura</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Despois</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Quere reconstruír a ruta?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Teclado non dispoñible durante a condución</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Non se pode construír a ruta desde a súa localización actual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Non se pode construír unha ruta ao destino. Elixa por favor outro punto</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Non hai sinal GPS. Móvase por favor a unha zona aberta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Non se pode construír unha ruta. Especifique por favor outros puntos de roteiro</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Para construír unha ruta, descargue os mapas faltantes no seu dispositivo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Ocorreu un erro. Reinicie a aplicación</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>A ruta reconstruirase desde a súa localización actual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>A ruta cambiarase a coche</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Non se amosan todos os marcadores</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Cambie ao teléfono para ver todos os marcadores</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Cám.velocidade</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Alerta velocidade</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Descargue os mapas na aplicación do dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 saída</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenar por defecto</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordenar por tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenar por distancia</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenar por data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordenar por nome</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Comida</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sitios de interese</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museos</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natación</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montañas</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animais</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteis</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edificios</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Diñeiro</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Tendas</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Estacionamento</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gasolineiras</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Buscar na lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Lugares sacros</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Seleccionar lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navegación en metro aínda non dispoñible nesta rexión</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Non se atopou ningún roteiro de metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Elixa un punto de inicio ou fin de roteiro máis próximo a unha estación de metro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Curvas de nivel</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Para usar as curvas de nivel, actualice ou descargue o mapa da área desexada</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>As curvas de nivel aínda non están dispoñibles nesta zona</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascenso</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descenso</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevación mín.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevación máx.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultade</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distancia:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tempo:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Amplíe o mapa para ver as isolíneas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Descargando</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Descarga o mapa xeral do mundo</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Non se puido crear o cartafol e mover os ficheiros na memoria interna do dispositivo ou na tarxeta SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Erro de disco</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Fallo de conexión</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desconecte o cable USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Manter pantalla acesa</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Cando está activada, a pantalla sempre estará acendida cando se mostre o mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostrar na pantalla de bloqueo</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Cando se activa, non ten que desbloquear o dispositivo para executar a aplicación.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Idioma do mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Datos do mapa de OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/gl/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/gl/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Grazas por utilizar os nosos mapas creados pola comunidade!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Coas súas doazóns e apoio, podemos crear os mellores mapas do mundo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Gústalle a nosa aplicación? Por favor doe para apoiar o seu desenvolvemento! Aínda non lle gusta? Díganos por que e arranxarémolo!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Se coñece a algún desarrollador ou desarrolladora de software, pódelle pedir que implemente algunha funcionalidade que vostede necesite.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Toque en calquera lugar do mapa para seleccionar calquera elemento. Manteña pulsado para ocultar e volver amosar a interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Sabía que a súa localización actual no mapa pódese seleccionar?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Pode axudar a traducir a nosa aplicación ao seu idioma.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>A nosa aplicación está desenvolta por uns poucos entusiastas e a comunidade.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Pode arranxar e mellorar facilmente os datos do mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>O noso principal obxectivo é crear mapas rápidos, centrados na privacidade e fáciles de utilizar que lle encantarán.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Agora usa Organic Maps na pantalla do teléfono</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Agora usa Organic Maps na pantalla do coche</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Conectouse a Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Pasar ao teléfono</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Á pantalla do coche</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps necesita acceder á localización. Cando sexa seguro, comprobe a notificación no teléfono.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Esta aplicación necesita o seu permiso</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps en Android Auto necesita permisos de localización para funcionar eficazmente</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Conceder permisos</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Ao aire libre</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>A navegador web non está dispoñible</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportar todos os marcadores e traxectos</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Configuración de síntese de voz do sistema</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Non se atoparon os axustes de síntese de voz. Está seguro de que o seu dispositivo admite esta función?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servizo desde o coche</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Borrar procura</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Achegar</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Afastar</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Enlace ao menú</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ver menú</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir noutra aplicación</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoservizo</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selecciona a opción</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Asentos ao aire libre</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Para unha navegación máis precisa, recomendamos que desactive o modo de aforro de enerxía na configuración da batería do teléfono.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Gravar traxecto</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Deter gravación de traxecto</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Grabación de ruta</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Deter sen gardar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuar gravación</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Gardar en Marcadores e traxectos?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>O traxecto está baleiro</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Non se pode mostrar o diálogo de selección de cartafoles porque non hai ningunha aplicación adecuada instalada no dispositivo. Instale un xestor de arquivos e ténteo de novo.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Elixir cor</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar traxecto</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Non hai ningunha aplicación instalada que poida abrir a localización</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto en navegación</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Seguir o sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Compartir pista</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Eliminar %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivel de dificultade</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderado</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Actualizando</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Actualice os seus mapas descargados</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>A actualización de mapas mantén actualizada a información sobre obxectos</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Actualizar (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Actualizar máis tarde de forma manual</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Eliminar traxecto</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Está seguro de que quere eliminar este traxecto?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nome do traxecto</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mover</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Traxecto</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Cambiar cor</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Quere enviar un informe de erro aos desenvolvedores?
+Dependemos dos nosos usuarios, xa que Organic Maps non recolle ningunha información sobre erros de forma automática. Grazas de antemán por apoiar a Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activar a sincronización con iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>A sincronización con iCloud é unha función experimental en desenvolvemento. Asegúrese de realizar unha copia de respaldo de todos os seus marcadores e traxectos.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud está desactivado</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Active iCloud na configuración do dispositivo para utilizar esta función.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activar</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Copia de seguridade</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Fallo de sincronización de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Erro: non se puido sincronizar debido a un erro de conexión</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Erro: non se puido sincronizar porque se superou a cota de iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Erro: iCloud non está dispoñible</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listas eliminadas recentemente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Limpar</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Eliminar todo</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar todo</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribúe a OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Engadir lugar</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Actualizar o mapa para contribuír</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Necesitas actualizar o %1 mapa á última versión antes de poder contribuír aos datos de OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>A miña posición</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Os meus lugares</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Almacenamento interno privado</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Almacenamento interno compartido</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Tarxeta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Almacenamento externo compartido</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wifi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punto do mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>o meu</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>pé</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Para amosar as rutas, os mapas deben actualizarse.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Saída</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>O mapa do metro non está dispoñible</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ti</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Rexións descargadas en violeta</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ruta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>É necesario detectar a localización en segundo plano para gozar plenamente da funcionalidade da aplicación. Utilízase para navegar e gardar a ruta recentemente percorrida.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determinar a súa localización é necesario para a navegación e para gardar o traxecto recentemente percorrido.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Iniciar sesión con contrasinal</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Inicio de sesión usando o navegador</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Últimos empregados</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>A cor dos marcadores cambiou</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>A cor dos traxectos cambiou</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Deslizadores</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>VERMELLO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>AZUL</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Cor Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Reixa</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/he/omim.ts
+++ b/qt/translations/he/omim.ts
@@ -1,0 +1,3936 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="he">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>חזור</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>בטל</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>מחק</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>הורד מפות</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>הורדת הקובץ נכשלה. לחץ לניסיון נוסף.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>מוריד…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>ק&quot;מ</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>מייל</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>מאוחר יותר</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>חיפוש</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>חפש במפה</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>שרותי המיקום של מכשיר או ישום זה זה כבויים. יש להפעילם דרך &quot;הגדרות&quot; (Settings).</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>דיוק מוגבל</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>כדי להבטיח ניווט מדויק לאפשר מיקום מדויק בהגדרות.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>הצג במפה</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>ההורדה נכשלה</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>נסה שוב</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>אודות Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>חינם לכולם, מיוצרים באהבה</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• ללא מודעות, ללא מעקב, ללא איסוף נתונים</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• אין ריקון סוללה, עובד במצב לא מקוון</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• מהיר, מינימליסטי, שפותח על ידי הקהילה</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>אפליקציית קוד פתוח שנוצרה על ידי חובבים ומתנדבים.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>הגדרות מיקום</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>סגור</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>נדרש מאיץ חומרה OpenGL. לצערינו מכשיר זה אינו נתמך.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>הורדה</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>אנא נתק כבל USB או הכנס כרטיס זכרון כדי להשתמש ב-Organic Maps.</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>אנא פנה שטח אחסון בכרטיס הזיכרון או בכונן USB כדי להשתמש בישום</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>תחילה, נוריד למכשירך מפה כללית של העולם.
+מפה זו דורשת נפח אחסון של %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>עבור למפה</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>מוריד %1. תוכל עתה
+להמשיך למפה.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>להוריד %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>לעדכן %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>הפסק</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>המשך</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>הורדה של %1 נכשלה</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>הוסף רשימה חדשה</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>שם רשימת הסימניות</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>סימניות</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>סימניות ומסלולים</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>שם</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>כתובת</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>רשימה</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>הגדרות</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>שמור מפות אל</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>בחר מיקום במחשבך לשמירת המפות שתוריד.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>מפות שהורדו</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 פנוי מתוך %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>להעביר המפות?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>שגיאה בהעברת הקבצים</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>פעולה זו יכולה להמשך מספר דקות.
+המתן בבקשה…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>יחידות מדידה</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>בחר בין מיילים לקילומטרים</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>בטל הורדה</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>השאר ביקורת</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>כן</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>הורד מפה</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>רשימות סימניות</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>איפה לאכול</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>מצרכים</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>תחבורה</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>דלק</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>חניה</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>קניות</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>יד שניה</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>בית מלון</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>נקודות עיניין</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>בידור</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>כספומט</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>חיי לילה</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>שעשועים</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>בנק</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>בית מרקחת</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>בית חולים</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>שירותים</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>דואר</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>משטרה</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>מיחזור</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>מים</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>עבור קרוואנים</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>הערות</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>סימניות של Organic Maps שותפו איתך</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>שלום!
+
+מצורפות הסימניות שלי, אפשר לפתוח אותן ב-Organic Maps. אם צריך, ניתן להוריד את האפליקצייה מכאן: https://omaps.app/get?kmz
+
+תהנו לנווט עם Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>טוען סימניות</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>הסימניות נטענו בהצלחה! ניתן למצוא אותם על המפה או במסך ניהול הסימניות.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>טעינת הסימניות נכשלה. יתכן שהקובץ פגום.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>סוג הקובץ אינו מזוהה על ידי האפליקציה:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>נכשל בפתיחת הקובץ %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>ערוך</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>מיקומך לא אותר עדיין</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>מצטערים, הגדרות שמירת מפה אינן זמינות כרגע.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>הורדת מפת המדינה מתבצעת כעת.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>קבלו את המיקום שלי ב-Organic Maps!
+%1 או %2
+אין לך מפות בלי אינטרנט? להוריד כאן: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>היי, בדוק את הסיכה שלי במפה של Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>היי, בדקו את המיקום הנוכחי שלי במפה של Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>היי,
+
+אני כאן: %1. הקש על הלינק %2 או על %3 כדי לראות את המקום על המפה.
+
+תודה.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>שיתוף</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>דוא&quot;ל</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>הועתק: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>בוצע</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>נתוני OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>האם אתה בטוח שברצונך להתנתק מחשבון OpenStreetMap שלך?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>מסלולים</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>אורך</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>שיתוף מיקום שלי</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>הגדרות כלליות</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>מידע</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>ניווט</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>כפתורי + ו- על המפה</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>הצג על המסך</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>סגנון לילה בעת ניווט בחושך</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>מצב לילה</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>כבוי</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>מופעל</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>אוטומטי</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>פרספקטיבה</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>מבנים בתלת-מימד</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>הגדרת מבנים בתלת מימד מבוטלת במצב חיסכון בחשמל</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>הנחיות קוליות</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>הכריזו על שמות רחובות</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>כאשר מופעל, שם הרחוב או היציאה שאליו יש לפנות יוקרא בקול.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>שפת קול</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>כדי להוריד קול באיכות גבוהה יותר, פתח את אפליקציית ההגדרות ועבור אל נגישות → VoiceOver → דיבור → קול.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>בדיקת הנחיות קוליות (TTS, טקסט לדיבור)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>אם אינך שומע את הקול כעת, בדוק את עוצמת הקול או את הגדרות הטקסט לדיבור של המערכת.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>לא זמין</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>זום אוטומטי</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>מרחק</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>הראה במפה</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>תפריט</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>אתר</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>חדשות</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>משוב</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>דרגו את האפליקציה</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>עזרה</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>שאלות ותשובות</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>לתרום</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>כבר נתרם</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>הזכר מאוחר יותר</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>לתמוך ב-Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>תמכו בפרויקט</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>זכויות יוצרים</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>דווח על באג</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>שפר את כיוון החץ על ידי הזזת הטלפון בתנועה של שמונה כדי לכייל את המצפן.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>הזז את הטלפון בתנועה של דמות שמונה כדי לכייל את המצפן ולתקן את כיוון החץ במפה.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>לחץ לחיצה ארוכה במפה כדי להציג את הממשק</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>עדכן הכל</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>בטל הכול</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>מפות שהורדת</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>נוסף/ו לתור</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>קרוב אלי</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>מפות</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>הורד הכל</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>מוריד:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>למחיקת המפה, יש לעצור את הניווט.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>ניתן ליצור רק מסלולים שמוכלים במלואם בתוך מפה אחת.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>הורידו את המפה</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>נסה שוב</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>מחק מפה</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>עדכן מפה</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>שירותי מיקום של Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>קבע במהירות את המיקום המשוער שלך באמצעות Bluetooth, WiFi או רשת סלולרית</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>הורד את כל המפות במסלול שלך</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>כדי ליצור מסלול, יש להוריד ולעדכן את כל המפות מהמיקום שלך ועד ליעד.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>אין מספיק מקום</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>יש להפעיל שירותי מיקום</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>שמור</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>יצירה</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>אדום</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>צהוב</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>כחול</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>ירוק</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>סגול</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>כתום</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>חום</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>ורוד</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>סגול עמוק</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>כחול בהיר</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>ציאן</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>טורקיז</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>ליים</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>כתום עמוק</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>אפור</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>כחול אפרפר</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>מידע</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps גרסה: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>מראה</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>בהיר</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>כהה</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>בהיר משחר עד שקיעה</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>אחר</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>העניקו במתנה מפות חינמיות וללא פרסומות למיליוני משתמשים!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>דווח או תקן נתוני מפה שגויים</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>להתנדב</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>עקבו ופנו אלינו:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>יישום הדוא&quot;ל לא הוגדר. אנא הגדירו אותו או השתמשו בכל דרך אחרת על מנת ליצור עמנו קשר בכתובת %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>שגיאה בשליחת דוא&quot;ל</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>כיול המצפן</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>מפות זמינות</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>נמצא</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>לעדכן</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>נכשלה</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>סימניה</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>בעת נסיעה לאורך המסלול, שים לב לדברים הבאים:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— תנאי הכביש, חוקי התנועה והתמרורים תמיד מקבלים עדיפות על פני הנחיות ניווט;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— ייתכנו אי-דיוקים במפה, וייתכן כי המסלול המוצע אינו תמיד הדרך המיטבית להגעה אל היעד;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— יש לראות במסלולים המוצעים המלצה בלבד;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— יש להיות זהירים בשימוש במסלולים סביב גבולות: המסלולים המוצעים באפליקציה עשויים לחצות גבולות מדינה במקומות אסורים.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>שמור על ערנות ועל הבטיחות בכביש!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>בדוק אות GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>לא ניתן ליצור מסלול. לא ניתן לזהות את קואורדינטות ה-GPS הנוכחיות.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>בדוק את אות ה-GPS שלך. הפעלת Wi-Fi תשפר את הדיוק בזיהוי המיקום שלך.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>הפעל שירותי מיקום</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>לא ניתן לאתר קואורדינטות GPS נוכחיות. הפעל שירותי מיקום כדי לחשב מסלול.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>לא ניתן לאתר מסלול</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>לא ניתן ליצור מסלול.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>כוונן את נקודת ההתחלה או היעד שלך.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>כוונן נקודת התחלה</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>לא נוצר מסלול. לא ניתן לאתר את נקודת ההתחלה.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>בחר נקודת התחלה הקרובה יותר לכביש כלשהו.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>כוונן יעד</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>לא נוצר מסלול. לא ניתן לאתר את היעד.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>בחר נקודת יעד הקרובה יותר לכביש כלשהו.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>לא ניתן לאתר את נקודת הביניים.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>כוונן את נקודת הביניים.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>שגיאת מערכת</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>לא ניתן ליצור מסלול עקב שגיאת אפליקציה.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>נסה שוב</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>לא עכשיו</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>האם ברצונך להוריד את המפה וליצור מסלול מיטבי יותר, הכולל יותר מאשר מפה אחת?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>הורד מפות נוספות כדי ליצור מסלול יותר טוב שחוצה את גבולות המפה הזו.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>הורד את הקבצים הדרושים</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>הורד ועדכן את כל המפות לאורך הדרך על מנת לחשב מסלול.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>על מנת להתחיל לחפש וליצור מסלולים, הורידו בבקשה את המפה. לאחר מכן לא תזדקקו יותר לחיבור לאינטרנט.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>בחר מפה</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>הצג</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>הסתר</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>קטגוריות</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>היסטוריה</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>אופס, לא נמצאו תוצאות.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>יש להוריד את האזור בו החיפוש מתבצע או להוסיף שם עיר/כפר קרוב.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>חיפושים קודמים</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>צפה בחיפושים האחרונים שלך.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>נקה היסטוריית חיפוש</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>ויקיפדיה</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>מאמר מ-wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>ויקימדיה קומונס</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>המיקום שלך</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>צא לדרך</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>מסלול מכאן</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>מסלול לכאן</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>ניווט זמין רק מהמיקום הנוכחי שלך.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>ברצונך לתכנן מסלול מהמיקום הנוכחי שלך?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>הבא</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>משעה</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>עד</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>הוסף לוח זמנים</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>מחק לוח זמנים</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>כל היום (24 שעות)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>פתוח</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>סגור</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>הוסף שעות סגירה</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>שעות פתיחה</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>מצב מתקדם</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>מצב פשוט</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>שעות סגירה</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>ערכים לדוגמה</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>תקן טעות</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>בחר מיקום</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>בבקשה תארו את הבעיה בפירוט כדי שקהילת OpenStreetMap תוכל לתקן אותה.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>או תקנו אותה בעצמכם: https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>שלח</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>בעיה</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>המקום הזה לא קיים</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>סגור בשל עבודות תחזוקה</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>מקום כפול</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>הורדה אוטומטית של מפות</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>יומי</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>סגור היום</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>סגור</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>היום</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>נפתח עוד %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>נסגר עוד %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>סגור</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>עריכת שעות פעילות</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>אין לך חשבון OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>הירשם ב-OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>כניסה</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>לא מחובר</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>היכנס ל-OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>סיסמה</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>שכחת סיסמה?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>התנתק</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>ערוך מקום</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>הוסף שפה</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>רחוב</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>מספר בית</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>פרטים</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>מדיה חברתית</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>בִּניָן</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>הוסף רחוב</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>יש להזין שם רחוב</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>בחר שפה</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>בחר רחוב</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>סגנון בישול</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>בחר סיגנון בישול</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>דוא&quot;ל או שם משתמש</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>הוסף טלפון</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>קומה</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>רמה: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>כל העריכות שלך במפה יימחקו יחד עם המפה.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>עדכן מפות</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>ליצירת מסלול, יש לעדכן את כל המפות ולתכנן מסלול שנית.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>חפש מפה</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>נא לוודא כי המכשיר מחובר לאינטרנט.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>אין מספיק מקום</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>נא לפנות שטח אחסון</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>שגיאת התחברות.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>שינויים מאומתים</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>גרור את המפה כדי למקם את הצלב במיקום של המקום או העסק.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>עריכת מקום</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>הוספת מקום</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>שם המקום</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>כפי שנכתב בשפה המקומית</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>קטגוריה</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>תאור מפורט של הבעיה</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>בעיה אחרת</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>הוסף בית עסק</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>לא ניתן למקם כאן פריט</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>נתוני OpenStreetMap שנוצרו על ידי הקהילה החל מ-%1. למידע נוסף על איך לערוך ולעדכן את המפה ב-OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>\u200FOpenStreetMap.org (OSM) הוא פרויקט קהילתי לבניית מפה חופשית ופתוחה. זהו המקור העיקרי לנתוני מפות ב-Organic Maps והוא פועל בדומה לוויקיפדיה. ניתן להוסיף או לערוך מקומות והם הופכים לזמינים למיליוני משתמשים בכל רחבי העולם.
+הצטרף לקהילה ועזור ליצור מפה טובה יותר לכולם!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>צור חשבון OpenStreetMap או היכנס כדי לפרסם את עריכות המפה שלך לעולם.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 מתוך %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>להוריד באמצעות חיבור אינטרנט סלולרי?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>זה עשוי להיות יקר עם חבילות גלישה מסוימות או בנדידה.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>הזן מספר בית תקין</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>מספר קומות (מקסימום: %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>מספר הקומות לא יכול להיות גבוה מ-%1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>מיקוד</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>יש להזין מיקוד תקין</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>הערה למתנדבי OpenStreetMap (אופציונלי)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>תארו שגיאות במפה או דברים שלא ניתן לערוך באמצעות Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>העריכות שלך מועלות למסד הנתונים הציבורי של &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. נא לא להוסיף מידע אישי או מוגן בזכויות יוצרים.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>עוד על OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>היסטוריית העריכה שלך</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>הערות נתוני המפה שלך</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>מַפעִיל</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>מַפעִיל: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>לא מוצאים קטגוריה מתאימה?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>באמצעות Organic Maps ניתן להוסיף קטגוריות נקודה פשוטות בלבד, כלומר לא ניתן להוסיף עיירות, כבישים, אגמים, מבנים וכו&#x27;. אנא הוסיפו קטגוריות כאלה ישירות ל-&lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. עיינו &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;במדריך&lt;/a&gt; שלנו לקבלת הוראות מפורטות.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>לא הורדת אף מפה</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>הורד מפה כדי לחפש ולנווט ללא חיבור לאינטרנט.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>המיקום הנוכחי לא ידוע.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>קמ״ש</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>מייל לשעה</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ש׳</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>ד׳</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>י</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>ש׳׳</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>עוד</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>ערוך סימניה</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>הערות אישיות (טקסט או HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>תגובה…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>למחוק את כל השינויים המקומיים?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>מחק</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>למחוק את המקום שהוסף?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>מחק</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>המקום לא קיים</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>נא להסביר את הסיבה למחיקת המקום</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>הזן מספר טלפון תקין</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>הזן כתובת אינטרנט תקינה</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>הזן דוא&quot;ל תקין</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>הזן כתובת פייסבוק תקינה, משתמש, או שם עמוד</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>הזן כתובת אינטרנט או שם משתמש Instagram תקינים</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>הזן כתובת אינטרנט או שם משתמש Twitter תקינים</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>הזן כתובת אינטרנט או שם משתמש VK תקינים</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>הזן מזהה LINE או כתובת אינטרנט תקינים</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>הוסף מקום ל-OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>או, לחלופין, השאר הודעה לקהילת OpenStreetMap כדי שמישהו אחר יוכל להוסיף או לתקן את המקום כאן.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>הערה תישלח ל-OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>לשלוח לכל המשתמשים?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>יש לוודא שלא הזנת מידע אישי או פרטי.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>עורכי OpenStreetMap יבדקו את השינויים ויצרו איתך קשר אם יש להם שאלות כלשהן.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>עצור</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>הקלטת המסלול</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>קבל</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>דחה</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>השתמש באינטרנט סלולרי כדי להראות מידע מפורט?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>השתמש תמיד</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>רק היום</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>אל תשתמש היום</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>אינטרנט סלולרי</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>אינטרנט סלולרי נחוץ בשביל הודעות על עדכון מפות ובשביל העלאת עריכות.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>אף פעם אל תשתמש</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>שאל תמיד</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>כדי להציג מידע על עומס תנועה, יש לעדכן את המפות.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>הגדל תגיות במפה</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>נא לעדכן את Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>מידע על עומס תנועה לא זמין.</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>הפעל logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>משוב כללי</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>אנחנו משתמשים מערכת TTS של המערכת כדי לספק הנחיות קוליות. הרבה מכשירי Android מוגדרים להשתמש ב-Google TTS, שניתן להוריד ולעדכן מחנות Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>עבור שפות מסוימות, יהיה עליך להתקין סינתיסייזר דיבור או חבילת שפה נוספת מחנות האפליקציות (Google Play, Galaxy Store, App Gallery, FDroid).
+פתח את הגדרות המכשיר שלך → שפה וקלט → דיבור → פלט טקסט לדיבור.
+כאן תוכל לנהל את הגדרות סינתזת הדיבור (לדוגמה, להוריד חבילת שפה לשימוש במצב לא מקוון) ולבחור מנוע טקסט לדיבור אחר.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>למידע נוסף ניתן לקרוא את המדריך הזה.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>תעתיק לאותיות לטיניות</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>למידע נוסף</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>יש להוסיף נקודת התחלה למסלול באמצעות חיפוש או בלחיצה על המפה</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>יש לבחור נקודת יעד באמצעות חיפוש או בלחיצה על המפה</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>ניהול מסלול</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>תכנון</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>הסר עצירה</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>הוסף עצירה</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>נשמר</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>התחבר ל-OpenStreetMap כדי להעלות אוטומטית את כל עריכות המפה שלך. למידע נוסף &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;כאן&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>בעיית גישה לאחסון</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>לא ניתן לגשת לאחסון החיצוני. ייתכן כי כרטיס הזיכרון הוסר, נפגם, או שמערכת הקבצים היא לקריאה בלבד. נא לבדוק את כרטיס הזיכרון או ליצור איתנו קשר בכתובת support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>בצע אמולציה לאחסון רע</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>נא להזין שם תקין</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>רשימות</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>הסתר הכל</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>הצג הכל</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>סימניה %n</numerusform>
+<numerusform>%n סימניות</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>צור רשימה חדשה</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>ייבוא סימניות ומסלולים</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>לא ניתן לשתף עקב שגיאת אפליקציה</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>שגיאת שיתוף</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>אי אפשר לשתף רשימה ריקה</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>השם לא יכול להיות ריק</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>נא להזין את שם הרשימה</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>רשימה חדשה</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>השם הזה כבר תפוס</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>נא לבחור שם אחר</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>נא להמתין…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>מספר טלפון</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>פרופיל OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>נמצא %n קובץ. תוכלו לראות אותו לאחר ההמרה.</numerusform>
+<numerusform>נמצאו %n קבצים. תוכלו לראות אותם לאחר ההמרה.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>שחזור</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>מסלול %n</numerusform>
+<numerusform>%n מסלולים</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>פרטיות</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>מדיניות פרטיות</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>תנאי שימוש</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>תעבורה</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>טיולים</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>רכיבה על אופניים</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>רכבת תחתית</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>סגנונות ושכבות מפה</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>רשימה זו ריקה</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>כדי להוסיף סימניה, לחץ על מקום במפה ואז לחץ על סימן הכוכב</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>שנה את צבע כל הסימניות</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>שנה את צבע כל המסלולים</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…עוד</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>ייצא KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>ייצוא GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>ייצא GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>מחק רשימה</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>מצלמות מהירות</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>תיאור מיקום</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>מוריד המפות</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>הזהר כשהמהירות מופרזת</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>הזהר תמיד</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>אל תזהיר אף פעם</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>מצב חיסכון בסוללה</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>נסה להפחית שימוש בסוללה על חשבון פונקציות מסוימות</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>אף פעם</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>כשהסוללה חלשה</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>תמיד</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>שמות סימניות על המפה</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>אם יש יותר מדי סימניות, הצגת שמותיהן על המפה עלולה להאט את פעולת האפליקציה.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>הצג מימין</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>הצג בתחתית</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>הפעל אפשרות זו כדי לתעד ובאופן ידני לשלוח אלינו פרטים דיאגנוסטיים על הבעיה שלך בעזרת הכפתור &quot;דווח על באג&quot; בתפריט עזרה. הפרטים עשויים לכלול מידע על מיקום.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>אפשרויות מסלול</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>הימנע מכבישי אגרה</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>הימנע מדרכי עפר</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>הימנע ממעבורות</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>הימנע מכבישים מהירים</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>לא ניתן לחשב מסלול</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>לא נמצא מסלול. ייתכן כי זה נגרם מאפשרויות המסלול שלך או ממידע לא שלם של OpenStreetMap. נא לשנות אפשרויות מסלול ולנסות שנית.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>הגדר כבישים להימנע מהם</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>אפשרויות מסלול מופעלות</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>כביש אגרה</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>דרך לא סלולה</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>מעבורת</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>כן</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>לא</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>כן</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>לא</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>קיבולת: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>רשת: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>הגעת!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>אוקיי</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>מיון…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>מיון סימניות</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>לפי ברירת מחדל</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>לפי סוג</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>לפי מרחק</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>לפי תאריך</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>לפי שם</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>לפני שבוע</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>לפני חודש</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>לפני יותר מחודש</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>לפני יותר משנה</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>קרוב אלי</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>אחרים</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>תכנון המסלול נכשל</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>שעת הגעה: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>הורד ועדכן את כל המפות בדרך כדי לחשב מסלול.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>שינית את מפת העולם! זה לא חייב להיות סוד, אפשר לספר לחברים ולערוך אותה ביחד.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>שתף עם חברים</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>סגור כעת</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>נפתח מחר ב-%1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>נפתח ביום %1 ב-%2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>נפתח מחר ב-%1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>נסגר ב-%1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>הוספת שעות פעילות</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>סיסמה (לפחות 8 תווים)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>שם משתמש או סיסמה לא תקינים.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>חשבון OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>עדכון אחרון</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>תודה</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>שם המקום</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>טלפון</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>לתשומת לבך</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>שגיאת הורדה</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>בחר קטגוריה</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>פופולארי</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>כל הקטגוריות</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>הוספת מקומות חדשים למפה, ועריכת מקומות קיימים ישירות מהאפליקציה.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>שנה מיקום</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>כדי להוריד, צריך עוד מקום. נא למחוק מידע שאינו הכרחי.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>אני משפר את המפות של Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>הערה מפורטת</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>ההצעות שלך לשינוי המפה יישלחו לקהילת OpenStreetMap. יש לתאר פרטים נוספים שלא ניתן לערוך ב-Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>אירעה שגיאה בעת איתור המיקום שלך. יש לוודא שהמכשיר שלך פועל כראוי ולנסות שנית מאוחר יותר.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>שירותי מיקום לא מופעלים</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>אפשרו גישה למיקום בהגדרות המכשיר</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. פתחו את &quot;הגדרות&quot; (Settings)</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. געו ב&quot;מיקום&quot; (Location)</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. בחרו: אפשר בעת השימוש ביישום</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. בחר פרטיות</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. בחר שירותי מיקום</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. הפעל את שירותי המיקום</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>או המשך להשתמש ב-Organic Maps ללא מיקום</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>הזמנה</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>התקשר</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>שם סימניה</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>מחק סימניה</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>ההערה שלך תישלח אל OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…עוד</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>עדכן</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>להשבית הקלטה של המסלול האחרון שלך?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>השבת</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>בדקו</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>האפליקצייה Organic Maps משתמשת במיקום שלך ברקע כדי להקליט את המסלול האחרון שלך.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>הגדרות כלליות</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>כדי להציג מידע על עומס תנועה, יש לעדכן את האפליקצייה.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>גודל קובץ יומן: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>גרור לכאן כדי להסיר</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>החלף תחנה</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>התחל מ-</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>התחבר ל-OpenStreetMap כדי להעלות אוטומטית את כל עריכות המפה שלך. למידע נוסף</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>כאן</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>הסתר מסך</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 מתוך %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>מוריד %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>מחיל %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>השם הזה ארוך מדי</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>זוהו קבצים חדשים</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>המרה</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>שגיאה</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>חלק מהקבצים לא הומרו</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>אירעה שגיאה</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>פופולארי</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>הסתר מהמפה</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>אירעה שגיאה בטעינת התגיות, נא לנסות שנית</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>ימין</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>תחתית</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>נצא לדרך</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>יעד</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>מרכוז</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>תוצאות חיפוש</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>אז</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>האם ברצונך לבנות את המסלול מחדש?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>המקלדת לא זמינה בזמן נהיגה</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>לא ניתן לבנות מסלול מהמיקום הנוכחי שלך</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>לא ניתן למצוא מסלול ליעד שלך. נא לבחור נקודת יעד אחרת.</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>אין אות GPS. נא להגיע לאזור פתוח.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>לא ניתן לבנות מסלול. נא לציין נקודות מסלול נוספות.</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>כדי ליצור מסלול, יש להוריד מפות חסרות למכשיר שלך</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>אירעה שגיאה. נא להפעיל מחדש את האפליקציה</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>המסלול ייבנה מחדש מהמיקום הנוכחי שלך</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>המסלול יומר למסלול נסיעה</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>לא כל הסימניות מוצגות</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>עבור לטלפון כדי לראות את כל הסימניות</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>מצלמות מהירות</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>אזהרות מהירות</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>נא להוריד מפות באפליקצייה במכשיר הנייד שלך</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>יציאה %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>מיין כברירת מחדל</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>מיין לפי סוג</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>מיין לפי מרחק</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>מיין לפי תאריך</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>מיין לפי שם</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>אוכל</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>אטרקציות</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>מוזיאונים</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>פארקים</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>שחייה</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>הרים</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>חיות</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>בתי מלון</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>מבנים</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>כסף</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>חנויות</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>חניות</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>תחנות דלק</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>רפואה</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>חפש ברשימה</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>מקומות דת</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>בחר רשימה</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>ניווט ברכבת תחתית עוד לא זמין באזור זה</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>מסלול רכבת תחתית לא נמצא</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>נא לבחור נקודת התחלה או סוף קרובה יותר לתחנת רכבת תחתית</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>קווי מתאר</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>כדי להפעיל קווי מתאר יש להוריד את המפה לאזור זה</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>קווי מתאר עוד לא זמינים לאזור זה</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>עלייה</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>ירידה</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>מינ&#x27; גובה</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>מקס&#x27; גובה</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>קושי</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>מרחק:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>זמן:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>התקרב כדי לחקור קווי מתאר</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>מוריד</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>הורד את מפת העולם</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>לא ניתן ליצור תיקייה ולהעביר קבצים בזיכרון הפנימי או בכרטיס הזיכרון</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>שגיאת כונן</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>כשל חיבור</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>נתק כבל USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>השאר מסך דלוק</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>כאשר מופעל, המסך תמיד יהיה דולק בעת הצגת המפה.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>הצג במסך הנעילה</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>כאשר מופעל, האפליקציה תעבוד במסך הנעילה אפילו כשהמכשיר נעול.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>שפת המפה</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>נתוני מפה מ-OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>תודה על השימוש במפות שנבנו בקהילה שלנו!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>עם התרומות והתמיכה שלך, נוכל ליצור את המפות הטובות בעולם!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>האם אתה אוהב את האפליקציה שלנו? אנא תרמו כדי לתמוך בפיתוח! לא אוהב את זה עדיין? אנא הודע לנו, ואנחנו נתקן את זה!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>אם אתה מכיר מפתח תוכנה, אתה יכול לבקש ממנו ליישם תכונה שאתה צריך.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>הקש בכל מקום במפה כדי לבחור משהו. הקש ארוכות כדי להסתיר ולהציג בחזרה את הממשק.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>האם אתה יודע שאתה יכול לבחור את המיקום הנוכחי שלך על המפה?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>אתה יכול לעזור לתרגם את האפליקציה שלנו לשפה שלך.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>האפליקציה שלנו פותחה על ידי כמה חובבים והקהילה.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>אתה יכול בקלות לתקן ולשפר את נתוני המפה.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>המטרה העיקרית שלנו היא לבנות מפות מהירות, ממוקדות פרטיות, קלות לשימוש שתאהבו.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>אתה משתמש כעת ב-Organic Maps במסך הטלפון</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>אתה משתמש כעת ב-Organic Maps במסך המכונית</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>אתה מחובר ל-Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>המשך בטלפון</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>למסך המכונית</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps זקוק לגישה למיקום. כאשר זה בטוח, בדוק את ההודעה בטלפון שלך.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>אפליקציה זו זקוקה לאישור שלך</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps ב-Android Auto זקוק להרשאות מיקום כדי לפעול ביעילות</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>הענק הרשאות</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>טיול רגלי</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>דפדפן אינטרנט אינו זמין</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>עוצמת שמע</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>ייצא את כל הסימניות והרצועות</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>הגדרות סינתזת דיבור במערכת</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>הגדרות סינתזת דיבור לא נמצאו, האם אתה בטוח שהמכשיר שלך תומך בזה?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>דרייב ת&#x27;רו</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>נקה את החיפוש</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>לְהִתְמַקֵד</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>להקטין את התצוגה</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>קישור לתפריט</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>תפריט תצוגה</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>פתח באפליקציה אחרת</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>שירות עצמי</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>בחר אפשרות</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>ישיבה בחוץ</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>לניווט המדויק ביותר, אנו ממליצים להשבית את מצב חיסכון בחשמל בהגדרות הסוללה של הטלפון.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>הקלט מסלול</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>הפסק הקלטת מסלול</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>הקלטת מסלול</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>הפסק בלי לשמור</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>המשך להקליט</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>לשמור בסימניות ומסלולים?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>המסלול ריק - אין מה לשמור</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>לא ניתן להציג תיבת דו-שיח לבחירת תיקיות מכיוון שלא מותקנת אפליקציה מתאימה במכשיר שלך. אנא התקן אפליקציית מנהל קבצים ונסה שוב</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>בחר צבע</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>עריכת מסלול</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>לא מותקנת אפליקציה שיכולה לפתוח את המיקום</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>אוטומטי בניווט</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>לפי הגדרות המערכת</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>שתף מסלול</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>למחוק %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>רמת קושי</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>קל</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>מתון</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>קשה</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>מעדכן</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>עדכן את המפות שהורדת</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>עדכון המפות שומר על המידע על פריטים עדכני</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>עדכן (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>עדכן ידנית מאוחר יותר</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>מחק מסלול</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>האם אתה בטוח שברצונך למחוק את הרצועה הזו?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>שם המסלול</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>הזז</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>מסלול</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>שנה צבע</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>מפה</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>האם ברצונך לשלוח דיווח על תקלה למפתחים?
+אנו מסתמכים על המשתמשים שלנו, שכן Organic Maps אינה אוספת מידע על תקלות באופן אוטומטי. תודה מראש על תמיכתך ב-Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>הפעל סנכרון iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>סנכרון iCloud הוא תכונה ניסיונית בפיתוח. ודא שעשית גיבוי של כל הסימניות והרצועות שלך.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud מושבת</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>אנא הפעל את iCloud בהגדרות המכשיר שלך כדי להשתמש בתכונה זו.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>לְאַפשֵׁר</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>גיבוי</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>כשל בסינכרון iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>שגיאה: הסנכרון נכשל עקב שגיאת חיבור</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>שגיאה: הסנכרון נכשל עקב חריגה ממכסת iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>שגיאה: iCloud אינו זמין</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>רשימות שנמחקו לאחרונה</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>נקה</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>מחק הכל</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>לשחזר</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>לשחזר הכל</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>תרום ל-OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>הוסף מקום</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>עדכן את המפה כדי לתרום</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>עליך לעדכן את המפה של %1 לגרסה האחרונה לפני שתוכל לתרום לנתוני OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>המיקום שלי</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>המקומות שלי</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>אחסון פנימי פרטי</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>אחסון פנימי משותף</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>כרטיס זיכרון</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>אחסון חיצוני משותף</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>מיקוד</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>נקודת מפה</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>מ׳</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>ק״מ</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>מייל</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>רגל</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>כדי להציג מסלולים, יש לעדכן את המפות.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>יציאה</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>כניסה</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>מפת רכבת תחתית לא זמינה</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>אתה</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>אזורים שהורדו בסגול</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>נתיב</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>גילוי המיקום הנוכחי ברקע נחוץ כדי ליהנות באופן מלא מהפונקציונליות של האפליקציה. הוא משמש לניווט ולשמירה על המסלול שנסעת לאחרונה.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>קביעת המיקום שלך נחוצה לניווט ולשמירה על המסלול שנסעת לאחרונה.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>התחבר עם סיסמה</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>כניסה באמצעות דפדפן</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>בשימוש לאחרונה</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>צבע הסיմניות שונה</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>צבע המסלולים שונה</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>ספקטרום</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>מחוונים</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>אדום</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ירוק</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>כחול</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>צבע sRGB הקסדצימלי #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>רשת</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/hi/omim.ts
+++ b/qt/translations/hi/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="hi">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>पीछे</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>निरस्त करना</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>हटाना</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>डाउनलोड विफल हो गया है. पुनः प्रयास करने के लिए स्पर्श करें.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>डाउनलोड हो रहा है…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>किलोमीटर</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>मील</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>बाद में</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>खोज</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>मानचित्र पर खोजें</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>वर्तमान में आपके पास इस डिवाइस या एप्लिकेशन के लिए सभी स्थान सेवाएँ अक्षम हैं। कृपया उन्हें सेटिंग्स में सक्षम करें।</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>सीमित सटीकता</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>सटीक नेविगेशन सुनिश्चित करने के लिए सेटिंग्स में सटीक स्थान सक्षम करें।</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>मानचित्र पर दिखाएँ</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>डाउनलोड विफल हो गया है</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>पुनः प्रयास करें</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps के बारे में</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>सभी के लिए मुफ़्त, प्यार से बनाया गया</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• कोई विज्ञापन नहीं, कोई ट्रैकिंग नहीं, कोई डेटा संग्रह नहीं</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• कोई बैटरी ख़त्म नहीं, ऑफ़लाइन काम करता है</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• तेज़, न्यूनतम, समुदाय द्वारा विकसित</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>उत्साही और स्वयंसेवकों द्वारा बनाया गया ओपन-सोर्स एप्लिकेशन।</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>स्थान सेटिंग्स</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>बंद करना</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>ऐप को हार्डवेयर त्वरित ओपनजीएल की आवश्यकता है। दुर्भाग्य से, आपका डिवाइस समर्थित नहीं है.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>डाउन लोड करना</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps का उपयोग करने के लिए कृपया USB केबल डिस्कनेक्ट करें या मेमोरी कार्ड डालें।</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>ऐप का उपयोग करने के लिए कृपया पहले एसडी कार्ड/यूएसबी स्टोरेज पर कुछ जगह खाली कर लें</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>ऐप का उपयोग शुरू करने से पहले, कृपया अपने डिवाइस पर सामान्य विश्व मानचित्र डाउनलोड करें।
+यह %1 स्टोरेज का उपयोग करेगा।</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>मानचित्र पर जाएं</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>डाउनलोड हो रहा है %1. अब तुम यह कर सकते हो
+मानचित्र पर आगे बढ़ें.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>डाउनलोड करना %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>अद्यतन %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>विराम</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>जारी रखने के लिए</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 डाउनलोड विफल हो गया है</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>एक नई सूची जोड़ें</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>बुकमार्क सूची का नाम</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>बुकमार्क</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>बुकमार्क और ट्रैक</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>नाम</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>पता</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>सूची</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>समायोजन</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>इसमें मानचित्र सहेजें</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>मानचित्र डाउनलोड करने के लिए फ़ोल्डर का चयन करें.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>मानचित्र डाउनलोड किए गए</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2 में से %1 मुफ्त</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>मानचित्र स्थानांतरित करें?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>मानचित्र फ़ाइलें ले जाने में त्रुटि</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>इसमें कई मिनट लग सकते हैं.
+कृपया प्रतीक्षा करें…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>नाप की इकाइयां</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>मील और किलोमीटर के बीच चुनें</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>डाउनलोड रद्द करें</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>समीक्षा लिखें</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>हाँ</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>बुकमार्क सूचियाँ</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>कहाँ खाना है</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>किराने का सामान</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>सार्वजनिक परिवहन</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>गैस स्टेशन</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>पार्किंग</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>खरीदारी</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>सेकंड हैंड</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>होटल</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>जगहें</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>मनोरंजन</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>एटीएम</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>रात्रि जीवन</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>पारिवारिक अवकाश</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>बैंक</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>दवाखाना</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>चिकित्सालय</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>शौचालय</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>डाकघर</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>थाना</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>पुनर्चक्रण</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>जल</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>आरवी सुविधाएं</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>टिप्पणियाँ</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps बुकमार्क आपके साथ साझा किए गए थे</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>नमस्ते!
+
+संलग्न हैं मेरे बुकमार्क; कृपया उन्हें Organic Maps में खोलें। यदि आपने इसे इंस्टॉल नहीं किया है तो आप इसे यहाँ डाउनलोड कर सकते हैं: https://omaps.app/get?kmz
+
+Organic Maps के साथ यात्रा का आनंद लें!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>बुकमार्क लोड हो रहे हैं</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>बुकमार्क सफलतापूर्वक लोड हो गए! आप उन्हें मानचित्र पर या बुकमार्क प्रबंधक स्क्रीन पर पा सकते हैं।</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>बुकमार्क लोड करने में विफल. फ़ाइल दूषित या दोषपूर्ण हो सकती है.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>फ़ाइल प्रकार ऐप द्वारा पहचाना नहीं गया है:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>फ़ाइल खोलने में असफल %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>संपादन करना</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>आपका स्थान अभी तक निर्धारित नहीं किया गया है</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>क्षमा करें, मानचित्र संग्रहण सेटिंग वर्तमान में अक्षम हैं।</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>मानचित्र डाउनलोड अभी प्रगति पर है.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Organic Maps में मेरा वर्तमान स्थान देखें! %1 या %2 खोलें। ऑफ़लाइन मानचित्र नहीं हैं? यहाँ डाउनलोड करें: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>अरे, Organic Maps में मेरा पिन देखो!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>अरे, Organic Maps के नक्शे पर मेरी वर्तमान स्थिति देखो!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>नमस्ते,
+
+मैं अब यहाँ हूँ: %1. इस लिंक पर क्लिक करें %2 या यह लिंक %3 मानचित्र पर स्थान देखने के लिए
+
+धन्यवाद.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>साझा करें</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>ईमेल</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>क्लिपबोर्ड पर नकल: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>हो गया</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap डेटा: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>क्या आप वाकई अपने OpenStreetMap खाते से लॉग आउट करना चाहते हैं?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>पटरियों</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>लंबाई</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>मेरा स्थान साझा करें</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>सामान्य सेटिंग्स</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>जानकारी</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>मार्गदर्शन</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>मानचित्र पर + और - बटन</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>मानचित्र पर बटन प्रदर्शित करें</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>अंधेरे में नेविगेट करते समय नाइट स्टाइल</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>रात का मोड</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>बंद</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>चालू</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>स्वचालित</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>परिप्रेक्ष्य दृश्य</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3डी इमारतें</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3डी इमारतें बिजली बचत मोड में अक्षम हैं</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>ध्वनि निर्देश</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>सड़कों के नाम की घोषणा करें</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>सक्षम होने पर, सड़क का नाम या मुड़ने के लिए निकास का नाम ज़ोर से बोला जाएगा।</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>आवाज की भाषा</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>बेहतर गुणवत्ता वाली आवाज़ डाउनलोड करने के लिए, सेटिंग्स ऐप खोलें और एक्सेसिबिलिटी → VoiceOver → स्पीच → वॉइस पर जाएँ।</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>ध्वनि निर्देशों का परीक्षण करें (टीटीएस, टेक्स्ट-टू-स्पीच)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>यदि आपको अभी आवाज नहीं सुनाई देती है तो वॉल्यूम या सिस्टम टेक्स्ट-टू-स्पीच सेटिंग्स की जांच करें।</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>उपलब्ध नहीं है</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>ऑटो ज़ूम</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>दूरी</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>मानचित्र पर देखें</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>मेन्यू</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>वेबसाइट</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>समाचार</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>प्रतिक्रिया</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>एप्लिकेशन की श्रेणी बताओ</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>सहायता</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>अक्सर पूछे जाने वाले प्रश्नों</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>दान देना</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>पहले से दान</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>बाद में याद दिलाना</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps का समर्थन करें</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>परियोजना का समर्थन करें</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>कॉपीराइट</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>एक बग रिपोर्ट करो</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>कंपास को कैलिब्रेट करने के लिए फोन को 8 की आकृति में घुमाएँ और तीर की दिशा बेहतर करें।</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>कंपास को कैलिब्रेट करने और नक्शे पर तीर की दिशा ठीक करने के लिए फोन को 8 की आकृति में घुमाएँ।</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>इंटरफ़ेस देखने के लिए मानचित्र पर फिर से देर तक टैप करें</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>सभी अपडेट करें</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>सब रद्द करो</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>डाउनलोड</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>पंक्तिबद्ध</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>मेरे पास</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>नक्शे</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>सभी डाउनलोड</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>डाउनलोड हो रहा है:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>नक्शा हटाने के लिए, कृपया नेविगेशन रोकें।</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>मार्ग केवल उन्हीं का निर्माण किया जा सकता है जो किसी एक क्षेत्र के नक्शे के भीतर पूरी तरह से समाहित हों।</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>नक्शा डाउनलोड करें</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>दोबारा प्रयास करें</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>नक्शा हटाएँ</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>नक्शा अपडेट करें</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play स्थान सेवाएँ</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>ब्लूटूथ, वाईफाई या मोबाइल नेटवर्क का उपयोग करके तुरंत अपना अनुमानित स्थान निर्धारित करें</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>अपने मार्ग के सभी मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>मार्ग बनाने के लिए, हमें आपके स्थान से आपके गंतव्य तक के सभी मानचित्रों को डाउनलोड और अपडेट करना होगा।</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>पर्याप्त स्थान नहीं</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>कृपया स्थान सेवाएँ सक्षम करें</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>सहेजें</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>बनाएं</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>लाल</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>पीला</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>नीला</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>हरा</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>बैंगनी</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>नारंगी</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>भूरा</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>गुलाबी</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>डीप पर्पल</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>हल्का नीला</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>सायन</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>टील</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>लाइम</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>गहरा नारंगी</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>ग्रे</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>नीला धूसर</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>जानकारी</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps संस्करण: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>प्रकटन</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>हल्का</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>गहरा</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>भोर से शाम तक लाइट</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>अन्य</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>लाखों उपयोगकर्ताओं को बिना विज्ञापनों वाले मुफ़्त नक्शे उपहार में दें!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>गलत मानचित्र डेटा की रिपोर्ट करें या उसे ठीक करें</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>स्वयंसेवक</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>फ़ॉलो करें और हमसे संपर्क करें:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>ईमेल क्लाइंट सेट अप नहीं किया गया है. कृपया इसे कॉन्फ़िगर करें या %1 पर हमसे संपर्क करें</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>ईमेल भेजने में त्रुटि</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>कम्पास अंशांकन</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>उपलब्ध</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>मिला</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>अपडेट</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>असफल</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>बुकमार्क</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>मार्ग का अनुसरण करते समय कृपया ध्यान रखें:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— सड़क की स्थिति, यातायात कानून और सड़क संकेत हमेशा नेविगेशन संकेतों पर प्राथमिकता देते हैं;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— नक्शा गलत हो सकता है, और सुझाया गया मार्ग हमेशा गंतव्य तक पहुंचने का सबसे इष्टतम तरीका नहीं हो सकता है;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— सुझाए गए मार्गों को केवल अनुशंसाओं के रूप में समझा जाना चाहिए;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— सीमावर्ती क्षेत्रों में मार्गों के साथ सावधानी बरतें: हमारे ऐप द्वारा बनाए गए मार्ग कभी-कभी अनधिकृत स्थानों पर देश की सीमाओं को पार कर सकते हैं।</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>कृपया सड़कों पर सतर्क और सुरक्षित रहें!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS सिग्नल की जाँच करें</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>मार्ग बनाने में असमर्थ. वर्तमान जीपीएस निर्देशांक की पहचान नहीं की जा सकी.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>कृपया अपना GPS सिग्नल जांचें। वाई-फाई सक्षम करने से आपके स्थान की सटीकता बेहतर होगी।</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>स्थान सेवाएँ सक्षम करें</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>वर्तमान जीपीएस निर्देशांक का पता लगाने में असमर्थ. मार्ग की गणना करने के लिए स्थान सेवाएँ सक्षम करें।</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>मार्ग ढूंढने में असमर्थ</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>मार्ग बनाने में असमर्थ.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>कृपया अपनी प्रारंभिक बिंदु या गंतव्य समायोजित करें।</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>प्रारंभ बिंदु समायोजित करें</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>रूट नहीं बनाया गया. प्रारंभिक बिंदु का पता लगाने में असमर्थ.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>कृपया सड़क के पास कोई प्रारंभिक बिंदु चुनें।</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>गंतव्य समायोजित करें</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>रूट नहीं बनाया गया. गंतव्य का पता लगाने में असमर्थ.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>कृपया सड़क के निकट स्थित गंतव्य बिंदु चुनें।</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>मध्यवर्ती बिंदु का पता नहीं लगाया जा सका।</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>कृपया अपना मध्यवर्ती बिंदु समायोजित करें।</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>सिस्टम त्रुटि</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>एप्लिकेशन त्रुटि के कारण मार्ग बनाने में असमर्थ.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>कृपया फिर से प्रयास करें</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>अभी नहीं</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>क्या आप नक्शा डाउनलोड करके एक से अधिक नक्शों में फैला एक अधिक अनुकूल मार्ग बनाना चाहेंगे?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>इस नक्शे की सीमाओं को पार करने वाला बेहतर मार्ग बनाने के लिए अतिरिक्त नक्शे डाउनलोड करें।</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>आवश्यक फ़ाइलें डाउनलोड करें</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>मार्ग की गणना करने के लिए अनुमानित पथ के सभी मानचित्र डाउनलोड या अपडेट करें।</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>मार्ग खोजना और बनाना शुरू करने के लिए, कृपया मानचित्र डाउनलोड करें। इसके बाद आपको इंटरनेट कनेक्शन की जरूरत नहीं पड़ेगी.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>नक्शा चुनें</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>दिखाएँ</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>छिपाना</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>श्रेणियाँ</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>इतिहास</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>उफ़, कोई परिणाम नहीं मिला.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>उस क्षेत्र को डाउनलोड करें जहां आप खोज रहे हैं या पास के शहर/गांव का नाम जोड़ने का प्रयास करें।</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>खोज इतिहास</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>अपनी हालिया खोजें देखें।</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>स्पष्ट इतिहास की खोज</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>विकिपीडिया</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org से लेख</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>विकिमीडिया कॉमन्स</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>आपकी लोकेशन</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>जाएँ</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>यहाँ से</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>यहाँ तक</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>नेविगेशन केवल आपके वर्तमान स्थान से उपलब्ध है।</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>क्या आप अपने वर्तमान स्थान से मार्ग की योजना बनाना चाहते हैं?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>अगला</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>से</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>के लिए</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>अनुसूची जोड़ें</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>अनुसूची हटाएँ</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>पूरा दिन (24 घंटे)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>खुला</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>गैर-कारोबारी घंटे जोड़ें</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>काम करने के घंटे</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>उन्नत मोड</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>सरल मोड</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>गैर-कारोबारी घंटे</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>उदाहरण मान</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>गलती सुधारें</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>स्थान चुनें</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>कृपया समस्या का विस्तार से वर्णन करें ताकि OpenStreetMap समुदाय इसे ठीक कर सके।</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>या इसे स्वयं https://www.openstreetmap.org/ पर करें।</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>भेजें</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>समस्या</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>यह स्थान मौजूद नहीं है</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>रखरखाव के लिए बंद</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>डुप्लिकेट स्थान</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>मानचित्र स्वतः डाउनलोड करें</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>दैनिक</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>आज बंद</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>आज</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>%1 में खुल जाएगा</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>%1 में बंद हो जाता है</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>व्यावसायिक घंटे संपादित करें</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>आपके पास अभी तक OpenStreetMap खाता नहीं है?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Openstreetmap पर पंजीकरण करें</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>लॉगिन</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>साइन इन नहीं किया गया है</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMap में लॉगिन करें</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>पासवर्ड</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>अपना पासवर्ड भूल गए?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>लॉग आउट</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>स्थान संपादित करें</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>एक भाषा जोड़ें</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>गली</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>भवन का नंबर</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>विवरण</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>सोशल मीडिया</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>इमारत</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>एक सड़क जोड़ें</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>कृपया एक सड़क का नाम दर्ज करें</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>एक भाषा चुनें</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>एक सड़क चुनें</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>व्यंजन</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>व्यंजन चुनें</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>ईमेल या उपयोगकर्ता नाम</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>फोन नंबर डालें</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>मंजिल</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>स्तर: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>आपके सभी नक्शा संपादन नक्शे के साथ हटा दिए जाएंगे।</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>नक्शे अपडेट करें</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>मार्ग बनाने के लिए, आपको सभी मानचित्र अपडेट करने होंगे और फिर मार्ग की दोबारा योजना बनानी होगी।</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>मानचित्र ढूंढें</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>कृपया सुनिश्चित करें कि आपका डिवाइस इंटरनेट से जुड़ा हो।</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>पर्याप्त जगह नहीं</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>कृपया कोई भी अनावश्यक डेटा हटा दें</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>लॉगिन त्रुटि</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>सत्यापित परिवर्तन</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>स्थान या व्यवसाय के स्थान पर क्रॉस लगाने के लिए मानचित्र को खींचें।</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>संपादन</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>जोड़ना</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>स्थान का नाम</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>जैसा कि स्थानीय भाषा में लिखा गया है</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>वर्ग</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>समस्या का विस्तृत विवरण</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>अलग समस्या</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>व्यवसाय जोड़ें</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>यहाँ कोई वस्तु स्थित नहीं की जा सकती</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>समुदाय-निर्मित OpenStreetMap डेटा %1 तक। OpenStreetMap.org पर मानचित्र को संपादित और अपडेट करने के तरीके के बारे में और जानें</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) एक समुदाय परियोजना है जो एक मुफ्त और खुले नक्शे का निर्माण करती है। यह Organic Maps में नक्शा डेटा का मुख्य स्रोत है और विकिपीडिया की तरह काम करती है। आप स्थान जोड़ या संपादित कर सकते हैं और वे दुनिया भर के लाखों उपयोगकर्ताओं के लिए उपलब्ध हो जाते हैं।
+समुदाय में शामिल हों और सभी के लिए एक बेहतर नक्शा बनाने में मदद करें!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>अपने मानचित्र संपादनों को दुनिया भर में प्रकाशित करने के लिए एक OpenStreetMap खाता बनाएं या लॉग इन करें।</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%2 में से %1</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>सेलुलर नेटवर्क कनेक्शन पर डाउनलोड करें?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>कुछ प्लानों या रोमिंग के साथ यह काफी महंगा हो सकता है।</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>एक मान्य भवन संख्या दर्ज करें</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>मंजिलों की संख्या (अधिकतम %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>मंजिलों की संख्या %1 से अधिक नहीं होनी चाहिए</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ज़िप कोड</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>एक मान्य ज़िप कोड दर्ज करें</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap स्वयंसेवकों के लिए नोट (वैकल्पिक)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>नक्शे पर त्रुटियों या ऐसी चीज़ों का वर्णन करें जिन्हें Organic Maps के साथ संपादित नहीं किया जा सकता।</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>आपके संपादन सार्वजनिक &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; डेटाबेस पर अपलोड किए जाते हैं। कृपया व्यक्तिगत या कॉपीराइट जानकारी न जोड़ें।</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap के बारे में अधिक जानकारी</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>आपका संपादन इतिहास</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>आपका मानचित्र डेटा नोट्स</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>ऑपरेटर</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>ऑपरेटर: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>कोई उपयुक्त श्रेणी नहीं मिल रही?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps केवल सरल बिंदु श्रेणियाँ जोड़ने की अनुमति देता है, जिसका अर्थ है कि शहर, सड़कें, झीलें, इमारतों की रूपरेखा आदि नहीं। कृपया ऐसी श्रेणियाँ सीधे &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; पर जोड़ें। विस्तृत चरण-दर-चरण निर्देशों के लिए हमारी &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;गाइड&lt;/a&gt; देखें।</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>आपने कोई भी नक्शा डाउनलोड नहीं किया है</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>ऑफ़लाइन खोज और नेविगेशन के लिए मानचित्र डाउनलोड करें।</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>वर्तमान स्थान अज्ञात है।</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>किमी/घंटा</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>घंटे</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>मिनट</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>दिन</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>सेकंड</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>और</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>बुकमार्क संपादित करें</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>व्यक्तिगत नोट्स (टेक्स्ट या एचटीएमएल)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>टिप्पणी…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>सभी स्थानीय परिवर्तनों को रद्द करें?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>अस्वीकार करें</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>जोड़ी गई जगह को हटाएं?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>मिटाना</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>जगह मौजूद नहीं है</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>कृपया स्थान को हटाने का कारण बताएं</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>एक वैध फ़ोन नंबर दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>एक मान्य वेब पता दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>एक वैध ईमेल दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>एक वैध फेसबुक वेब पता, खाता या पेज का नाम दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>एक वैध इंस्टाग्राम उपयोगकर्ता नाम या वेब पता दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>एक वैध ट्विटर उपयोगकर्ता नाम या वेब पता दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>एक वैध VK उपयोगकर्ता नाम या वेब पता दर्ज करें</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>एक वैध LINE ID या वेब पता दर्ज करें</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>OpenStreetMap में स्थान जोड़ें</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>या, वैकल्पिक रूप से, OpenStreetMap समुदाय के लिए एक नोट छोड़ें ताकि कोई और यहाँ कोई स्थान जोड़ या ठीक कर सके।</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>नोट OpenStreetMap को भेजा जाएगा</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>क्या आप इसे सभी उपयोगकर्ताओं को भेजना चाहते हैं?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>सुनिश्चित करें कि आपने कोई निजी या व्यक्तिगत डेटा दर्ज नहीं किया है।</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap संपादक परिवर्तन की जाँच करेंगे और यदि उनके कोई प्रश्न हों तो आपसे संपर्क करेंगे।</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>रुकें</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>ट्रैक रिकॉर्ड करना</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>मुझे स्वीकार है</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>मैंने गिराया</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>विस्तृत जानकारी दिखाने के लिए मोबाइल इंटरनेट का उपयोग करें?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>हमेशा उपयोग करें</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>केवल आज</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>आज उपयोग न करें</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>मोबाइल इंटरनेट</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>मानचित्र अद्यतन अधिसूचनाओं और संपादन अपलोड करने के लिए मोबाइल इंटरनेट आवश्यक है।</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>कभी उपयोग न करो</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>हमेशा पूछिये</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>यातायात डेटा दिखाने के लिए मानचित्रों को अपडेट करना होगा।</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>मानचित्र लेबल के लिए आकार बढ़ाएँ</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>कृपया Organic Maps अपडेट करें</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>यातायात डेटा उपलब्ध नहीं है</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>लॉगिंग करने देना</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>सामान्य प्रतिक्रिया</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>हम वॉयस निर्देशों के लिए सिस्टम TTS का उपयोग करते हैं। कई Android डिवाइस Google TTS का उपयोग करते हैं, आप इसे Google Play से डाउनलोड या अपडेट कर सकते हैं।</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>कुछ भाषाओं के लिए, आपको ऐप स्टोर (Google Play, Galaxy Store, App Gallery, FDroid) से एक स्पीच सिंथेसाइज़र या एक अतिरिक्त भाषा पैक इंस्टॉल करना होगा।
+अपने डिवाइस की सेटिंग्स खोलें → भाषा और इनपुट → स्पीच → टेक्स्ट टू स्पीच आउटपुट.
+यहां आप वाक् संश्लेषण के लिए सेटिंग्स प्रबंधित कर सकते हैं (उदाहरण के लिए, ऑफ़लाइन उपयोग के लिए भाषा पैक डाउनलोड करें) और एक अन्य टेक्स्ट-टू-स्पीच इंजन का चयन कर सकते हैं।</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>अधिक जानकारी के लिए कृपया इस गाइड को देखें।</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>लैटिन में लिप्यंतरण</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>और जानें</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>मार्ग का प्रारंभिक बिंदु जोड़ने के लिए खोज का उपयोग करें या मानचित्र पर टैप करें</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>गंतव्य बिंदु जोड़ने के लिए खोज का उपयोग करें या मानचित्र पर टैप करें</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>मार्ग प्रबंधित करें</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>योजना</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>रोक हटाएँ</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>गंतव्य जोड़ें</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>सहेजा गया</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>कृपया अपने सभी मानचित्र संपादनों को स्वचालित रूप से अपलोड करने के लिए OpenStreetMap पर लॉगिन करें। अधिक जानें &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;यहां&lt;/a&gt;।</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>भंडारण पहुँच समस्या</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>बाहरी भंडारण तक पहुँच नहीं मिल पा रही है। हो सकता है कि एसडी कार्ड हटा दिया गया हो, क्षतिग्रस्त हो, या फ़ाइल सिस्टम केवल-पठन (read-only) मोड में हो। कृपया अपना एसडी कार्ड जांचें या support@organicmaps.app पर हमसे संपर्क करें।</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>खराब स्टोरेज का अनुकरण करें</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>कृपया एक सही नाम दर्ज करें</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>सूचियों</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>सभी को छिपाएं</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>सब दिखाएं</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>एक नई सूची बनाएं</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>बुकमार्क और सेटिंग्स आयात करें</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>एप्लिकेशन त्रुटि के कारण साझा करने में असमर्थ</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>साझा करने में त्रुटि</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>खाली सूची साझा नहीं की जा सकती</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>नाम खाली नहीं हो सकता</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>कृपया सूची का नाम दर्ज करें</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>नई सूची</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>यह नाम पहले ही ले लिया गया है</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>कृपया कोई अन्य नाम चुनें</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>कृपया प्रतीक्षा करें…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>फ़ोन नंबर</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap प्रोफ़ाइल</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>पुनर्स्थापित करें</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n tracks?</numerusform>
+<numerusform>%n tracks?</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>निजता</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>गोपनीयता नीति</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>उपयोग की शर्तें</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>यातायात</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>हाइकिंग</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>साइकिलिंग</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>भूमिगत मार्ग</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>मानचित्र शैलियाँ और परतें</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>यह सूची खाली है</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>बुकमार्क जोड़ने के लिए, नक्शे पर किसी स्थान पर टैप करें और फिर स्टार आइकन पर टैप करें</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>सभी बुकमार्क का रंग बदलें</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>सभी ट्रैकों का रंग बदलें</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…और अधिक</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>निर्यात KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>जीपीएक्स निर्यात करें</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>निर्यात GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>सूची हटाएँ</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>गति कैमरा</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>स्थान का विवरण</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>नक्शा डाउनलोडर</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>तेज़ गति से गाड़ी चलाने के बारे में चेतावनी दें</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>हमेशा चेतावनी</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>कभी चेतावनी न दें</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>बिजली की बचत अवस्थाt</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>कुछ कार्यक्षमता की कीमत पर बिजली के उपयोग को कम करने का प्रयास करें।</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>कभी नहीं</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>जब बैटरी कम हो</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>हमेशा</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>नक्शे पर बुकमार्क के नाम</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>यदि बहुत सारे बुकमार्क हों, तो नक्शे पर उनके नाम दिखाने से ऐप धीमा हो सकता है।</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>दाईं ओर दिखाएँ</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>नीचे दिखाएँ</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>सहायता संवाद में &quot;बग की रिपोर्ट करें&quot; का उपयोग करके हमें अपनी समस्या के बारे में विस्तृत डायग्नोस्टिक लॉग रिकॉर्ड करने और मैन्युअल रूप से भेजने के लिए इस विकल्प को अस्थायी रूप से सक्षम करें। लॉग में स्थान की जानकारी शामिल हो सकती है.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>रूटिंग विकल्प</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>पथकर को टालना</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>कच्ची सड़कों से बचें</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>नौकाओं से बचें</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>फ़्रीवेज़ से बचें</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>मार्ग की गणना करने में असमर्थ</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>कोई मार्ग नहीं मिल सका. यह आपके रूटिंग विकल्पों या अधूरे OpenStreetMap डेटा के कारण हो सकता है। कृपया अपने रूटिंग विकल्प बदलें और पुनः प्रयास करें।</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>बचने के लिए सड़कों को परिभाषित करें</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>रूटिंग विकल्प सक्षम</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>शुल्क मार्ग</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>अनपक्की सड़क</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>फेरी क्रॉसिंग</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>हॉं</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>नहीं</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>हॉं</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>नहीं</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>क्षमता: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>नेटवर्क: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>आप पहुँच गए हैं!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>ठीक है</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>सॉर्ट करें…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>बुकमार्क सॉर्ट करें</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>डिफ़ॉल्ट रूप से</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>प्रकार के अनुसार</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>दूरी के अनुसार</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>दिनांक के अनुसार</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>नाम द्वारा</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>एक हफ्ता पहले</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>एक महीने पहले</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>एक महीने से भी अधिक पहले</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>एक साल से भी अधिक पहले</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>मेरे पास</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>अन्य</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>रूट योजना विफल</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>आगमन का समय: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>मार्ग की गणना करने के लिए अनुमानित पथ के साथ सभी मानचित्र डाउनलोड करें और अपडेट करें।</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>आपने दुनिया का नक्शा बदल दिया है! इसे अपने तक ही मत रखना; अपने दोस्तों को बताएं और मिलकर इसे संपादित करें।</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>दोस्तों के साथ साझा करें</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>अब बंद</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>कल सुबह %1 बजे खुलेगा</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 को %2 पर खोलता है</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1 बजे खुलता है</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1 बजे बंद हो जाता है</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>खुलने का समय जोड़ें</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>पासवर्ड (न्यूनतम 8 वर्ण)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>अमान्य उपयोगकर्ता नाम या पासवर्ड।</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM खाता</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>अंतिम अपलोड</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>धन्यवाद</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>स्थान का नाम</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>फ़ोन</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>कृपया ध्यान दें</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>डाउनलोड त्रुटि</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>श्रेणी चुनें</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>लोकप्रिय</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>सभी श्रेणियाँ</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>नक्शे में नए स्थान जोड़ें, और ऐप से ही मौजूदा स्थानों को संपादित करें।</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>स्थान बदलें</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>डाउनलोड करने के लिए आपको अधिक जगह की आवश्यकता होगी। कृपया कोई भी अनावश्यक डेटा हटा दें.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>मैंने Organic Maps के नक्शे बेहतर किए।</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>विस्तृत टिप्पणी</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>आपके सुझाए गए नक्शा परिवर्तन OpenStreetMap समुदाय को भेजे जाएंगे। कृपया उन अतिरिक्त विवरणों का वर्णन करें जिन्हें Organic Maps में संपादित नहीं किया जा सकता।</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>आपका स्थान निर्धारित करते समय एक त्रुटि उत्पन्न हुई. जांचें कि आपका उपकरण ठीक से काम कर रहा है और बाद में पुनः प्रयास करें।</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>स्थान सेवाएँ अक्षम हैं</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>डिवाइस सेटिंग्स में भू-स्थानिक जानकारी तक पहुँच सक्षम करें</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. सेटिंग्स खोलें</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. स्थान पर टैप करें</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. ऐप का उपयोग करते समय चुनें</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. गोपनीयता का चयन करें</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. स्थान सेवाएँ चुनें</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. स्थान सेवाएँ चालू करें</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>या बिना लोकेशन के Organic Maps का उपयोग जारी रखें</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>पुस्तक</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>कॉल करें</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>बुकमार्क का नाम</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>बुकमार्क हटाएँ</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>आपका नोट OpenStreetMap पर भेजा जाएगा</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…और अधिक</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>अपडेट</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>क्या आप हाल ही में यात्रा किए गए मार्ग की रिकॉर्डिंग अक्षम करना चाहते हैं?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>अक्षम करें</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>देखें</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps आपके हाल ही में यात्रा किए गए मार्ग को रिकॉर्ड करने के लिए पृष्ठभूमि में आपके स्थान का उपयोग करता है।</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>सामान्य सेटिंग्स</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>ट्रैफ़िक डेटा दिखाने के लिए, एप्लिकेशन को अपडेट करना होगा।</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>लॉग फ़ाइल का आकार: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>हटाने के लिए यहां खींचें</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>स्टॉप बदलें</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>से शुरू करें</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>कृपया अपने सभी मानचित्र संपादनों को स्वचालित रूप से अपलोड करने के लिए OpenStreetMap पर लॉगिन करें। अधिक जानें</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>यहां</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>स्क्रीन छिपाएँ</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 का %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>डाउनलोड %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>लागू करना %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>यह नाम बहुत लंबा है</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>नई फाइलें पाई गईं</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>बदलना</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>त्रुटि</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>कुछ फ़ाइलें परिवर्तित नहीं की गईं.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>एक त्रुटि पाई गई</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>लोकप्रिय</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>नक्शे से छिपाएँ</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>टैग लोड करते समय एक त्रुटि हुई, कृपया फिर से प्रयास करें</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>सही</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>नीचला</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>चलो चलते हैं</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>गंतव्य</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>पुनः केंद्रित करें</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>खोज परिणाम</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>फिर</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>क्या आप मार्ग का पुनर्निर्माण करना चाहते हैं?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>ड्राइविंग के दौरान कीबोर्ड उपलब्ध नहीं है</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>आपके वर्तमान स्थान से मार्ग बनाने में असमर्थ</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>अपने गंतव्य तक पहुंचने का मार्ग ढूंढने में असमर्थ. कृपया कोई अन्य अंतिम बिंदु चुनें</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>कोई जीपीएस सिग्नल नहीं. कृपया किसी खुले क्षेत्र में चले जाएँ</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>मार्ग बनाने में असमर्थ. कृपया अन्य मार्ग बिंदु निर्दिष्ट करें</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>मार्ग बनाने के लिए, अपने डिवाइस पर गुम मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>एक त्रुटि पाई गई। कृपया एप्लिकेशन पुनः प्रारंभ करें</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>मार्ग आपके वर्तमान स्थान से फिर से बनाया जाएगा</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>मार्ग को ऑटोमोबाइल में परिवर्तित किया जाएगा</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>सभी बुकमार्क नहीं दिखाए गए हैं</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>सभी बुकमार्क देखने के लिए फ़ोन पर स्विच करें</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>स्पीडकैम्स</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>गति चेतावनी</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>कृपया अपने मोबाइल डिवाइस पर ऐप में मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 निकास</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>डिफ़ॉल्ट द्वारा क्रमबद्ध करें</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>प्रकार के अनुसार क्रमबद्ध करें</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>दूरी के अनुसार क्रमबद्ध करें</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>दिनांक के अनुसार क्रमबद्ध करें</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>नाम द्वारा क्रमबद्ध करें</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>खाना</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>दृश्य</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>संग्रहालय</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>पार्क</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>तैराकी</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>पहाड़</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>जानवर</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>होटल</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>इमारतें</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>पैसा</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>दुकान</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>पार्किंग</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>गैस स्टेशन</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>दवा</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>सूची में खोजें</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>धार्मिक स्थल</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>सूची चुनें</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>इस क्षेत्र में सबवे नेविगेशन अभी उपलब्ध नहीं है</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>सबवे मार्ग नहीं मिला</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>कृपया सबवे स्टेशन के निकट प्रारंभ या समाप्ति बिंदु चुनें</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>रूप रेखा लाइंस</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>कॉन्टूर लाइनों को सक्रिय करने के लिए इस क्षेत्र का नक्शा डेटा डाउनलोड करना आवश्यक है।</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>इस क्षेत्र में समरेखीय रेखाएँ अभी उपलब्ध नहीं हैं</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>चढ़ाई</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>उतरान</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>न्यूनतम ऊँचाई</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>अधिकतम ऊँचाई</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>कठिनाई</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>वितरण:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>समय:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>इज़ोलाइन्स का अन्वेषण करने के लिए ज़ूम इन करें</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>डाउनलोड हो रहा है</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>विश्व मानचित्र डाउनलोड करें</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>आंतरिक डिवाइस की मेमोरी या एसडीकार्ड पर फ़ोल्डर बनाने और फ़ाइलें स्थानांतरित करने में असमर्थ</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>डिस्क त्रुटि</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>कनेक्शन विफलता</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>यूएसबी केबल डिस्कनेक्ट करें</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>स्क्रीन ऑन करो</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>सक्षम होने पर,मानचित्ररप्रदर्शिततकरतेतेसमययस्क्रीननहमेशााचालूलूरहेगी।।</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>लॉक स्क्रीन पर दिखाएँ</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>सक्षम होने पर, डिवाइस लॉक होने पर भी ऐप लॉकस्क्रीन पर काम करेगा।</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>मानचित्र भाषा</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap से मानचित्र डेटा</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/hi/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>हमारे समुदाय-निर्मित मानचित्रों का उपयोग करने के लिए धन्यवाद!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>आपके दान और समर्थन से, हम दुनिया में सबसे अच्छे मानचित्र बना सकते हैं!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>क्या आपको हमारा ऐप पसंद है? कृपया विकास का समर्थन करने के लिए दान करें! अभी तक यह पसंद नहीं आया? कृपया हमें बताएं, और हम इसे ठीक कर देंगे!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>यदि आप किसी सॉफ़्टवेयर डेवलपर को जानते हैं, तो आप उससे वह सुविधा लागू करने के लिए कह सकते हैं जिसकी आपको आवश्यकता है।</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>कुछ भी चुनने के लिए मानचित्र पर कहीं भी टैप करें। इंटरफ़ेस को छिपाने और वापस दिखाने के लिए लंबे समय तक टैप करें।</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>क्या आप जानते हैं कि आप मानचित्र पर अपना वर्तमान स्थान चुन सकते हैं?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>आप हमारे ऐप को अपनी भाषा में अनुवाद करने में मदद कर सकते हैं।</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>हमारा ऐप कुछ उत्साही लोगों और समुदाय द्वारा विकसित किया गया है।</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>आप मानचित्र डेटा को आसानी से ठीक और सुधार सकते हैं।</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>हमारा मुख्य लक्ष्य तेज़, गोपनीयता-केंद्रित, उपयोग में आसान मानचित्र बनाना है जो आपको पसंद आएंगे।</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>आप अब फोन स्क्रीन पर Organic Maps का उपयोग कर रहे हैं</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>आप अब कार स्क्रीन पर Organic Maps का उपयोग कर रहे हैं</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>आप Android Auto से कनेक्ट हैं</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>फ़ोन पर जारी रखें</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>कार स्क्रीन पर</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps इसे स्थान तक पहुंच की आवश्यकता है। जब यह सुरक्षित हो, तो अपने फोन पर सूचना देखें।</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>इस ऐप को आपकी अनुमति की आवश्यकता है</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps Android Auto में प्रभावी ढंग से काम करने के लिए इसे स्थान अनुमतियों की आवश्यकता होती है</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>अनुमतियाँ प्रदान करें</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>लंबी पैदल यात्रा</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>वेब ब्राउज़र उपलब्ध नहीं है</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>आवाज़</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>सभी बुकमार्क और ट्रैक निर्यात करें</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>सिस्टम वाक् संश्लेषण सेटिंग्स</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>स्पीच सिंथेसिस सेटिंग्स नहीं मिलीं, क्या आप सुनिश्चित हैं कि आपका डिवाइस इसका समर्थन करता है?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>ड्राइव करते हुए किसी जगह से गुजरना</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>खोज साफ़ करें</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>ज़ूम इन</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>ज़ूम आउट</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>मेनू लिंक</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>मेनू देखें</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>किसी अन्य ऐप में खोलें</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>स्वयं सेवा</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>विकल्प चुनें</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>घर के बाहर बैठने</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>सबसे सटीक नेविगेशन के लिए, हम फ़ोन की बैटरी सेटिंग्स में पावर सेविंग मोड को अक्षम करने की सलाह देते हैं।</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>ट्रैक रिकॉर्ड करें</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>ट्रैक रिकॉर्डिंग रोकें</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>ट्रैक रिकॉर्डिंग</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>बिना सहेजे रुकें</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>रिकॉर्डिंग जारी रखें</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>मार्ग रिकॉर्डिंग बुकमार्क और ट्रैक में सहेजें?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>मार्ग खाली है - बचाने के लिए कुछ नहीं</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>फ़ोल्डर चयन संवाद प्रदर्शित करने में असमर्थ क्योंकि आपके डिवाइस पर कोई उपयुक्त ऐप इंस्टॉल नहीं है। कृपया एक फ़ाइल प्रबंधक ऐप इंस्टॉल करें और पुनः प्रयास करें।</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>रंग चुनें</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>मार्ग संपादित करें</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>कोई ऐप इंस्टॉल नहीं है जो लोकेशन खोल सके</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>नेविगेशन में ऑटो</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>सिस्टम का अनुसरण करें</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>ट्रैक साझा करें</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>%1 हटाएँ?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>कठिनाई का स्तर</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>आसान</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>मध्यम</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>कठिन</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>अपडेट हो रहा है</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>अपने डाउनलोड किए गए मानचित्र अपडेट करें</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>मानचित्रों का अपडेट होना ऑब्जेक्ट्स के बारे में जानकारी अप टू डेट रखता है</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>(%1) अपडेट करें</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>बाद में मैनुअल रूप से अपडेट करें</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>ट्रैक हटाएँ</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>क्या आप वाकई इस ट्रैक को हटाना चाहते हैं?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>ट्रैक का नाम</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>स्थानांतरित करें</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>ट्रैक</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>रंग बदलना</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>नक्शा</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>क्या आप डेवलपर्स को बग रिपोर्ट भेजना चाहेंगे?
+हम अपने उपयोगकर्ताओं पर निर्भर हैं, क्यूंकि Organic Maps स्वचालित रूप से कोई त्रुटि जानकारी एकत्र नहीं करता। Organic Maps का समर्थन करने के लिए अग्रिम धन्यवाद!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud सिंक्रोनाइज़ेशन सक्षम करें</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud सिंक्रोनाइज़ेशन विकासाधीन एक प्रायोगिक सुविधा है। सुनिश्चित करें कि आपने अपने सभी बुकमार्क और ट्रैक का बैकअप बना लिया है।</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud अक्षम है</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>कृपया इस सुविधा का उपयोग करने के लिए अपने डिवाइस की सेटिंग में iCloud सक्षम करें।</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>सक्षम</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>बैकअप</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud सिंक्रनाइज़ेशन विफलता</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>त्रुटि: कनेक्शन त्रुटि के कारण सिंक्रनाइज़ करने में विफल</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>त्रुटि: iCloud कोटा पार हो जाने के कारण सिंक्रनाइज़ करने में विफल</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>त्रुटि: iCloud उपलब्ध नहीं है</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>हाल ही में हटाई गई सूचियाँ</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>साफ करें</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>सभी हटा दो</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>पुनः प्राप्त करें</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>सभी पुनः प्राप्त करें</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap में योगदान करें</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>स्थान जोड़ें</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>योगदान करने के लिए मानचित्र अपडेट करें</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>आपको OpenStreetMap डेटा में योगदान करने से पहले %1 मानचित्र को नवीनतम संस्करण में अपडेट करना होगा</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>मेगाबाइट</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>गीगाबाइट</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>मेरा स्थान</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>मेरे स्थान</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>आंतरिक निजी भंडारण</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>आंतरिक साझा भंडारण</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>एसडी कार्ड</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>बाह्य साझा भंडारण</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>वाईफ़ाई</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>डाक कोड</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>मानचित्र बिंदु</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>मी</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>किमी</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>मील</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>फीट</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>मार्ग दिखाने के लिए, मानचित्रों को अपडेट किया जाना चाहिए।</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>निकास</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>प्रवेश</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>मेट्रो मानचित्र अनुपलब्ध है</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>आप</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>बैंगनी डाउनलोड किए गए क्षेत्र</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>रास्ता</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>ऐप की कार्यक्षमता का पूरी तरह से आनंद लेने के लिए पृष्ठभूमि में स्थान का पता लगाना आवश्यक है। इसका उपयोग मार्गदर्शन और आपके हाल ही में किए गए यात्रा को सहेजने के लिए किया जाता है।</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>मार्गदर्शन के लिए और अपने हाल ही में किए गए यात्रा को सहेजने के लिए आपका स्थान निर्धारित करना आवश्यक है।</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>पासवर्ड से लॉगिन करें</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ब्राउज़र का उपयोग करके लॉगिन करें</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>हाल ही में उपयोग किए गए</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>बुकमार्क का रंग बदल दिया गया</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>ट्रैकों का रंग बदल दिया गया</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>स्पेक्ट्रम</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>स्लाइडर्स</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>लाल</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>हरा</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>नीला</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB हेक्स रंग #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>ग्रिड</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/hr/omim.ts
+++ b/qt/translations/hr/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="hr">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Nazad</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Otkaži</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Izbriši</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Preuzmi karte</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Preuzimanje neuspješno. Dotaknite za ponovni pokušaj.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Preuzimanje…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milje</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Kasnije</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Pretraživaj</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Pretraži kartu</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Vi trenutno imate sve lokacijske servise za ovaj uređaj ili aplikaciju isključene. Molim vas uključite ih u postavkama.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ograničena preciznost</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Za točnu navigaciju omogućite Preciznu lokaciju u postavkama.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Prikaži na karti</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Preuzimanje nije uspjelo</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Pokušaj ponovo</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>O Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Besplatno za sve, napravljeno sa ljubavi</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Nema reklama, nema praćenja, nema prikupljanja podataka</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Nema pražnjenja baterije, radi izvan mreže</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Brzo, minimalističko, razvijeno od zajednice</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Otvorenog koda aplikacija napravljena od entuzijasta i volontera.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Postavke lokacije</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zatvori</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Aplikacija zahtijeva hardverski ubrzani OpenGL. Nažalost, vaš uređaj nije podržan.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Preuzmi</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Isključite USB kabel ili umetnite memorijsku karticu kako biste koristili Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Prvo oslobodite prostor na SD kartici/USB memoriji kako biste mogli koristiti aplikaciju</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Prije nego što počnete koristiti aplikaciju, preuzmite svjetsku preglednu kartu na vaš uređaj.
+Iskoristit će %1 memorije.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Prikaži kartu</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Preuzima se %1. Sada možete
+nastaviti na kartu.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Preuzmi %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Ažurirati %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pauza</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Nastavi</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 neuspješno preuzimanje</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Dodaj novi popis</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Ime popisa zabilješki</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Zabilješke</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Zabilješke i putevi</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Naziv</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresa</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Postavke</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Sačuvaj karte u</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Odaberite mapu u koju ćete preuzeti karte.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Preuzete karte</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 slobodno od %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Premjesti karte?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Greška pri premještanju kartnih datoteka</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ovo može potrajati nekoliko minuta. Molimo pričekajte…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mjerne jedinice</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Odaberite između milja i kilometara</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Otkaži instaliranje</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Ostavi recenziju</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Preuzmi kartu</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Popisi zabilješki</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Gdje jesti</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Prehrambene namirnice</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Prijevoz</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzin</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkiranje</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Kupovina</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Rabljeno</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Zanimljivosti</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Zabava</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Noćni život</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Obiteljski odmor</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Ljekarna</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Bolnica</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toalet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pošta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policija</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciklaža</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Voda</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Sadržaji za kampere</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Bilješke</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps zabilješke su s tobom dijeljene</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Zdravo!&#32;
+&#32;
+U privitku su moje zabilješke; otvori ih u aplikaciji Organic Maps. Ako nije instalirana, možeš je preuzeti na: https://omaps.app/get?kmz&#32;
+&#32;
+Uživaj u putovanju s Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Učitavanje zabilješki</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Zabilješke su uspješno učitane! Možeš ih pronaći na karti ili na ekranu „Upravljač zabilješki”.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Neuspjelo učitavanje zabilješki. Datoteka je možda oštećena ili neispravna.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Aplikacija ne prepoznaje vrstu datoteke:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Neuspjelo otvaranje datoteke %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Uredi</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Vaša lokacija još nije određena</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Žao nam je, postavke pohrane karata su trenutačno onemogućene.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Preuzimanje karte je sada u tijeku.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Provjerite moju trenutnu lokaciju na Organic Maps! %1 ili %2 Nemate offline karte? Preuzmite ovdje: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hej, pogledaj moj marker u Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hej, pogledaj moju trenutnu lokaciju na mapi Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Bok,  sada sam ovdje: %1. Klikni na ovaj link %2 ili na ovaj %3 da vidiš mjesto na karti.  Hvala.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Dijeli</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail adresa</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopirano u međuspremnik: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Gotovo</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap podaci: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Stvarno se želiš odjaviti sa svog OpenStreetMap računa?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Putevi</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Dužina</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Dijeli moju lokaciju</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Opće postavke</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informacije</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigacija</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Gumbi „+“ i „-“ na karti</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Prikaži na karti</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Noćni stil pri navigaciji u mraku</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Noćni modus</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Isključeno</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Uključeno</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatski</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Prikaz perspektive</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D zgrade</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D zgrade su deaktivirane u modusu štednje energije</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Glasovne upute</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Najavi imena cesta</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Kada je omogućeno, naziv ulice ili izlaza za skretanje bit će izgovoren naglas.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Jezik glasa</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Za preuzimanje glasa veće kvalitete otvorite aplikaciju Postavke i idite na Pristupačnost → VoiceOver → Govor → Glas.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testiraj glasovne upute (TTS, pretvaranje teksta u govor)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Provjeri glasnoću ili postavke sustava za pretvaranje teksta u govor ako sada ne čuješ glas.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nedostupno</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatsko zumiranje</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Udaljenost</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Prikaži na karti</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Izbornik</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Web stranica</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Novosti</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Povratne informacije</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Ocijeni aplikaciju</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Pomoć</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Često postavljena pitanja</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doniraj</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Već si donirao/la</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Podsjeti me kasnije</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Podrži Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Podrži projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autorska prava</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Prijavi grešku</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Poboljšajte smjer strelice pomicanjem telefona u obliku osmice za kalibraciju kompasa.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Pomaknite telefon u obliku osmice kako biste kalibrirali kompas i fiksirali smjer strelice na karti.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ponovno dugotrajno pritiskanje na kartu da biste vidjeli sučelje</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aktualiziraj sve</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Prekini sve</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Preuzeto</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>U redu čekanja</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>U mojoj blizini</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Karte</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Preuzmi sve</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Preuzimanje:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Da biste izbrisali kartu, molimo zaustavite navigaciju.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Rute se mogu stvarati samo ako su u potpunosti sadržane unutar karte jednog područja.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Preuzmi kartu</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Pokušaj ponovo</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Izbriši kartu</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aktualiziraj kartu</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play usluge lokacija</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Brzo odredite svoju približnu lokaciju pomoću Bluetootha, Wi-Fi-ja ili mobilne mreže</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Preuzmite sve karte duž vaše rute</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Da bismo kreirali rutu, moramo preuzeti i ažurirati sve karte od vaše lokacije do odredišta.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nema dovoljno memorije</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Aktiviraj usluge lokacija</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Spremi</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>stvori</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Crvena</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Žuta</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Plava</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zelena</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Ljubičasta</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Narančasta</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Smeđa</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Ružičasta</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tamnoljubičasta</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Svjetloplava</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cijan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Tirkizna</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limunasta</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tamnonarančasta</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Siva</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Plavo siva</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informacije</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps verzija: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Izgled</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Svijetla</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tamna</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Svijetlo od zore do sumraka</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Ostalo</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Poklonite besplatne karte bez oglasa milijunima korisnika!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Prijavite ili ispravite netočne podatke karte</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volonter</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Pratite nas i kontaktirajte nas:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Klijent e-pošte nije postavljen. Molimo konfigurirajte ga ili nas kontaktirajte na %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Greška pri slanju e-pošte</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibracija kompasa</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Dostupno</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Pronađeno</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aktualizirano</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Neuspjelo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>zabilješka</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Prilikom praćenja rute, imajte sljedeće na umu:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>– Uvjeti na cesti, prometni propisi i prometni znakovi uvijek imaju prednost pred navigacijskim savjetima;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>– Karta može biti netočna, a predložena ruta možda nije uvijek najoptimalniji način za dolazak do odredišta;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>– Predložene rute treba shvatiti samo kao preporuke;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>– Budite oprezni s rutama u pograničnim zonama: rute koje je kreirala naša aplikacija ponekad mogu prelaziti državne granice na nedozvoljenim mjestima.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Budite oprezni i sigurni na cestama!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Provjeri GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nije moguće stvoriti rutu. Trenutne GPS koordinate nisu mogle biti utvrđene.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Provjerite GPS signal. Aktiviranje Wi-Fi-ja poboljšat će točnost vaše lokacije.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktiviraj usluge lokacija</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Nije moguće pronaći trenutačne GPS koordinate. Omogućite usluge lokacije kako biste izračunali rutu.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Nije moguće pronaći rutu</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Nije moguće stvoriti rutu.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Molimo prilagodite svoju polaznu točku ili odredište.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Podesite početnu točku</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Ruta nije stvorena. Nije moguće pronaći polaznu točku.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Molimo odaberite polaznu točku bliže cesti.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Podesite odredište</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Ruta nije stvorena. Odredište nije moguće pronaći.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Molimo odaberite odredišnu točku smještenu bliže cesti.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nije moguće pronaći posrednu točku.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Molimo prilagodite svoju međustanicu.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistemski greška</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Nije moguće stvoriti rutu zbog pogreške u aplikaciji.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Pokušaj ponovo</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ne sada</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Želite li preuzeti kartu i stvoriti optimalniju rutu koja obuhvaća više karata?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Preuzmite dodatne karte kako biste stvorili bolju rutu koja prelazi granice ove karte.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Preuzmite potrebne datoteke</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Preuzmite ili ažurirajte sve karte duž predviđenog puta kako biste izračunali rutu.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Za početak pretraživanja i izrade ruta, molimo preuzmite kartu. Nakon toga vam više neće biti potrebna internetska veza.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Odaberi kartu</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Prikaži</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Sakrij</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorije</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Povijest</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ups, nema rezultata.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Preuzmi regiju u kojoj tražiš ili pokušavaš dodati ime obližnjeg grada/sela.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Povijest pretrage</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Pogledaj svoje nedavne pretrage.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Izbriši povijest pretraživanja</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedija</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Članak s wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Tvoja lokacija</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Početak</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Ruta od</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Ruta do</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigacija je dostupna samo s vaše trenutne lokacije.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Želite li isplanirati rutu od svoje trenutne lokacije?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Dalje</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Od</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Do</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Dodaj raspored</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Izbriši raspored</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Cijeli dan (24 sata)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Otvoreno</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zatvoreno</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Dodaj neradno vrijeme</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Radno vrijeme</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Napredni modus</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Jednostavni modus</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Neradno vrijeme</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Vrijednosti primjera</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Ispravi grešku</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Odaberi lokaciju</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Detaljno opiši problem kako bi ga OpenStreetMap zajednica mogla riješiti.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ili to obavi na https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Pošalji</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Ovo mjesto ne postoji</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Zatvoreno zbog održavanja</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplo mjesto</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatski preuzmi karte</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Dnevno</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Danas zatvoreno</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Zatvoreno</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Danas</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Otvara za %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Zatvara za %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zatvoreno</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Uredi radno vrijeme</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nemaš OpenStreetMap račun?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registriraj se na OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Prijava</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nisi prijavljen/a</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Prijava na OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Lozinka</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Ne sjećaš se lozinke?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Odjavi se</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Uredi mjesto</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Dodaj jezik</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Ulica</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Kućni broj</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalji</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Društveni mediji</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Zgrada</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Dodaj ulicu</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Upiši ime ulice</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Odaberi jezik</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Odaberi ulicu</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuhinja</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Odaberi kuhinju</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mail adresa ili korisničko ime</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Dodaj telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Kat</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Kat: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Sve vaše izmjene karte bit će izbrisane zajedno s kartom.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Ažuriraj karte</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Da biste stvorili rutu, morate ažurirati sve karte i zatim ponovno isplanirati rutu.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Pronađi kartu</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Molimo provjerite je li vaš uređaj povezan na Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nema dovoljno memorije</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Izbriši sve nepotrebne podatke</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Greška pri prijavi.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Potvrđene promjene</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Povucite kartu da postavite križ na lokaciju mjesta ili tvrtke.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Uređivanje</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Dodavanje</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Naziv mjesta</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Kao što je napisano na lokalnom jeziku</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorija</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detaljan opis problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Drugi problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Dodaj tvrtku</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Nijedan objekt se ovdje ne može locirati</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Podaci OpenStreetMapa koje je zajednica kreirala na dan %1. Saznajte više o tome kako uređivati i ažurirati kartu na OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) je projekt zajednice za izradu slobodne i otvorene karte. To je glavni izvor kartnih podataka u Organic Mapsu i funkcionira slično kao Wikipedia. Možete dodavati ili uređivati mjesta i ona postaju dostupna milijunima korisnika diljem svijeta. Pridružite se zajednici i pomozite u izradi bolje karte za sve!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Kreirajte OpenStreetMap račun ili se prijavite kako biste objavili svoje izmjene karte svijetu.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Preuzimanje putem mobilne mreže?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Ovo može biti znatno skupo s nekim tarifama ili ako ste u roamingu.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Unesite važeći broj zgrade</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Broj katova (maksimalno %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Broj katova ne smije prelaziti %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Poštanski broj</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Unesite važeći poštanski broj</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Napomena za volontere OpenStreetMapa (neobavezno)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Opisujte pogreške na karti ili stavke koje se ne mogu uređivati pomoću Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vaše izmjene se učitavaju u javnu bazu podataka &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Molimo vas da ne dodajete osobne podatke ili podatke zaštićene autorskim pravima.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Više o OpenStreetMapu</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Vaša povijest uređivanja</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vaše bilješke o podacima karte</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operater: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Ne možete pronaći odgovarajuću kategoriju?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps omogućuje dodavanje samo jednostavnih kategorija točaka, znači bez navođenja gradova, cesta, jezera, obrisa zgrada itd. Dodajte takve kategorije izravno na &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Pogledajte naš &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;vodič&lt;/a&gt; za detaljne upute.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Niste preuzeli nijednu kartu</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Preuzmite karte za pretraživanje i navigaciju izvan mreže.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Trenutna lokacija je nepoznata.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Više</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Uredi zabilješku</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Osobne bilješke (tekst ili html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentiraj…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Odbaci sve lokalne promjene?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Odbaci</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Izbriši dodano mjesto?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Izbriši</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Mjesto ne postoji</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Molimo navedite razlog brisanja mjesta</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Unesite valjan broj telefona</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Unesite valjanu web-adresu</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Unesite valjanu e-poštu</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Unesite valjanu Facebook web-adresu, korisničko ime ili naziv stranice</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Unesite valjano Instagram korisničko ime ili web-adresu</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Unesite valjano korisničko ime na Twitteru ili web-adresu</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Unesite valjano VK korisničko ime ili web-adresu</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Unesite valjani LINE ID ili web-adresu</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Dodaj mjesto na OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ili, alternativno, ostavite bilješku zajednici OpenStreetMap kako bi netko drugi ovdje mogao dodati ili ispraviti mjesto.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Napomena će biti poslana OpenStreetMapu</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Želite li to poslati svim korisnicima?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Provjerite jeste li unijeli bilo kakve privatne ili osobne podatke.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Urednici OpenStreetMapa provjerit će promjene i kontaktirat će vas ako budu imali pitanja.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stani</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Snimanje staze</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Prihvati</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Odbaci</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Koristite mobilni internet za prikaz detaljnih informacija?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Uvijek koristi</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Samo danas</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ne koristiti danas</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilni internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Za obavijesti o ažuriranju karata i učitavanje izmjena potreban je mobilni internet.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nikada ne koristiti</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Uvijek pitaj</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Za prikaz podataka o prometu karte se moraju ažurirati.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Povećajte veličinu oznaka na karti</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Molimo ažurirajte Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Podaci o prometu nisu dostupni</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Omogući zapisivanje</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Opći povratne informacije</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Koristimo sustavni TTS za glasovne upute. Mnogi Android uređaji koriste Google TTS, možete ga preuzeti ili ažurirati s Google Playa.</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Za neke jezike morat ćete instalirati sintesizer govora ili dodatni jezični paket iz trgovine aplikacijama (Google Play, Galaxy Store, App Gallery, FDroid).
+Otvorite postavke uređaja → Jezik i unos → Govor → Izlaz tekst u govor.
+Ovdje možete upravljati postavkama za sintetički govor (na primjer, preuzeti jezični paket za rad bez interneta) i odabrati drugi mehanizam pretvaranja teksta u govor.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Za više informacija pogledajte ovaj vodič.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterirati u latinično pismo</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Saznajte više</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Koristite pretraživanje, odaberite oznaku ili dodirnite kartu kako biste dodali početnu točku rute</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Koristite pretraživanje, odaberite oznaku ili dodirnite kartu kako biste dodali odredišnu točku</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Upravljanje rutom</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Ukloni Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Dodaj stajalište</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Spremljeno</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Molimo prijavite se na OpenStreetMap kako biste automatski učitali sve svoje izmjene karte. Saznajte više &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ovdje&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problem s pristupom pohrani</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Vanjska pohrana nije dostupna. SD kartica je možda uklonjena, oštećena ili je datotečni sustav samo za čitanje. Molimo provjerite svoju SD karticu ili nas kontaktirajte na support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emuliraj loše pohranjivanje</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Molimo unesite ispravno ime</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Popisi</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Sakrij sve</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Prikaži sve</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n zabilješka</numerusform>
+<numerusform>%n zabilješke</numerusform>
+<numerusform>%n zabilješki</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Stvori novi popis</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Uvezi zabilješke i puteve</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nije moguće dijeliti zbog greške aplikacije</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Greška prilikom dijeljenja</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Prazan popis se ne može dijeliti</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Ime ne smije biti prazno</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Upiši ime popisa</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Novi popis</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ovo se ime već koristi</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Odaberi jedno drugo ime</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Pričekaj …</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Broj telefona</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Pronađena je %n datoteka. Možeš je vidjeti nakon konverzije.</numerusform>
+<numerusform>Pronađene su %n datoteke. Možeš ih vidjeti nakon konverzije.</numerusform>
+<numerusform>Pronađeno je %n datoteka. Možeš ih vidjeti nakon konverzije.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Obnovi</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n put</numerusform>
+<numerusform>%n puta</numerusform>
+<numerusform>%n puteva</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatnost</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politika privatnosti</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Uvjeti korištenja</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Promet</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Planinarenje</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Biciklizam</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Podzemna željeznica</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stilovi karta i slojevi</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Ovaj je popis prazan</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Za dodavanje zabilješke dodirni mjesto na karti, a zatim dodirni ikonu zvjezdice</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Promijeni boju svih oznaka</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Promijeni boju svih tragova</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>… više</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Izvezi KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Izvezi GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Izvezi GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Izbriši popis</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Brzinske kamere</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Opis mjesta</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Preuzimač karti</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Upozori ako voziš prebrzo</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Upozori uvijek</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Upozori nikada</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modus štednje energije</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Pokušaj smanjiti potrošnju energije na štetu nekih funkcionalnosti.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nikada</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Kada je baterija slaba</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Uvijek</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Imena zabilješki na karti</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ako ima previše zabilješki, prikazivanje njihovih imena na karti može usporiti aplikaciju.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Prikaži desno</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Prikaži dolje</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Privremeno omogućite ovu opciju kako biste snimili i ručno poslali detaljne dijagnostičke zapise o vašem problemu nama putem opcije &quot;Prijavi grešku&quot; u dijaloškom okviru Pomoć. Zapisi mogu uključivati informacije o lokaciji.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opcije za određivanje rute</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Izbjegni cestarine</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Izbjegni neasfaltirane ceste</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Izbjegni trajekte</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Izbjegni autoputeve</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nije moguće izračunati rutu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Nije pronađena ruta. To može biti uzrokovano vašim opcijama za rutiranje ili nepotpunim podacima OpenStreetMapa. Molimo promijenite svoje opcije za rutiranje i pokušajte ponovno.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definirajte ceste koje želite izbjegavati</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opcije za određivanje rute su aktivirane</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Cesta sa cestarinom</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Neasfaltirana cesta</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Prijevoz trajektom</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Broj mjesta: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Mreža: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Stigli ste!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>U redu</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Razvrstaj…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Razvrstaj zabilješke</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Po zadanim postavkama</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Po vrsti</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Po udaljenosti</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Po datumu</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Po imenu</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Prije tjedan dana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Prije mjesec dana</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Više od mjesec dana</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Više od godinu dana</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>U mojoj blizini</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Drugo</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Planiranje rute nije uspjelo</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Dolazak na %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Preuzmite i ažurirajte sve karte duž predviđene rute kako biste izračunali rutu.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Promijenili ste kartu svijeta! Nemojte je zadržavati samo za sebe; recite svojim prijateljima i uređujte je zajedno.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Podijeli s prijateljima</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Zatvoreno sada</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Otvara se sutra u %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Otvara %1 u %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Otvara se u %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Zatvara se u %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Dodaj radno vrijeme</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Lozinka (najmanje 8 znakova)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Neispravno korisničko ime ili lozinka.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM račun</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Posljednje učitavanje</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Hvala</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Naziv mjesta</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Molimo imajte na umu</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Greška pri preuzimanju</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Odaberite kategoriju</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popularno</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Sve kategorije</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Dodajte nova mjesta na kartu i uređujte postojeća izravno u aplikaciji.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Promijeni lokaciju</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Za preuzimanje potrebno vam je više prostora. Molimo, izbrišite sve nepotrebne podatke.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Poboljšao sam karte aplikacije &quot;Organic Maps&quot;</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detaljan komentar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vaše predložene izmjene karte bit će poslane zajednici OpenStreetMapa. Molimo opišite sve dodatne detalje koje nije moguće urediti u Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Došlo je do pogreške pri određivanju vaše lokacije. Provjerite radi li vaš uređaj ispravno i pokušajte ponovno kasnije.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Usluge lokacije su onemogućene</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Omogućite pristup geolokaciji u postavkama uređaja</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Otvorite Postavke</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Dodirnite Lokacija</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Odaberite Tijekom korištenja aplikacije</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Odaberite Privatnost</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Odaberite Usluge lokacije</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Uključite usluge lokacije</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ili nastavite koristiti Organic Maps bez lokacije</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Knjiga</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Pozovite</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Ime zabilješke</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Izbriši zabilješku</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Vaša će bilješka biti poslana OpenStreetMapu</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…više</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Ažuriranje</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Onemogućite snimanje vaše nedavno pređene rute?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Onemogući</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Pogledajte</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps koristi tvoju lokaciju u pozadini kako bi zabilježila tvoju nedavno pređenu rutu.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Opće postavke</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Za prikaz podataka o prometu aplikacija se mora ažurirati.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Veličina zapisnika: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Povucite ovdje za uklanjanje</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Zamijeni Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Počni od</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Molimo prijavite se na OpenStreetMap kako biste automatski učitali sve svoje izmjene karte. Saznajte više</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ovdje</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Sakrije zaslon</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 od %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Preuzimanje %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Primjena %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ovo je ime predugačko</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Otrkivene su nove datoteke</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Pretvori</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Greška</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Neke datoteke nisu konvertirane.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Dogodila se greška</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popularno</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Skrij s karte</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Došlo je do pogreške pri učitavanju oznaka, molimo pokušajte ponovno</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Desno</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Dno</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Idemo</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Odredište</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Ponovno centriraj</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Rezultati pretraživanja</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Zatim</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Želite li ponovno izgraditi rutu?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tastatura nije dostupna tijekom vožnje</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Nije moguće izraditi rutu s vaše trenutne lokacije</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nije moguće pronaći rutu do vaše odredišta. Molimo odaberite drugu završnu točku</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nema GPS signala. Molimo premjestite se na otvoreno područje</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nije moguće izraditi rutu. Molimo navedite druge točke rute</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Da biste stvorili rutu, preuzmite nedostajuće karte na svoj uređaj</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Došlo je do pogreške. Molimo ponovno pokrenite aplikaciju</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Ruta će biti ponovno izgrađena od vaše trenutne lokacije</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Ruta će biti pretvorena u automobilsku</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ne prikazuju se sve zabilješke</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Prijeđi na mobitel za prikaz svih zabilješki</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Upozorenja na brzinu</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Molimo preuzmite karte u aplikaciji na svom mobilnom uređaju</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 izlaz</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortiraj prema zadanim postavkama</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sortiraj po vrsti</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sortiraj po udaljenosti</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sortiraj po datumu</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sortiraj po nazivu</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Hrana</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Atrakcije</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzeji</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parkovi</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Plivanje</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Planine</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Životinje</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteli</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Zgrade</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Novac</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Dućani</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkiralište</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzinske stanice</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Traži u popisu</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Vjerska mjesta</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Odaberi popis</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigacija podzemnom željeznicom u ovom području još nije dostupna</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Nije pronađena ruta podzemne željeznice</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Molimo odaberite početnu ili završnu točku bliže stanici metroa</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Izohipse</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Aktiviranje izohipsa zahtijeva preuzimanje podataka karte za ovo područje</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Izohipse još nisu dostupne za ovo područje</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Uzbrdo</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Nizbrdo</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. visina</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. visina</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Razina težine</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Udaljenost:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Vrijeme:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Uvećaj prikaz karte za prikaz izohipsa</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Preuzimanje</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Preuzmi preglednu kartu svijeta</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nije moguće stvoriti mapu i premjestiti datoteke na internu memoriju uređaja ili SD karticu</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Greška diska</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Greška u povezivanju</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Odspoji USB kabel</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Ostavi ekran uključen</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Kada je omogućeno, zaslon će uvijek biti uključen dok se prikazuje karta.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Prikaži na zaslonu zaključavanja</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Kada je omogućeno, aplikacija će raditi na zaslonu zaključavanja čak i kada je uređaj zaključan.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Jezik karte</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Podaci karte od OpenStreetMapa</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Hvala što koristiš karte koje je izradila naša zajednica!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Uz vaše donacije i podršku možemo stvoriti najbolje karte na svijetu!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Sviđa li vam se naša aplikacija? Molimo donirajte kako biste podržali razvoj! Još vam se ne sviđa? Recite nam zašto i mi ćemo to popraviti!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ako poznajete programera, možete ga ili je zamoliti da implementira značajku koja vam je potrebna.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Dodirnite bilo koje mjesto na karti da biste odabrali bilo što. Dugi dodir služi za skrivanje i prikazivanje sučelja.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Jeste li znali da se vaša trenutna lokacija na karti može odabrati?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Možete pomoći u prevođenju naše aplikacije na svoj jezik.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Našu je aplikaciju razvilo nekoliko entuzijasta i zajednica.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Možete jednostavno popraviti i poboljšati podatke karte.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Naš glavni cilj je izraditi brze karte usmjerene na privatnost i jednostavne za korištenje koje ćete voljeti.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Sada koristiš Organic Maps na ekranu telefona</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Sada koristiš Organic Maps na ekranu auta</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Povezan/a si s Android Autom</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Nastavi na telefonu</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Na ekran auta</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps treba pristup lokacijama. Kada je sigurno, provjeri obavijest na telefonu.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ova aplikacija treba tvoju dozvolu</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Za učinkovit rad Organic Maps treba dozvole za lokacije u aplikaciji Android Auto</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Odobri dozvole</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Na otvorenom</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web preglednik nije dostupan</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Glasnoća</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Izvezi sve zabilješke i puteve</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Postavke sustava za sintetičku govornu reprodukciju</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Postavke sintetičkog govora nisu pronađene, jeste li sigurni da vaš uređaj to podržava?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Prolaz za automobile</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Očisti pretragu</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Uvećaj</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Umanji</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Poveznica za jelovnik</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Prikaži jelovnik</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Otvori u drugoj aplikaciji</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Samoposluga</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Odaberi opciju</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sjedenje na otvorenom</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Za najprecizniju navigaciju preporučujemo onemogućavanje načina štednje energije u postavkama baterije telefona.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Snimanje staze</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Zaustavi snimanje staze</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Snimanje staze</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Prekini bez spremanja</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Nastavi snimanje</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Spremiti u „Zabilješke i putevi”?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Staza je prazna - nema što spremiti</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nije moguće prikazati dijalog za odabir mape jer na vašem uređaju nije instalirana odgovarajuća aplikacija. Molimo instalirajte upravitelj datoteka i pokušajte ponovno.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Odaberi boju</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Uredi stazu</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nije instalirana nijedna aplikacija koja može otvoriti lokaciju</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automatski u navigaciji</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Prati sustav</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Podijeli stazu</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Izbrisati %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Razina težine</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Jednostavno</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Umjereno</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Teško</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Ažuriranje</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Ažuriraj preuzete karte</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Ažuriranje karata održava informacije o objektima ažurnima</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Ažuriranje (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Ručno ažuriraj kasnije</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Izbriši stazu</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Jeste li sigurni da želite izbrisati ovu stazu?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Naziv pjesme</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Pomakni</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Staza</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Promijeni boju</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Karta</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Želite li poslati izvještaj o grešci programerima?
+Oslanjamo se na naše korisnike jer Organic Maps ne prikuplja automatski nikakve informacije o pogreškama. Unaprijed hvala što podržavate Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Omogući sinkronizaciju s iCloudom</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Sinkronizacija iClouda je eksperimentalna funkcija u razvoju. Spremi sigurnosnu kopiju svih svojih zabilješki i puteva.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud je onemogućen</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Molimo omogućite iCloud u postavkama svog uređaja kako biste koristili ovu značajku.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Omogući</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sigurnosna kopija</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Neuspjeh sinkronizacije s iCloudom</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Greška: Sinhronizacija nije uspjela zbog pogreške veze</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Greška: Sinhronizacija nije uspjela zbog prekoračenja iCloud kvote</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Greška: iCloud nije dostupan</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nedavno izbrisani popisi</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Očisti</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Izbriši sve</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Obnovi</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Obnovi sve</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Doprinijeti OpenStreetMapu</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Dodaj mjesto</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Ažuriraj kartu za doprinos</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Morate ažurirati %1 kartu na najnoviju verziju prije nego što možete doprinijeti podacima OpenStreetMapa</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Moja pozicija</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Moja Mjesta</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Interna privatna pohrana</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interna dijeljenja pohrana</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD kartica</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Vanjska dijeljena pohrana</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Poštanski Broj</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Točka na karti</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Za prikaz ruta, karte moraju biti ažurirane.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Izlaz</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ulaz</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Karta podzemne željeznice nije dostupna</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ti</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Ljubičaste preuzete regije</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Ruta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Otkrivanje lokacije u pozadini potrebno je za potpuno uživanje u funkcionalnosti aplikacije. Koristi se za navigaciju i spremanje nedavno prešlih ruta.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Određivanje vaše lokacije potrebno je za navigaciju i za spremanje nedavno prešlih ruta.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Prijava s lozinkom</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Prijava putem preglednika</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nedavno korišteno</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Boja oznaka je promijenjena</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Boja tragova je promijenjena</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Klizači</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>CRVENO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZELENA</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>PLAVA</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB heksadecimalna boja #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rešetka</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/hu/omim.ts
+++ b/qt/translations/hu/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="hu">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Vissza</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Mégse</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Törlés</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Térképek letöltése</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Nem sikerült letölteni. Próbálja meg újra.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Letöltés…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilométer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mérföld</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Később</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Keresés</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Keresés a térképen</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Jelenleg az eszköz vagy alkalmazás helymeghatározási szolgáltatásai le vannak tiltva. Engedélyezze őket a Beállításokban.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Korlátozott pontosság</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>A pontos navigáció érdekében engedélyezze a beállításokban a pontos helymeghatározást.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Megjelenítés a térképen</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Sikertelen letöltés</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Újrapróbálkozás</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Az Organic Maps névjegye</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Mindenki számára ingyenes – szeretettel készült</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Nincs hirdetés, nyomon követés és adatgyűjtés</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Nem merül le az akkumulátor – offline is működik</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Gyors, minimalista – a közösség által fejlesztett</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>A rajongók és az önkéntesek által létrehozott nyílt forráskódú alkalmazás.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Helymeghatározási beállítások</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Bezárás</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Hardveres gyorsítású OpenGL szükséges. Sajnos az Ön eszköze nem támogatott.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Letöltés</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Bontsa az USB-kapcsolatot vagy helyezzen be egy memóriakártyát az Organic Maps használatához</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Az alkalmazás használatához először szabadítson fel némi helyet az SD-kártyán/USB-tárolón</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Mielőtt elkezdené használni az alkalmazást, töltse le az áttekintő világtérképet az eszközére.&#32;
+Ez %1 tárhelyet fog igénybe venni.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ugrás a térképre</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 letöltése. Most már
+továbbléphet a térképre.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Letölti a következőt: %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Frissíti a következőt: %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Szüneteltetés</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Folytatás</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Nem sikerült letölteni a következőt: %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Új lista hozzáadása</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Könyvjelzőlista neve</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Könyvjelzők</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Könyvjelzők és nyomvonalak</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Név</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Cím</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Beállítások</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Térképek mentési helye</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Válassza ki a mappát a térképek letöltéséhez.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Letöltött térképek</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 szabad terület ennyiből: %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Áthelyezi a térképeket?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Hiba történt a térképfájlok áthelyezése közben</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ez több percig is eltarthat.
+Kis türelmet…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mértékegységek</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Válasszon kilométer és mérföld között</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Letöltés megszakítása</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Ajánlás írása</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Igen</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Térkép letöltése</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Könyvjelzőlisták</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Hol lehet enni valamit</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Élelmiszerek</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Tömegközlekedés</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzinkút</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkoló</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Bevásárlás</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Használt cikk</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Szálloda</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Látnivalók</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Szórakozás</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Pénzautomata</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Éjszakai élet</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Családi kiruccanás</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Gyógyszertár</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Kórház</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>WC</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Rendőrség</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Újrahasznosítás</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Víz</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Lakókocsis létesítmények</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Jegyzetek</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Egy Organic Maps könyvjelzőt osztottak meg Önnel</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Üdvözlöm!
+
+Mellékeltem a könyvjelzőimet; nyissa meg őket az Organic Maps alkalmazásban. Ha még nem telepítette, akkor innen tudja letölteni: https://omaps.app/get?kmz
+
+Jó utat kívánok az Organic Maps alkalmazással!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Könyvjelzők betöltése</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>A könyvjelzők sikeresen betöltődtek! Megtalálhatja őket a térképen vagy a Könyvjelzők kezelése képernyőn.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Nem sikerült betölteni a könyvjelzőket. A fájl sérült vagy hibás lehet.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Az alkalmazás nem ismeri fel a következő fájltípust:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nem sikerült megnyitni a(z) %1 fájlt
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Szerkesztés</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Az Ön tartózkodási helye még nincs meghatározva</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>A térképek tárolása jelenleg ki van kapcsolva.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>A térkép letöltése folyamatban van.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Tekintse meg a tartózkodási helyemet az Organic Maps alkalmazásban! %1 vagy %2. Nincs offline térképe? Töltse le innen: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Tekintse meg a térképjelzőmet az Organic Maps alkalmazásban!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Tekintse meg a tartózkodási helyemet az Organic Maps alkalmazásban!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Üdvözlöm!
+
+Jelenleg itt tartózkodom: %1. Kattintson a következő hivatkozásra: %2, vagy ide: %3, hogy megtekintse a tartózkodási helyemet a térképen.
+
+Köszönöm!</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Megosztás</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail-cím</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>A vágólapra másolva: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Kész</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap adatok: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Biztosan ki akar jelentkezni az OpenStreetMap fiókjából?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Nyomvonalak</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Hossz</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Saját tartózkodási hely megosztása</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Általános beállítások</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Információk</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigáció</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>„+” és „-” gombok a térképen</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Megjelenítés a térképen</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Éjszakai stílus a sötétben történő navigáláshoz</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Éjszakai mód</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Ki</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Be</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatikus</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivikus nézet</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D épületek</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>A 3D épületek energiatakarékos módban ki vannak kapcsolva</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Hangutasítások</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Utcanevek felolvasása</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Ha engedélyezve van, a rendszer hangosan kimondja annak az utcának vagy kijáratnak a nevét, amelyre be kell kanyarodni.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>A hangutasítások nyelve</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Jobb minőségű hang letöltéséhez nyissa meg a Beállítások alkalmazást, majd lépjen a Kisegítő lehetőségek → VoiceOver → Beszéd → Hang menübe.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Hangutasítások tesztelése (TTS)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Ellenőrizze a hangerőt vagy a rendszer TTS-beállításait, ha most nem hallja a hangot.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nem érhető el</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatikus nagyítás</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Távolság</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Megtekintés a térképen</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menü</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Honlap</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Hírek</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Visszajelzés</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Értékelje az alkalmazást</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Súgó</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>GYIK</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Adományozás</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Már adományozott</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Emlékeztessen később</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Támogassa az Organic Maps-et</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Támogatás</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Szerzői jogok</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Hibajelentés</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Javítsa a nyíl irányát az eszköz nyolcas mozgatásával az iránytű kalibrálásához.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mozgassa az eszközt egy nyolcas mozdulattal az iránytű kalibrálásához és a nyíl irányának rögzítéséhez a térképen.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Érintse meg újra hosszan a térképet a kezelőfelület megjelenítéséhez</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Összes frissítése</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Összes visszavonása</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Letöltve</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Várólistához adva</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>A közelben</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Térképek</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Összes letöltése</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Letöltés:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Állítsa le a navigációt a térkép törléséhez.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Útvonalakat csak akkor lehet készíteni, ha teljesen rajta vannak egy térképen.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Térkép letöltése</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Újra</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Térkép törlése</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Térkép frissítése</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play helymeghatározási szolgáltatások</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bluetooth, Wi-Fi vagy mobil-adatforgalom segítségével gyorsan meghatározhatja hozzávetőleges tartózkodási helyét</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Összes térkép letöltése az útvonal mentén</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Az útvonal létrehozásához le kell töltenie és frissítenie kell az összes térképet az Ön tartózkodási helyétől az úti céljáig.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nincs elegendő tárhely</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Kapcsolja be a helymeghatározási szolgáltatást</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Mentés</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>létrehozás</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Piros</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Sárga</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Kék</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zöld</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Lila</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Narancssárga</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Barna</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rózsaszín</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Mély lila</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Világoskék</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cián</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Zöldeskék</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Mély narancssárga</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Szürke</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Kékes szürke</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Információ</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Az Organic Maps verziója: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Megjelenés</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Világos</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Sötét</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Világos hajnaltól alkonyatig</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Egyéb</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Ajándékozzon ingyenes, hirdetésmentes térképeket felhasználók millióinak!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Hibás térképadatok jelentése vagy javítása</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Önkéntes</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Kövessen és lépjen kapcsolatba velünk:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Az e-mail kliens nem lett beállítva. Állítsa be, vagy lépjen kapcsolatba velünk a(z) %1 címen</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Hiba az e-mail küldése során</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Iránytű kalibrálása</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Elérhető</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Megtalálva</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Frissítés</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Sikertelen</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>könyvjelző</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Az útvonal követése során vegye figyelembe az alábbiakat:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>– Az útviszonyok, a közlekedési szabályok és a jelzőtáblák mindig elsőbbséget élveznek a navigációs útmutatással szemben;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>– A térkép pontatlan lehet és a javasolt útvonal lehetséges, hogy nem mindig a legoptimálisabb módja az úti cél elérésének;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>– A javasolt útvonalakat csupán ajánlottként kell tekinteni;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>– Legyen óvatos az útvonalakkal a határzónákban: az alkalmazásunk által létrehozott útvonalak néha nem engedélyezett helyeken léphetik át az országhatárokat.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Mindig maradjon éber és vezessen biztonságosan az utakon!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Ellenőrizze a GPS-jelet</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nem sikerült létrehozni az útvonalat. A jelenlegi GPS-koordináták nem azonosíthatók.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Ellenőrizze a GPS-jelet. A Wi-Fi engedélyezése javítja a helymeghatározási pontosságot.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Engedélyezze a helymeghatározási szolgáltatásokat</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>A jelenlegi GPS-koordináták nem találhatók. Engedélyezze a helymeghatározási szolgáltatásokat az útvonal kiszámításához.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Nem sikerült meghatározni az útvonalat</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Nem lehet létrehozni az útvonalat.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Pontosítsa a kiindulási pontot vagy az úti célt.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Pontosítsa a kiindulási pontot</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Az útvonal nem lett létrehozva. Nem sikerült meghatározni a kiindulási pontot.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Válasszon egy, az úthoz közelebb eső kiindulási pontot.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Pontosítsa az úti célt</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Az útvonal nem lett létrehozva. Nem sikerült meghatározni az úti célt.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Válasszon egy, az úthoz közelebb eső úti célt.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nem sikerült meghatározni a köztes célpontot.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Pontosítsa a köztes célpontot.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Rendszerhiba</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Nem lehet létrehozni az útvonalat egy alkalmazáshiba miatt.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Próbálja meg újra</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Most nem</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Szeretné letölteni a térképet, és egynél több térképen átívelő, optimálisabb útvonalat létrehozni?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Töltsön le további térképeket, hogy egy jobb útvonalat hozzon létre, amely keresztezi ennek a térképnek a határait.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Töltse le a szükséges fájlokat</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Az útvonaltervezéshez töltse le és frissítse az összes térkép- és útvonal-információt a tervezett út mentén.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Az útvonalak kereséséhez és létrehozásához, töltse le a térképet és többé nem lesz szüksége internetkapcsolatra.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Térkép kiválasztása</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Megjelenítés</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Elrejtés</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategóriák</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Előzmények</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Nincs eredmény.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Töltse le a keresett régiót, vagy próbálja meg hozzáadni egy közeli város vagy település nevét.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Keresési előzmények</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Legutóbbi keresések megtekintése.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>A keresési előzmények törlése</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Cikk a wikipedia.org-ról</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Saját tartózkodási hely</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Indítás</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Kiindulási pont</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Úti cél</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>A navigáció csak a jelenlegi tartózkodási helyétől érhető el.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Szeretne útvonalat tervezni a jelenlegi tartózkodási helyétől?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Következő</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Ettől</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Eddig</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Ütemterv hozzáadása</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Ütemterv törlése</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Egész nap (24 óra)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Nyitva</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zárva</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Zárvatartás hozzáadása</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Nyitvatartás</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Speciális mód</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Egyszerű mód</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Zárvatartás</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Példaértékek</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Hiba javítása</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Hely kiválasztása</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Írja le részletesen a problémát, hogy az OpenStreetMap csapata kijavíthassa.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Vagy javítsa ki Ön itt: https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Küldés</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Hibajegy</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>A hely nem létezik</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Karbantartás miatt nem érhető el</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplikált hely</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatikus térképletöltés</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Naponta</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Ma zárva</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Zárva</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Ma</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Kinyit %1 múlva</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Bezár %1 múlva</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zárva</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Nyitvatartás szerkesztése</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nem rendelkezik még felhasználói fiókkal az OpenStreetMapen?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Regisztráció az OpenStreetMap oldalon</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Bejelentkezés</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nincs bejelentkezve</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Jelentkezzen be az OpenStreetMap fiókjába</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Jelszó</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Elfelejtette a jelszavát?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Kijelentkezés</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Hely szerkesztése</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Nyelv hozzáadása</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Utca</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Házszám</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Részletek</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Közösségi média</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Épület</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Utca hozzáadása</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Adjon meg egy utcanevet</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Válasszon nyelvet</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Válasszon utcát</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Konyha</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Konyha kiválasztása</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mail-cím vagy felhasználónév</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Telefonszám hozzáadása</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Szint</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>%1. szint</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Az összes térképszerkesztés törlődik a térképpel együtt.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Térképek frissítése</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Az útvonal létrehozásához frissítenie kell az összes térképet, majd újra meg kell terveznie az útvonalat.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Térkép keresése</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Győződjön meg arról, hogy az eszköz csatlakozik az internethez.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nincs elegendő tárhely</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Törölje a felesleges adatokat</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Bejelentkezési hiba.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Jóváhagyott módosítás</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Húzza a térképet, hogy a keresztet a hely vagy üzlet helyére helyezze.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Szerkesztés</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Hozzáadás</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Hely neve</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Ahogyan az, a helyi nyelven írva van</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategória</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>A probléma részletes leírása</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Más jellegű probléma</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Vállalkozás hozzáadása</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Itt nem található objektum</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>A közösségi OpenStreetMap adatok frissítésének időpontja: %1. Tudjon meg többet a térkép szerkesztéséről és frissítéséről az OpenStreetMap.org oldalon</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>Az OpenStreetMap.org (OSM) egy közösségi projekt, amelynek célja egy ingyenes és nyílt térkép létrehozása. Ez az Organic Maps alkalmazás térképadatainak fő forrása, és a Wikipédiához hasonlóan működik. Helyeket adhat hozzá vagy szerkeszthet, és azok világszerte felhasználók milliói számára válnak elérhetővé.&#32;
+Csatlakozzon a közösséghez, és segítsen egy jobb térképet készíteni mindenki számára!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Hozzon létre egy fiókot az OpenStreetMapen, vagy jelentkezzen be, hogy közzétehesse térképszerkesztéseit a világ számára.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 / %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Biztosan letölti mobiladat-forgalom használatával?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Ez egyes díjcsomagok vagy roaming esetén jelentős költségekkel járhat.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Adjon meg egy érvényes házszámot</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Emeletek száma (legfeljebb: %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Ez az épület legfeljebb %1 emeletes lehet</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Irányítószám</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Adjon meg egy érvényes irányítószámot</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Megjegyzés az OpenStreetMap közreműködőinek (nem kötelező)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Írja le a térképen található hibákat vagy olyan dolgokat, amelyeket nem lehet az Organic Maps segítségével szerkeszteni</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>A szerkesztései feltöltődnek a nyilvános &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Hu:Névjegy&quot;&gt;OpenStreetMap&lt;/a&gt; adatbázisba. Ne adjon hozzá személyes vagy szerzői jogvédelem alatt álló információkat.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>További részletek az OpenStreetMap adatbázisról</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Saját szerkesztési előzmények</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Saját térképadat-jegyzetek</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Üzemeltető</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Üzemeltető: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nem találja a megfelelő kategóriát?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Az Organic Maps csak egyszerű pontkategóriák hozzáadását teszi lehetővé, azaz nem tartalmaz városokat, utakat, tavakat, épületek körvonalait stb., az ilyen kategóriákat közvetlenül az &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; oldalon adhatja hozzá. A részletes, lépésről lépésre történő útmutatásért tekintse meg az &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;útmutatónkat&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Még nem töltött le térképet</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Térképek letöltése az offline kereséshez és navigáláshoz.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>A jelenlegi tartózkodási hely ismeretlen.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/ó</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mf/ó</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ó</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>p</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>nap</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>mp</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Tovább</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Könyvjelző szerkesztése</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Személyes jegyzetek (szöveg vagy html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Megjegyzés…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Elveti az összes módosítást?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Elvetés</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Töröl egy hozzáadott helyet?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Törlés</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>A hely nem létezik</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Adja meg a hely törlésének okát</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Adjon megy egy érvényes telefonszámot</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Adjon meg egy érvényes weboldalcímet</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Adjon meg egy érvényes e-mail-címet</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Adjon meg egy érvényes Facebook-webcímet, fiók- vagy oldalnevet</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Adjon meg egy érvényes Instagram felhasználónevet vagy webcímet</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Adjon meg egy érvényes X (Twitter) felhasználónevet vagy webcímet</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Adjon meg egy érvényes VK felhasználónevet vagy webcímet</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Adjon meg egy érvényes LINE ID-t vagy webcímet</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Hely hozzáadása az OpenStreetMap adatbázishoz</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Vagy írjon egy jegyzetet az OpenStreetMap közösségnek, hogy valaki más hozzáadhassa vagy kijavíthassa ezt a helyet.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>A jegyzet fel lesz töltve az OpenStreetMapre</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Szeretné elküldeni az összes felhasználónak?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Győződjön meg arról, hogy nem ad meg semmilyen személyes információt.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Az OpenStreetMap szerkesztői ellenőrzik a változásokat, és felveszik Önnel a kapcsolatot, ha kérdéseik vannak.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Megállítás</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Nyomvonal rögzítése</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Elfogadás</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Elutasítás</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Mobiladat-forgalom használata a részletes információk megjelenítéséhez?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Mindig használja</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Csak ma</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ma ne használja</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiladat-forgalom</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Internetkapcsolatra van szükség a térképfrissítési értesítésekhez, valamint a helyekre és könyvjelzőkre vonatkozó részletes információk megjelenítéséhez.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Soha ne használja</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Mindig kérdezzen rá</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Forgalmi adatok megjelenítéséhez frissíteni kell a térképeket.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Betűméret növelése a térképen</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Frissítse az Organic Maps alkalmazást</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Forgalmi adatok nem állnak rendelkezésre</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Naplózás engedélyezése</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Általános visszajelzés</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Az Organic Maps TTS-rendszert használ a hangnavigációhoz. Sok androidos eszköz használja a Google TTS-t; töltse le vagy frissítse a Google Play áruházból</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Egyes nyelveknél másik beszédszintetizátort vagy további nyelvi csomagot kell telepítenie az alkalmazás-áruházból (Google Play, Galaxy Store, App Gallery, FDroid).&#32;
+Nyissa meg az eszköz beállításait → Nyelv és bevitel → Beszéd → Szöveg-beszéd átalakító kimenet.&#32;
+Itt kezelheti a beszédszintézis beállításokat (például: nyelvi csomag letöltése a kapcsolat nélküli használathoz) és másik szövegfelolvasót jelölhet ki.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>További tájékoztatást találhat még ebben az útmutatóban.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Átírás latin betűkre</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Tudjon meg többet</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Használja a keresést, válasszon ki egy könyvjelzőt vagy koppintson a térképre az útvonal kiindulási pontjának hozzáadásához</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Használja a keresést, válasszon ki egy könyvjelzőt vagy koppintson a térképre egy úti cél hozzáadásához</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Útvonal kezelése</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Tervezés</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Megálló eltávolítása</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Köztes célpont hozzáadása</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Mentve</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Jelentkezzen be az OpenStreetMap rendszerébe, hogy automatikusan feltölthesse az összes térképszerkesztését. További információ &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;itt&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Tárhelyhozzáférési probléma</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Külső tárhely nem áll rendelkezésre, valószínűleg az SD-kártyát eltávolították vagy sérült, vagy rendszerfájl csak olvasható. Ellenőrizze, és lépjen kapcsolatba velünk a support@organicmaps.app címen</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Sérült tároló emulálása</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Adjon meg egy érvényes nevet</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listák</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Összes elrejtése</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Összes megjelenítése</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n könyvjelző</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Új lista létrehozása</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Könyvjelzők és nyomvonalak importálása</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nem lehet megosztani egy alkalmazáshiba miatt</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Megosztási hiba</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Üres lista nem osztható meg</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>A név nem lehet üres</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Adja meg a lista nevét</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Új lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ez a név már foglalt</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Válasszon másik nevet</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Kis türelmet…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonszám</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fájl található. Látni fogja azokat a konvertálás után.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Visszaállítás</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n nyomvonal</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Adatvédelem</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Adatvédelmi irányelvek</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Felhasználási feltételek</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Forgalom</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Túrázás</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Kerékpározás</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metró</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Térképstílusok és rétegek</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Ez a lista üres</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Egy könyvjelző hozzáadásához érintsen meg a térképen egy helyet, majd érintse meg a csillag ikont</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Összes könyvjelző színének módosítása</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Összes nyomvonal színének módosítása</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…több</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportálás KMZ-fájlba</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportálás GPX-fájlba</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportálás GeoJSON-fájlba</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Lista törlése</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Sebességmérő kamerák</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>A hely ismertetése</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Térképletöltő</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Gyorshajtáskor figyelmeztessen</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Mindig figyelmeztessen</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Soha ne figyelmeztessen</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energiatakarékos mód</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Próbálja meg csökkenteni az energiafelhasználást bizonyos funkciók rovására.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Soha</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Amikor az akkumulátor lemerül</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Mindig</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nevek könyvjelzőzése a térképen</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ha túl sok könyvjelző van, azok neveinek megjelenítése a térképen lelassíthatja az alkalmazást.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Megjelenítés jobb oldalon</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Megjelenítés alul</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Ha ideiglenesen engedélyezi ezt a beállítást, akkor a „Súgó” párbeszédpanel „Hibajelentés” menüpontjának használatával rögzítheti és kézzel küldheti el nekünk a problémával kapcsolatos részletes diagnosztikai naplókat. A naplók tartalmazhatnak helyadatokat.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Útvonaltervezési beállítások</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Díjköteles utak elkerülése</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Burkolatlan utak elkerülése</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Kompátkelők elkerülése</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Autópályák elkerülése</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nem lehet kiszámítani az útvonalat</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Nem sikerült útvonalat találni. Ennek oka lehet az útvonaltervezési beállítások vagy a hiányos OpenStreetMap-adatok. Módosítsa az útvonaltervezési beállításokat, és próbálja meg újra.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Elkerülendő utak meghatározása</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Útvonaltervezési beállítások engedélyezve</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Díjköteles utak</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Burkolatlan utak</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Kompátkelők</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Igen</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nem</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Igen</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nem</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapacitás: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Hálózat: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Megérkezett!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Rendezés…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Könyvjelzők rendezése</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Alapértelmezés szerint</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Típus szerint</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Távolság szerint</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Dátum szerint</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Név szerint</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Egy hete</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Egy hónapja</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Több mint egy hónapja</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Több mint egy éve</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>A közelben</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Egyebek</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Sikertelen útvonaltervezés</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Érkezés: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Töltse le és frissítse az összes térképet a tervezett útvonal mentén az útvonal kiszámításához.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Módosította a világtérképet! Ne tartsa meg magának, mondja el a barátainak, és szerkesszék azt közösen.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Ossza meg a barátaival</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Most zárva</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Holnap ekkor nyit: %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Nyitva ekkortól: %1 eddig: %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Kinyit ekkor: %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Bezár ekkor: %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Nyitvatartás hozzáadása</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Jelszó (legalább 8 karakter)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Érvénytelen felhasználónév vagy jelszó.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-fiók</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Utolsó frissítés</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Köszönjük</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Hely neve</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefonszám</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Megjegyzés</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Letöltési hiba</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Válasszon kategóriát</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Népszerű</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Összes kategória</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Új helyek hozzáadása a térképhez, és a meglévők szerkesztése közvetlenül az alkalmazásból.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Helyszín módosítása</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>A letöltéshez több szabad tárhelyre van szükség. Törölje a szükségtelen adatokat.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Fejlesztettem a Organic Maps térképeket</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Részletes megjegyzés</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Az Ön által javasolt térképmódosításokat elküldjük az OpenStreetMap közösségnek. Írja le azokat a további részleteket, amelyek nem szerkeszthetők az Organic Mapsben.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Hiba történt tartózkodási helye keresésekor. Ellenőrizze készüléke működését és próbálkozzon újra.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Helymeghatározás kikapcsolva</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Engedélyezze a hozzáférést a földrajzi helymeghatározáshoz a készülék beállításaiban</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Nyissa meg a „Beállítások” menüt</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Érintse meg a „Helymeghatározás” gombot</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Válassza az „Alkalmazás használata közben” lehetőséget</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Válassza az „Adatvédelem” menüpontot</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Válassza a „Helymeghatározási szolgáltatások” menüpontot</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Engedélyezze a „Helymeghatározási szolgáltatások lehetőséget</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Vagy folytassa az Organic Maps használatát helymeghatározás nélkül</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Foglalás</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Hívás</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Könyvjelző neve</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Könyvjelző törlése</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Az Ön megjegyzése el lesz küldve az OpenStreetMapnek</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…több</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Frissítés</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Megszakítod a legutóbb megtett utad rögzítését?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Letiltás</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Tekintse meg</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Az Organic Maps a háttérben az Ön tartózkodási helyét használja a nemrég megtett útvonal rögzítéséhez.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Általános beállítások</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>A forgalmi adatok megjelenítéséhez frissíteni kell az alkalmazást.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Naplófájl mérete: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Húzza ide az eltávolításhoz</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Megálló lecserélése</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Kiindulás innen</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Jelentkezzen be az OpenStreetMap rendszerébe, hogy automatikusan feltölthesse az összes térképszerkesztését. Tudjon meg többet</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>itt</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Kijelző elrejtése</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 letöltése…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 alkalmazása…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ez a név túl hosszú</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Új fájlok lettek észlelve</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Átalakítás</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Hiba</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Egyes fájlok nem lettek átalakítva.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Hiba történt</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Népszerű</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Elrejtés a térképről</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Hiba történt a címkék betöltése közben, próbálja meg újra</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Jobb</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Alul</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Gyerünk</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Célállomás</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Középre</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Keresési eredmények</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Utána</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Szeretné újratervezni az útvonalat?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>A billentyűzet nem érhető el vezetés közben</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Nem lehet útvonalat tervezni a jelenlegi helyről</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nem található útvonal a célállomáshoz. Válasszon egy másik célállomást</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nem található GPS-jel. Menjen egy nyílt területre</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nem sikerült útvonalat tervezni. Adjon meg más útvonalpontokat</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Útvonal létrehozásához tölts le a hiányzó térképeket az eszközére</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Hiba történt. Indítsa újra az alkalmazást</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Az útvonal újra lesz tervezve a jelenlegi helyéről</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Az útvonal autós útvonallá lesz átalakítva</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nem jelenik meg az összes könyvjelző</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Váltson telefonra az összes könyvjelző megtekintéséhez</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Sebességmérő kamerák</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Sebességfigyelmeztetések</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Töltsön le térképeket az alkalmazásban az eszközére</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 kijárat</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Alapértelmezés szerint</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Típus szerint</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Távolság szerint</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Dátum szerint</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Név szerint</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Étel</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Látnivalók</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Múzeumok</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parkok</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Úszás</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Hegyek</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Állatok</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotelek</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Épületek</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Pénz</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Üzletek</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkolók</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzinkutak</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Gyógyszer</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Keresés a listában</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Vallási helyek</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Lista kiválasztása</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metrónavigáció ebben a régióban még nem érhető el</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Nem található metróútvonal</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Válasszon egy, a metróállomáshoz közelebb eső kiindulási pontot vagy úti célt</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Szintvonalak</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>A szintvonalak aktiválásához a terület térképadatainak letöltése szükséges</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>A szintvonalak még nem állnak rendelkezésre ezen a területen</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Növekvő</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Csökkenő</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Legkisebb magasság</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Legnagyobb magasság</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Nehézség</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Távolság:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Idő:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Nagyítás az izovonalak felfedezéséhez</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Letöltés</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Áttekintő világtérkép letöltése</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nem lehet mappát létrehozni és fájlokat áthelyezni az eszköz belső memóriájában vagy az SD-kártyán</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Lemezhiba</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Kapcsolódási hiba</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB-kábel leválasztása</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Képernyő bekapcsolva tartása</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Ha engedélyezve van, a képernyő mindig be lesz kapcsolva a térkép megjelenítésekor.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Megjelenítés a zárolt képernyőn</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Ha engedélyezve van, nem kell minden alkalommal feloldania az eszközt, amíg az alkalmazás fut.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Térkép nyelve</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Térképadatok az OpenStreetMap adatbázisából</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/hu/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/hu/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Hu:Névjegy</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Köszönjük, hogy használja a közösség által készített térképeinket!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Adományaival és támogatásával létrehozhatjuk a világ legjobb térképes alkalmazását!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Tetszik az alkalmazásunk? Adományozzon, hogy támogassa a fejlesztést! – Mégsem tetszik? Jelezze felénk, hogy miért nem, és mi kijavítjuk!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ha ismer egy szoftverfejlesztőt, megkérheti őt egy olyan funkció megvalósítására, amelyre szüksége van.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Koppintson a térképen bárhová, hogy bármit kiválaszthasson. Hosszú koppintással elrejtheti és visszahozhatja a felületet.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Tudja, hogy kijelölheti pozícióját a térképen?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Segítsen lefordítani az alkalmazást az Ön nyelvére.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Ezt az alkalmazást néhány lelkes közreműködő és a közösség fejleszti.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Könnyedén javíthatja a térképadatokat.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>A fő célunk az, hogy gyors, az adatvédelemre fókuszáló, könnyen használható térképeket készítsünk, amelyeket szeretni fog.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Ön most az Organic Maps alkalmazást használja az eszköz képernyőjén</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ön most az Organic Maps alkalmazást használja az autó képernyőjén</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Ön kapcsolódik az Android Auto rendszerhez</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Folytatás a hordozható eszközön</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Az autó képernyőjére</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Az Organic Maps alkalmazásnak szüksége van a helymeghatározáshoz való hozzáférésre. Ha biztonságos, ellenőrizze az értesítést az eszközén.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ennek az alkalmazásnak szüksége van az Ön engedélyére</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Az Organic Maps az Android Autoban helymeghatározási engedélyeket igényel a hatékony működéshez</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Engedélyek megadása</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Kültéri</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>A webböngésző nem érhető el</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Hangerő</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Összes könyvjelző és nyomvonal exportálása</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Beszédszintézis-beállítások</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>A beszédszintézis-beállítások nem találhatók, biztos benne, hogy az eszköze támogatja?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Autós kiszolgálás</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Törölje a keresést</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Nagyítás</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Kicsinyítés</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menühivatkozás</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Menü megtekintése</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Megnyitás másik alkalmazásban</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Önkiszolgáló</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Válasszon ki egy beállítást</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Kiülős helyek</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>A legpontosabb navigáció érdekében javasoljuk az energiatakarékos üzemmód kikapcsolását az eszköz akkumulátor-beállításaiban.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Nyomvonal rögzítése</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Nyomvonal rögzítésének megállítása</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Nyomvonal rögzítése</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Megállítás mentés nélkül</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Rögzítés folytatása</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Menti a könyvjelzők és nyomvonalakba?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>A nyomvonal üres – nincs mit menteni</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nem lehet megjeleníteni a mappaválasztó párbeszédpanelt, mert nincs megfelelő alkalmazás telepítve az eszközén. Telepítsen egy fájlkezelő alkalmazást, és próbálja meg újra.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Válasszon színt</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Nyomvonal szerkesztése</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nincs telepített alkalmazás, amely meg tudja nyitni a helyet</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automatikus navigáció</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Rendszer követése</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Nyomvonal megosztása</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Törli %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nehézségi szint</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Könnyű</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mérsékelt</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Nehéz</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Frissítés</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Letöltött térképek frissítése</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>A térképek frissítésével naprakészen tarthatja az objektumokra vonatkozó adatokat</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Frissítés (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Kézi frissítés később</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Nyomvonal törlése</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Biztosan törölni szeretné ezt a nyomvonalat?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nyomvonal neve</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Áthelyezés</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Nyomvonal</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Szín módosítása</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Térkép</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Szeretne hibajelentést küldeni a fejlesztőknek?
+A felhasználóinkra támaszkodunk, mivel az Organic Maps nem gyűjt automatikusan hibainformációkat. Előre is köszönjük, hogy támogatja az Organic Maps csapatát!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud-szinkronizálás engedélyezése</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Az iCloud-szinkronizálás egy fejlesztés alatt álló kísérleti funkció. Győződjön meg arról, hogy készített biztonsági másolatot az összes könyvjelzőjéről és nyomvonaláról.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>Az iCloud le van tiltva</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>A funkció használatához engedélyezze az iCloudot a készülék beállításaiban.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Engedélyezés</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Biztonsági mentés</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-szinkronizálási hiba</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Hiba: Nem sikerült szinkronizálni egy kapcsolati hiba miatt</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Hiba: Nem sikerült szinkronizálni az iCloud-kvóta túllépése miatt</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Hiba: Az iCloud nem elérhető</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nemrég törölt listák</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Törlés</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Összes törlése</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Visszaállítás</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Összes visszaállítása</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Hozzájárulás az OpenStreetMaphez</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Hely hozzáadása</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Frissítse a térképet a hozzájáruláshoz</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>A hozzájáruláshoz frissítenie kell a %1 térképet a legújabb verzióra az OpenStreetMap adataihoz</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Saját pozícióm</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Saját helyeim</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Belső privát tárhely</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Belső közös tárhely</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kártya</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Külső közös tárhely</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wi-Fi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Irányítószám</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Térképpont</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mf</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>láb</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Az útvonalak megjelenítéséhez frissíteni kell a térképeket.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Kijárat</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Bejárat</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>A metrótérkép nem érhető el</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ön</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Lila színnel jelölt letöltött régiók</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Útvonal</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>A helymeghatározás a háttérben szükséges ahhoz, hogy teljes mértékben élvezhesse az alkalmazás funkcióit. A navigációhoz és a nemrég megtett útvonal mentéséhez használatos.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>A navigációhoz és a legutóbb megtett útvonal mentéséhez szükséges a helymeghatározás.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Bejelentkezés jelszóval</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Bejelentkezés böngésző használatával</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Legutóbb használt</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>A könyvjelzők színe megváltozott</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>A nyomvonalak színe megváltozott</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Csúszkák</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>PIROS</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZÖLD</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex szín #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rács</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/hy/omim.ts
+++ b/qt/translations/hy/omim.ts
@@ -1,0 +1,3932 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="hy">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Հետ</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Չեղարկել</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Ջնջել</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Ներբեռնել քարտեզներ</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Ներբեռնումը ձախողվեց: Հպեք՝ նորից փորձելու համար:</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Ներբեռնում…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Կիլոմետրեր</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Մղոններ</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Ավելի ուշ</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Որոնում</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Որոնում քարտեզի վրա</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Ձեր սարքում կամ հավելվածում անջատված են տեղորոշման բոլոր ծառայությունները: Խնդրում ենք միացնել դրանք Կարգավորումներում:</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Սահմանափակ ճշգրտություն</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Ճշգրիտ նավիգացիայի համար միացրեք «Ճշգրիտ տեղորոշումը» կարգավորումներում:</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Ցուցադրել քարտեզի վրա</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Ներբեռնումը ձախողվեց</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Փորձել նորից</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps-ի մասին</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Անվճար բոլորի համար՝ պատրաստված սիրով</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Ոչ մի գովազդ, հետևում կամ տվյալների հավաքագրում</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Չի սպառում մարտկոցը, աշխատում է օֆլայն</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Արագ, մինիմալիստական, մշակված համայնքի կողմից</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Էնտուզիաստների և կամավորների կողմից ստեղծված բաց կոդով հավելված:</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Տեղորոշման կարգավորումներ</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Փակել</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Հավելվածը պահանջում է ապարատային արագացմամբ OpenGL: Ցավոք, ձեր սարքը չի աջակցվում:</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Ներբեռնել</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps-ից օգտվելու համար խնդրում ենք անջատել USB մալուխը կամ տեղադրել հիշողության քարտը</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Հավելվածից օգտվելու համար խնդրում ենք ազատել տեղ SD քարտի/USB կրիչի վրա</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Նախքան հավելվածից օգտվելը, խնդրում ենք ներբեռնել աշխարհի ընդհանուր քարտեզը.
+Այն կզբաղեցնի %1 հիշողություն:</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Անցնել քարտեզին</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Ներբեռնվում է %1: Այժմ կարող եք
+անցնել քարտեզին:</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Ներբեռնե՞լ %1-ը:</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Թարմացնե՞լ %1-ը:</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Դադար</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Շարունակել</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1: ներբեռնումը ձախողվեց</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Ավելացնել նոր ցուցակ</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Էջանիշների ցուցակի անունը</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Էջանիշներ</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Էջանիշներ և հետագծեր</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Անուն</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Հասցե</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Ցուցակ</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Կարգավորումներ</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Պահպանել քարտեզները՝</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Ընտրեք պանակը, որտեղ ներբեռնվելու են քարտեզները:</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Ներբեռնված քարտեզներ</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 ազատ է %2-ից</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Տեղափոխե՞լ քարտեզները:</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Քարտեզի ֆայլերի տեղափոխման սխալ</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Դա կարող է տևել մի քանի րոպե.
+Խնդրում ենք սպասել…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Չափման միավորներ</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Ընտրեք մղոնների և կիլոմետրերի միջև</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Չեղարկել ներբեռնումը</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Թողնել կարծիք</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Այո</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Ներբեռնել քարտեզը</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Էջանիշների ցուցակներ</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Որտեղ սնվել</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Մթերային</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Տրանսպորտ</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Վառելիք</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Կայանատեղի</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Գնումներ</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Սեքենդ Հենդ</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Հյուրանոց</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Տեսարժան վայրեր</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Ժամանց</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Բանկոմատ</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Գիշերային կյանք</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Ընտանեկան հանգիստ</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Բանկ</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Դեղատուն</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Հիվանդանոց</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Զուգարան</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Փոստ</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Ոստիկանություն</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Վերամշակում</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Ջուր</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Քեմփինգներ</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Նշումներ</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Ձեզ հետ կիսվել են Organic Maps-ի էջանիշներով</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Ողջույն!
+Կից ներկայացված են իմ էջանիշները: Խնդրում եմ բացել դրանք Organic Maps-ում: Եթե այն տեղադրված չէ, կարող եք ներբեռնել այստեղ՝ https://omaps.app/get?kmz
+Վայելեք ճանապարհորդությունը Organic Maps-ի հետ:</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Էջանիշների բեռնում</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Էջանիշները հաջողությամբ բեռնվեցին: Դուք կարող եք գտնել դրանք քարտեզի վրա կամ «Էջանիշների կառավարիչ» էկրանին:</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Չհաջողվեց բեռնել էջանիշները: Ֆայլը կարող է վնասված կամ անսարք լինել:</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Ֆայլի տեսակը չի ճանաչվել հավելվածի կողմից՝
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Չհաջողվեց բացել %1 ֆայլը
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Խմբագրել</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ձեր տեղորոշումը դեռ չի որոշվել</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Ներեցեք, քարտեզների պահպանման կարգավորումները ներկայումս անջատված են:</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Քարտեզի ներբեռնումն ընթացքի մեջ է:</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Տես իմ ընթացիկ դիրքը Organic Maps-ում: %1 կամ %2 Չունե՞ք օֆլայն քարտեզներ: Ներբեռնեք այստեղ՝ https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Հեյ, տես իմ նշումը Organic Maps-ում:</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Հեյ, տես իմ ընթացիկ դիրքը Organic Maps քարտեզի վրա:</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Ողջույն,
+
+Ես հիմա այստեղ եմ՝ %1: Սեղմեք այս հղմանը՝ %2 կամ սրան՝ %3, տեղանքը քարտեզի վրա տեսնելու համար.
+
+Շնորհակալություն.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Կիսվել</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Էլ․ փոստ</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Պատճենված է սեղմատախտակին՝ %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Պատրաստ է</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap տվյալներ՝ %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Վստա՞հ եք, որ ցանկանում եք դուրս գալ ձեր OpenStreetMap հաշվից:</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Հետագծեր</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Երկարություն</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Կիսվել իմ տեղադիրքով</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Ընդհանուր կարգավորումներ</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Տեղեկություն</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Նավիգացիա</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>«+» և «-» կոճակները քարտեզի վրա</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Ցուցադրել քարտեզի վրա</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Գիշերային ոճ մթության մեջ վարելիս</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Գիշերային ռեժիմ</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Անջատված</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Միացված</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Ավտոմատ</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Հեռանկարային տեսք</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D շենքեր</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D շենքերն անջատված են էներգախնայողության ռեժիմում</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Ձայնային հրահանգներ</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Հայտարարել փողոցների անունները</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Միացված լինելու դեպքում, փողոցի անունը կամ շրջադարձի ելքը կհնչեցվի բարձրաձայն:</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Ձայնի լեզուն</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Ավելի բարձր որակի ձայն ներբեռնելու համար բացեք Կարգավորումներ հավելվածը և անցեք Մատչելիություն → VoiceOver → Խոսք → Ձայն։</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Փորձարկել ձայնային ուղղորդումը (TTS)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Ստուգեք ձայնի ուժգնությունը կամ համակարգի Text-To-Speech կարգավորումները, եթե հիմա ձայն չեք լսում:</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Անհասանելի է</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Ավտոմատ խոշորացում</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Հեռավորություն</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Դիտել քարտեզի վրա</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Մենյու</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Կայք</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Նորություններ</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Հետադարձ կապ</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Գնահատել հավելվածը</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Օգնություն</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Հաճախ տրվող հարցեր</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Նվիրաբերել</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Արդեն նվիրաբերել եմ</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Հիշեցնել ավելի ուշ</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Աջակցել Organic Maps-ին</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Աջակցել նախագծին</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Հեղինակային իրավունք</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Հայտնել սխալի մասին</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Նետի ուղղությունը բարելավելու համար հեռախոսը շարժեք ութաձև՝ կողմնացույցը կարգաբերելու նպատակով:</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Հեռախոսը շարժեք ութաձև՝ կողմնացույցը կարգաբերելու և քարտեզի վրա նետի ուղղությունը ուղղելու համար:</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Կրկին երկար սեղմեք քարտեզին՝ ինտերֆեյսը տեսնելու համար</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Թարմացնել բոլորը</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Չեղարկել բոլորը</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Ներբեռնված են</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Հերթագրված է</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Իմ մոտակայքում</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Քարտեզներ</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Ներբեռնել բոլորը</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Ներբեռնվում է՝</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Քարտեզը ջնջելու համար խնդրում ենք դադարեցնել նավիգացիան:</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Երթուղիները կարող են ստեղծվել միայն մեկ տարածաշրջանի քարտեզի սահմաններում:</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Ներբեռնել քարտեզը</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Կրկնել</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Ջնջել քարտեզը</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Թարմացնել քարտեզը</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Տեղորոշման ծառայություններ</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Արագ որոշեք ձեր մոտավոր տեղորոշումը Bluetooth-ի, WiFi-ի կամ բջջային ցանցի միջոցով</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Ներբեռնել ձեր երթուղու երկայնքով բոլոր քարտեզները</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Երթուղի ստեղծելու համար մենք պետք է ներբեռնենք և թարմացնենք բոլոր քարտեզները՝ ձեր գտնվելու վայրից մինչև նպատակակետ:</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Բավարար տեղ չկա</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Խնդրում ենք միացնել տեղորոշման ծառայությունները</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Պահպանել</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>ստեղծել</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Կարմիր</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Դեղին</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Կապույտ</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Կանաչ</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Մանուշակագույն</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Նարնջագույն</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Շագանակագույն</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Վարդագույն</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Մուգ մանուշակագույն</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Բաց կապույտ</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Երկնագույն</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Փիրուզագույն</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Լայմ</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Մուգ նարնջագույն</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Մոխրագույն</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Կապտամոխրագույն</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Տեղեկություն</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps-ի տարբերակ՝ %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Արտաքին տեսք</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Լուսավոր</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Մուգ</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Բաց թեմա լուսաբացից մինչև մթնշաղ</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Այլ</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Նվիրեք անվճար և առանց գովազդի քարտեզներ միլիոնավոր օգտատերերի:</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Հայտնել կամ ուղղել քարտեզի սխալ տվյալները</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Կամավոր</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Հետևեք և կապվեք մեզ հետ՝</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Էլ. փոստի հավելվածը կարգավորված չէ: Խնդրում ենք կարգավորել այն կամ կապվել մեզ հետ՝ %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Էլ. նամակի ուղարկման սխալ</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Կողմնացույցի կարգաբերում</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Հասանելի</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Գտնված</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Թարմացնել</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Ձախողվեց</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>էջանիշ</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Երթուղով շարժվելիս հիշեք՝</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Ճանապարհային պայմանները, երթևեկության կանոնները և նշանները միշտ ավելի կարևոր են, քան նավիգացիայի հուշումները;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Քարտեզը կարող է անճիշտ լինել, իսկ առաջարկվող երթուղին միշտ չէ, որ նպատակակետ հասնելու լավագույն տարբերակն է;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Առաջարկվող երթուղիները պետք է ընկալել միայն որպես խորհուրդ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Զգույշ եղեք սահմանամերձ գոտիներում երթուղիների հետ. հավելվածի կողմից ստեղծված երթուղիները երբեմն կարող են հատել պետական սահմանները չթույլատրված վայրերում:</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Խնդրում ենք լինել ուշադիր և զգույշ ճանապարհներին:</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Ստուգեք GPS ազդանշանը</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Հնարավոր չէ կառուցել երթուղին։ Ընթացիկ GPS կոորդինատները չեն որոշվել:</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Խնդրում ենք ստուգել GPS ազդանշանը: Wi-Fi-ի միացումը կբարելավի տեղորոշման ճշգրտությունը:</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Միացնել տեղորոշման ծառայությունները</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Հնարավոր չէ որոշել ընթացիկ GPS կոորդինատները։ Միացրեք տեղորոշման ծառայությունները՝ երթուղին հաշվարկելու համար:</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Երթուղին չի գտնվել</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Հնարավոր չէ կառուցել երթուղին:</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Խնդրում ենք փոխել մեկնարկային կետը կամ նպատակակետը:</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Փոխել մեկնարկային կետը</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Երթուղին չի կառուցվել։ Հնարավոր չէ գտնել մեկնարկային կետը:</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Խնդրում ենք ընտրել ճանապարհին ավելի մոտ մեկնարկային կետ:</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Փոխել նպատակակետը</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Երթուղին չի կառուցվել։ Հնարավոր չէ գտնել նպատակակետը:</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Խնդրում ենք ընտրել ճանապարհին ավելի մոտ նպատակակետ:</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Հնարավոր չէ գտնել միջանկյալ կետը:</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Խնդրում ենք փոխել միջանկյալ կետը:</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Համակարգային սխալ</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Հնարավոր չէ կառուցել երթուղին ծրագրային սխալի պատճառով:</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Խնդրում ենք փորձել կրկին</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ոչ հիմա</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Ցանկանո՞ւմ եք ներբեռնել քարտեզը և կառուցել ավելի օպտիմալ երթուղի, որն անցնում է մեկից ավելի քարտեզներով:</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Ներբեռնեք լրացուցիչ քարտեզներ՝ ավելի լավ երթուղի կառուցելու համար, որն անցնում է այս քարտեզի սահմաններից դուրս:</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Ներբեռնել պահանջվող ֆայլերը</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Ներբեռնեք կամ թարմացրեք երթուղու երկայնքով բոլոր քարտեզները՝ երթուղին հաշվարկելու համար:</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Որոնման և երթուղիների կառուցման համար խնդրում ենք ներբեռնել քարտեզը: Դրանից հետո ինտերնետ կապ այլևս չի պահանջվի:</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Ընտրել քարտեզը</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Ցուցադրել</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Թաքցնել</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Կատեգորիաներ</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Պատմություն</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ոչինչ չգտնվեց:</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Ներբեռնեք այն տարածաշրջանի քարտեզը, որտեղ որոնում եք կատարում, կամ փորձեք ավելացնել մոտակա քաղաքի/գյուղի անունը:</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Որոնման պատմություն</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Դիտեք ձեր վերջին որոնումները:</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Մաքրել որոնման պատմությունը</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Վիքիպեդիա</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Հոդված wikipedia.org-ից</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Վիքիպահեստ</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Ձեր գտնվելու վայրը</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Սկիզբ</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Երթուղի այստեղից</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Երթուղի դեպի այստեղ</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Նավիգացիան հասանելի է միայն ձեր ընթացիկ վայրից:</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Ցանկանո՞ւմ եք կառուցել երթուղի ձեր ընթացիկ վայրից:</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Հաջորդը</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Սկիզբ</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Ավարտ</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Ավելացնել գրաֆիկ</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Ջնջել գրաֆիկը</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Շուրջօրյա (24 ժամ)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Բաց է</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Փակ է</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Ավելացնել ոչ աշխատանքային ժամերը</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Աշխատանքային ժամեր</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Ընդլայնված ռեժիմ</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Պարզ ռեժիմ</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Ոչ աշխատանքային ժամեր</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Օրինակելի արժեքներ</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Ուղղել սխալը</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Ընտրել վայրը</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Խնդրում ենք մանրամասն նկարագրել խնդիրը, որպեսզի OpenStreetMap համայնքը կարողանա ուղղել այն:</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Կամ արեք դա ինքներդ https://www.openstreetmap.org/ կայքում</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Ուղարկել</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Խնդիր</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Այս վայրը գոյություն չունի</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Փակ է վերանորոգման համար</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Կրկնվող վայր</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Քարտեզների ավտոմատ ներբեռնում</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Ամեն օր</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Այսօր փակ է</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Փակ է</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Այսօր</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Բացվում է %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Փակվում է %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Փակ է</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Խմբագրել աշխատանքային ժամերը</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Չունե՞ք OpenStreetMap հաշիվ:</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Գրանցվել OpenStreetMap-ում</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Մուտք</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Մուտք չեք գործել</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Մուտք OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Գաղտնաբառ</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Մոռացե՞լ եք գաղտնաբառը:</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Դուրս գալ</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Խմբագրել վայրը</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Ավելացնել լեզու</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Փողոց</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Շենքի համարը</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Մանրամասներ</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Սոցիալական ցանցեր</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Շենք</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Ավելացնել փողոց</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Խնդրում ենք մուտքագրել փողոցի անունը</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Ընտրեք լեզուն</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Ընտրեք փողոցը</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Խոհանոց</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Ընտրել խոհանոց</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Էլ․ փոստ կամ օգտանուն</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Ավելացնել հեռախոսահամար</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Հարկ</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Հարկ՝ %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Քարտեզի հետ կջնջվեն նաև ձեր բոլոր խմբագրումները:</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Թարմացնել քարտեզները</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Երթուղի կառուցելու համար անհրաժեշտ է թարմացնել բոլոր քարտեզները, իսկ հետո կրկին պլանավորել երթուղին:</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Գտնել քարտեզ</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Համոզվեք, որ ձեր սարքը միացված է ինտերնետին:</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Բավականաչափ հիշողություն չկա</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Խնդրում ենք ջնջել ավելորդ տվյալները</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Մուտքի սխալ։</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Ստուգված փոփոխություններ</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Տեղաշարժեք քարտեզը՝ խաչը վայրի կամ կազմակերպության վրա տեղադրելու համար:</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Խմբագրում</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Ավելացում</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Վայրի անվանումը</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Ինչպես գրված է տեղական լեզվով</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Կատեգորիա</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Խնդրի մանրամասն նկարագրություն</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Այլ խնդիր</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Ավելացնել կազմակերպություն</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Այստեղ օբյեկտ չի կարող գտնվել</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Համայնքի կողմից ստեղծված OpenStreetMap տվյալներ՝ %1 թ. դրությամբ։ Իմացեք ավելին քարտեզի խմբագրման և թարմացման մասին OpenStreetMap.org կայքում:</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM)-ը համայնքային նախագիծ է՝ անվճար և բաց քարտեզ ստեղծելու համար: Այն Organic Maps-ի քարտեզային տվյալների հիմնական աղբյուրն է և աշխատում է Վիքիպեդիայի նման: Դուք կարող եք ավելացնել կամ խմբագրել վայրեր, և դրանք հասանելի կդառնան միլիոնավոր օգտատերերի ամբողջ աշխարհում.
+Միացեք համայնքին և օգնեք ստեղծել ավելի լավ քարտեզ բոլորի համար!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Ստեղծեք OpenStreetMap հաշիվ կամ մուտք գործեք՝ ձեր քարտեզային խմբագրումները հրապարակելու համար:</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1՝ %2-ից</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Ներբեռնե՞լ բջջային ցանցի միջոցով:</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Սա կարող է բավականին թանկ արժենալ որոշ սակագնային պլանների դեպքում կամ ռոումինգում:</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Մուտքագրեք շենքի վավեր համար</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Հարկերի քանակը (առավելագույնը %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Հարկերի քանակը չպետք է գերազանցի %1-ը</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Փոստային ինդեքս</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Մուտքագրեք վավեր փոստային ինդեքս</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Նշում OpenStreetMap կամավորների համար (ոչ պարտադիր)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Նկարագրեք քարտեզի սխալները կամ այն, ինչը հնարավոր չէ խմբագրել Organic Maps-ով</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Ձեր խմբագրումները բեռնվում են հանրային &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; տվյալների բազա։ Խնդրում ենք չավելացնել անձնական կամ հեղինակային իրավունքով պաշտպանված տեղեկություններ:</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Ավելին OpenStreetMap-ի մասին</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Ձեր խմբագրումների պատմությունը</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Ձեր նշումները քարտեզի տվյալների մասին</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Օպերատոր</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Օպերատոր՝ %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Չե՞ք գտնում համապատասխան կատեգորիա:</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps-ը թույլ է տալիս ավելացնել միայն պարզ կետային կատեգորիաներ, այսինքն՝ ոչ քաղաքներ, ճանապարհներ, լճեր, շենքերի ուրվագծեր և այլն։ Խնդրում ենք ավելացնել նման կատեգորիաները անմիջապես &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; կայքում։ Մանրամասն քայլ առ քայլ հրահանգների համար ստուգեք մեր &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;ուղեցույցը&lt;/a&gt;:</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Դուք դեռ քարտեզներ չեք ներբեռնել</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Ներբեռնեք քարտեզներ՝ օֆլայն որոնման և նավիգացիայի համար:</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Ընթացիկ դիրքն անհայտ է:</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>կմ/ժ</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>մղ/ժ</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ժ</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>ր</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>օ</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>վ</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Ավելին</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Խմբագրել էջանիշը</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Անձնական նշումներ (տեքստ կամ html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Մեկնաբանություն…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Չեղարկե՞լ բոլոր տեղական փոփոխությունները:</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Չեղարկել</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Ջնջե՞լ ավելացված վայրը:</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Ջնջել</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Վայրը գոյություն չունի</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Խնդրում ենք նշել վայրը ջնջելու պատճառը</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Մուտքագրեք վավեր հեռախոսահամար</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Մուտքագրեք վավեր վեբ հասցե</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Մուտքագրեք վավեր էլ. փոստ</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Մուտքագրեք վավեր Facebook-ի վեբ հասցե, հաշիվ կամ էջի անուն</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Մուտքագրեք վավեր Instagram-ի օգտանուն կամ վեբ հասցե</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Մուտքագրեք վավեր Twitter-ի օգտանուն կամ վեբ հասցե</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Մուտքագրեք վավեր VK-ի օգտանուն կամ վեբ հասցե</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Մուտքագրեք վավեր LINE ID կամ վեբ հասցե</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Ավելացնել վայր OpenStreetMap-ում</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Կամ թողեք նշում OpenStreetMap համայնքի համար, որպեսզի մեկ ուրիշը կարողանա ավելացնել կամ ուղղել վայրը:</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Նշումը կուղարկվի OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Ցանկանո՞ւմ եք ուղարկել այն բոլոր օգտատերերին:</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Համոզվեք, որ չեք մուտքագրել որևէ անձնական կամ գաղտնի տվյալ:</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-ի խմբագիրները կստուգեն փոփոխությունները և հարցերի դեպքում կկապվեն ձեզ հետ:</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Դադար</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Հետագծի ձայնագրում</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Ընդունել</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Մերժել</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Օգտագործե՞լ բջջային ինտերնետ՝ մանրամասն տեղեկատվություն ցուցադրելու համար:</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Միշտ օգտագործել</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Միայն այսօր</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Չօգտագործել այսօր</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Բջջային ինտերնետ</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Բջջային ինտերնետն անհրաժեշտ է քարտեզի թարմացման ծանուցումների և խմբագրումների վերբեռնման համար:</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Երբեք չօգտագործել</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Միշտ հարցնել</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Երթևեկության տվյալները ցուցադրելու համար քարտեզները պետք է թարմացվեն:</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Մեծացնել քարտեզի գրությունների չափսը</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Խնդրում ենք թարմացնել Organic Maps-ը</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Երթևեկության տվյալները հասանելի չեն</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Միացնել գրանցումը</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Ընդհանուր կարծիք</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Ձայնային հրահանգների համար օգտագործում ենք համակարգային TTS-ը։ Շատ Android սարքեր օգտագործում են Google TTS, որը կարող եք ներբեռնել կամ թարմացնել Google Play-ից։</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Որոշ լեզուների համար անհրաժեշտ կլինի տեղադրել խոսքի սինթեզատոր կամ լրացուցիչ լեզվական փաթեթ հավելվածների խանութից (Google Play, Galaxy Store, App Gallery, F-Droid).
+Բացեք սարքի կարգավորումները → Լեզու և մուտքագրում → Խոսք → Տեքստից խոսք։
+Այստեղ կարող եք կառավարել խոսքի սինթեզի կարգավորումները (օրինակ՝ ներբեռնել լեզվական փաթեթ օֆլայն օգտագործման համար) և ընտրել տեքստից խոսքի այլ շարժիչ։</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Լրացուցիչ տեղեկությունների համար խնդրում ենք ծանոթանալ այս ուղեցույցին։</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Տառադարձել լատինատառի</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Իմանալ ավելին</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Օգտագործեք որոնումը, ընտրեք էջանիշ կամ հպեք քարտեզին՝ երթուղու սկզբնակետ ավելացնելու համար</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Օգտագործեք որոնումը, ընտրեք էջանիշ կամ հպեք քարտեզին՝ նշանակման կետ ավելացնելու համար</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Կառավարել երթուղին</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Պլանավորել</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Հեռացնել կանգառը</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Ավելացնել կանգառ</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Պահպանված է</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Խնդրում ենք մուտք գործել OpenStreetMap, որպեսզի Ձեր քարտեզի փոփոխությունները ավտոմատ վերբեռնվեն: Իմացեք ավելին &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;այստեղ&lt;/a&gt;:</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Հիշողության հասանելիության խնդիր</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Արտաքին հիշողությունը հասանելի չէ։ SD քարտը գուցե հեռացված է, վնասված, կամ ֆայլային համակարգը միայն կարդալու համար է։ Խնդրում ենք ստուգել Ձեր SD քարտը կամ կապվել մեզ հետ support@organicmaps.app հասցեով։</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Նմանակել վատ հիշողությունը</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Խնդրում ենք մուտքագրել ճիշտ անուն</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Ցուցակներ</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Թաքցնել բոլորը</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Ցուցադրել բոլորը</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n էջանիշ</numerusform>
+<numerusform>%n էջանիշ</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Ստեղծել նոր ցուցակ</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Ներմուծել էջանիշներ և հետագծեր</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Հնարավոր չէ կիսվել հավելվածի սխալի պատճառով</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Կիսվելու սխալ</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Հնարավոր չէ կիսվել դատարկ ցուցակով</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Անունը չի կարող դատարկ լինել</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Խնդրում ենք մուտքագրել ցուցակի անունը</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Նոր ցուցակ</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Այս անունն արդեն զբաղված է</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Խնդրում ենք ընտրել այլ անուն</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Խնդրում ենք սպասել…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Հեռախոսահամար</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap պրոֆիլ</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n ֆայլ</numerusform>
+<numerusform>%n ֆայլ</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Վերականգնել</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n երթուղի</numerusform>
+<numerusform>%n երթուղի</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Գաղտնիություն</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Գաղտնիության քաղաքականություն</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Օգտագործման պայմաններ</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Երթևեկություն</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Արշավային</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Հեծանվային</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Մետրո</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Քարտեզի ոճեր և շերտեր</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Այս ցուցակը դատարկ է</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Էջանիշ ավելացնելու համար հպեք քարտեզի որևէ կետի, ապա՝ աստղիկի պատկերակին</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Փոխել բոլոր էջանիշների գույնը</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Փոխել բոլոր ուղիների գույնը</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…ավելին</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Արտահանել KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Արտահանել GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Արտահանել GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Ջնջել ցուցակը</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Արագաչափեր</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Վայրի նկարագրություն</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Քարտեզի ներբեռնիչ</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Զգուշացնել արագության գերազանցման դեպքում</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Միշտ զգուշացնել</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Երբեք չզգուշացնել</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Էներգախնայողության ռեժիմ</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Փորձել նվազեցնել էներգիայի սպառումը որոշ ֆունկցիոնալության հաշվին:</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Երբեք</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Երբ մարտկոցը լիցքաթափված է</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Միշտ</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Էջանիշների անունները քարտեզի վրա</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Եթե էջանիշները շատ են, քարտեզի վրա դրանց անունների ցուցադրումը կարող է դանդաղեցնել հավելվածը:</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Ցուցադրել աջից</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Ցուցադրել ներքևից</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Միացրեք այս ընտրանքը ժամանակավորապես՝ Ձեր խնդրի մասին մանրամասն ախտորոշիչ գրանցամատյանները գրանցելու և մեզ ձեռքով ուղարկելու համար՝ օգտագործելով «Զեկուցել սխալի մասին» Օգնության պատուհանում։ Գրանցամատյանները կարող են ներառել տեղադիրքի տվյալներ։</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Երթուղու ընտրանքներ</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Խուսափել վճարովի ճանապարհներից</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Խուսափել գրունտային ճանապարհներից</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Խուսափել լաստանավերից</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Խուսափել մայրուղիներից</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Հնարավոր չէ հաշվարկել երթուղին</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Երթուղին չի գտնվել։ Սա կարող է պայմանավորված լինել երթուղու ընտրանքներով կամ OpenStreetMap-ի ոչ ամբողջական տվյալներով։ Խնդրում ենք փոխել երթուղու ընտրանքները և կրկին փորձել։</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Սահմանել ճանապարհներ՝ խուսափելու համար</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Երթուղու ընտրանքները միացված են</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Վճարովի ճանապարհ</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Գրունտային ճանապարհ</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Լաստանավային ուղի</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Այո</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ոչ</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Այո</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ոչ</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Տարողություն՝ %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Ցանց՝ %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Դուք ժամանել եք</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Լավ</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Դասավորել…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Դասավորել էջանիշները</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Լռելյայն</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Ըստ տեսակի</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Ըստ հեռավորության</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Ըստ ամսաթվի</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Ըստ անվան</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Մեկ շաբաթ առաջ</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Մեկ ամիս առաջ</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Ավելի քան մեկ ամիս առաջ</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Ավելի քան մեկ տարի առաջ</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Իմ մոտակայքում</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Այլ</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Երթուղու պլանավորումը ձախողվեց</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ժամանումը՝ %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Ներբեռնել և թարմացնել բոլոր քարտեզները երթուղու երկայնքով՝ հաշվարկ կատարելու համար:</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Դուք փոխեցիք աշխարհի քարտեզը: Մի պահեք դա Ձեզ, պատմեք ընկերներին և խմբագրեք միասին:</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Կիսվել ընկերների հետ</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Փակ է</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Բացվում է վաղը %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Բացվում է %1՝ %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Բացվում է %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Փակվում է %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Ավելացնել աշխատանքային ժամերը</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Գաղտնաբառ (առնվազն 8 նիշ)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Սխալ օգտանուն կամ գաղտնաբառ:</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM հաշիվ</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Վերջին վերբեռնումը</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Շնորհակալություն</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Վայրի անունը</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Հեռախոս</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Խնդրում ենք նկատի ունենալ</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Ներբեռնման սխալ</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Ընտրեք կատեգորիան</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Հայտնի</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Բոլոր կատեգորիաները</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Ավելացրեք նոր վայրեր քարտեզին և խմբագրեք առկաները անմիջապես հավելվածից:</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Փոխել տեղադիրքը</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Ներբեռնելու համար անհրաժեշտ է ավելի շատ տարածք։ Խնդրում ենք ջնջել ավելորդ տվյալները։</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ես բարելավեցի Organic Maps քարտեզները</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Մանրամասն մեկնաբանություն</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Ձեր առաջարկած քարտեզի փոփոխությունները կուղարկվեն OpenStreetMap համայնքին։ Խնդրում ենք նկարագրել ցանկացած այլ մանրամասներ, որոնք հնարավոր չէ խմբագրել Organic Maps-ում։</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Ձեր տեղադիրքը որոշելիս առաջացել է սխալ։ Ստուգեք, որ Ձեր սարքը ճիշտ է աշխատում և փորձեք կրկին ավելի ուշ։</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Տեղորոշման ծառայություններն անջատված են</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Միացրեք աշխարհագրական տեղորոշման հասանելիությունը սարքի կարգավորումներում</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Բացեք Կարգավորումները</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Հպեք Տեղորոշում</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Ընտրեք «Հավելվածն օգտագործելիս»</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Ընտրեք Գաղտնիություն</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Ընտրեք Տեղորոշման ծառայություններ</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Միացրեք Տեղորոշման ծառայությունները</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Կամ շարունակեք օգտագործել Organic Maps-ն առանց տեղորոշման</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Ամրագրել</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Զանգել</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Էջանիշի անունը</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Ջնջել էջանիշը</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ձեր նշումը կուղարկվի OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…ավելին</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Թարմացնել</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Անջատե՞լ Ձեր անցած վերջին երթուղու ձայնագրումը:</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Անջատել</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Տեսեք սա</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps-ը օգտագործում է Ձեր տեղադիրքը ֆոնային ռեժիմում՝ Ձեր անցած վերջին երթուղին գրանցելու համար:</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Ընդհանուր կարգավորումներ</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Երթևեկության տվյալները ցուցադրելու համար հավելվածը պետք է թարմացվի:</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Գրանցամատյանի ֆայլի չափը՝ %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Քաշեք այստեղ՝ հեռացնելու համար</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Փոխարինել կանգառը</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Սկսել …-ից</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Խնդրում ենք մուտք գործել OpenStreetMap՝ Ձեր քարտեզի բոլոր փոփոխություններն ավտոմատ վերբեռնելու համար։ Իմացեք ավելին</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>այստեղ</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Թաքցնել էկրանը</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 %3-ից)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Ներբեռնվում է %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Կիրառվում է %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Այս անունը շատ երկար է</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Հայտնաբերվել են նոր ֆայլեր</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Փոխարկել</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Սխալ</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Որոշ ֆայլեր չեն փոխարկվել:</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Տեղի ունեցավ սխալ</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Հայտնի</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Թաքցնել քարտեզից</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Պիտակների բեռնման ժամանակ սխալ տեղի ունեցավ, խնդրում ենք փորձել կրկին</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Աջ</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Ներքև</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Գնացինք</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Նշանակման կետ</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Կենտրոնացնել</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Որոնման արդյունքներ</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Այնուհետև</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Ցանկանո՞ւմ եք վերակառուցել երթուղին:</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Ստեղնաշարը հասանելի չէ վարելիս</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Հնարավոր չէ կառուցել երթուղի Ձեր ընթացիկ տեղադիրքից</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Հնարավոր չէ գտնել երթուղի դեպի նշանակման վայր: Խնդրում ենք ընտրել այլ վերջնակետ</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS ազդանշան չկա: Խնդրում ենք տեղափոխվել բաց տարածք</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Հնարավոր չէ կառուցել երթուղի: Խնդրում ենք նշել երթուղու այլ կետեր</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Երթուղի ստեղծելու համար ներբեռնեք բացակայող քարտեզները Ձեր սարքում</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Տեղի ունեցավ սխալ: Խնդրում ենք վերագործարկել հավելվածը</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Երթուղին կվերակառուցվի Ձեր ընթացիկ տեղադիրքից</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Երթուղին կփոխարկվի ավտոմեքենայի երթուղու</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ոչ բոլոր էջանիշներն են ցուցադրվում</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Անցեք հեռախոսին՝ բոլոր էջանիշները տեսնելու համար</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Արագաչափեր</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Արագության զգուշացումներ</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Խնդրում ենք ներբեռնել քարտեզները հավելվածում՝ Ձեր բջջային սարքի վրա</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 ելք</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Դասավորել լռելյայն</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Դասավորել ըստ տեսակի</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Դասավորել ըստ հեռավորության</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Դասավորել ըստ ամսաթվի</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Դասավորել ըստ անվան</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Սնունդ</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Տեսարժան վայրեր</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Թանգարաններ</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Զբոսայգիներ</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Լողավազաններ</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Լեռներ</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Կենդանիներ</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Հյուրանոցներ</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Շենքեր</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Ֆինանսներ</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Խանութներ</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Կայանատեղի</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Լցակայաններ</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Առողջապահություն</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Փնտրել ցուցակում</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Կրոնական վայրեր</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Ընտրել ցուցակը</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Մետրոյով երթևեկությունը այս տարածաշրջանում դեռ հասանելի չէ</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Մետրոյի երթուղի չի գտնվել</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Խնդրում ենք ընտրել մետրոյի կայարանին ավելի մոտ սկզբնակետ կամ վերջնակետ</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Հորիզոնականներ</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Հորիզոնականների ակտիվացումը պահանջում է ներբեռնել այս տարածքի քարտեզի տվյալները</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Հորիզոնականները դեռ հասանելի չեն այս տարածքում</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Վերելք</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Վայրէջք</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Նվազգ. բարձրություն</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Առավել. բարձրություն</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Բարդություն</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Հեռ.՝</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Ժամ.՝</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Մեծացրեք մասշտաբը՝ հորիզոնականները տեսնելու համար</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Ներբեռնում</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Ներբեռնել աշխարհի ընդհանուր քարտեզը</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Հնարավոր չէ ստեղծել պանակ և տեղափոխել ֆայլերը սարքի ներքին հիշողության կամ SD քարտի վրա</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Սկավառակի սխալ</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Կապի խափանում</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Անջատեք USB մալուխը</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Էկրանը միացած պահել</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Միացված լինելու դեպքում քարտեզը ցուցադրելիս էկրանը միշտ միացած կլինի։</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Ցուցադրել կողպէկրանին</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Միացված լինելու դեպքում հավելվածը կաշխատի կողպէկրանին, նույնիսկ երբ սարքը կողպված է։</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Քարտեզի լեզուն</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Քարտեզի տվյալները՝ OpenStreetMap-ից</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Շնորհակալություն համայնքի կողմից ստեղծված մեր քարտեզներից օգտվելու համար։</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Ձեր նվիրատվություններով և աջակցությամբ մենք կարող ենք ստեղծել աշխարհի լավագույն քարտեզները։</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Հավանու՞մ եք մեր հավելվածը։ Խնդրում ենք նվիրատվություն կատարել՝ զարգացմանը աջակցելու համար։ Դեռ չե՞ք հավանում։ Խնդրում ենք հայտնել պատճառը, և մենք կշտկենք այն։</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Եթե ճանաչում եք ծրագրավորողի, կարող եք խնդրել նրան իրականացնել ձեզ անհրաժեշտ գործառույթը։</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Հպեք քարտեզի ցանկացած կետի՝ որևէ բան ընտրելու համար։ Երկար հպումը թաքցնում և ցուցադրում է ինտերֆեյսը։</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Գիտեի՞ք, որ քարտեզի վրա ձեր ընթացիկ դիրքը կարելի է ընտրել։</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Դուք կարող եք օգնել թարգմանել մեր հավելվածը ձեր լեզվով։</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Մեր հավելվածը մշակվում է մի քանի էնտուզիաստների և համայնքի կողմից։</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Դուք կարող եք հեշտությամբ ուղղել և բարելավել քարտեզի տվյալները։</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Մեր հիմնական նպատակն է ստեղծել արագ, գաղտնիությանը միտված և հեշտ օգտագործվող քարտեզներ, որոնք դուք կսիրեք։</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Դուք այժմ օգտագործում եք Organic Maps-ը հեռախոսի էկրանին</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Դուք այժմ օգտագործում եք Organic Maps-ը մեքենայի էկրանին</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Դուք միացված եք Android Auto-ին</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Շարունակել հեռախոսով</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Դեպի մեքենայի էկրան</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps-ին անհրաժեշտ է տեղադիրքի հասանելիություն։ Երբ անվտանգ լինի, ստուգեք ծանուցումը ձեր հեռախոսում։</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Այս հավելվածին անհրաժեշտ է ձեր թույլտվությունը</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto-ում Organic Maps-ի արդյունավետ աշխատանքի համար անհրաժեշտ է տեղադիրքի թույլտվություն</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Տալ թույլտվություններ</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Ակտիվ հանգիստ</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Վեբ զննարկիչը հասանելի չէ</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Ձայնի ուժգնություն</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Արտահանել բոլոր էջանիշները և հետագծերը</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Խոսքի սինթեզի համակարգային կարգավորումներ</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Խոսքի սինթեզի կարգավորումներ չեն գտնվել, համոզվա՞ծ եք, որ ձեր սարքն ունի այդ հնարավորությունը։</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Դրայվ-ին</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Մաքրել որոնումը</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Մեծացնել</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Փոքրացնել</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Մենյուի հղում</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Դիտել մենյուն</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Բացել այլ հավելվածում</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Ինքնասպասարկում</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Ընտրել տարբերակ</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Բացօթյա նստատեղեր</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Առավել ճշգրիտ նավիգացիայի համար խորհուրդ ենք տալիս անջատել էներգախնայողության ռեժիմը հեռախոսի մարտկոցի կարգավորումներում։</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Գրանցել հետագիծը</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Կանգնեցնել հետագծի գրանցումը</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Հետագծի գրանցում</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Կանգնեցնել առանց պահպանելու</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Շարունակել գրանցումը</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Պահպանե՞լ Էջանիշներում և Հետագծերում։</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Հետագիծը դատարկ է՝ պահպանելու ոչինչ չկա</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Հնարավոր չէ ցուցադրել պանակի ընտրության պատուհանը, քանի որ սարքում չկա համապատասխան հավելված։ Խնդրում ենք տեղադրել ֆայլերի կառավարիչ և փորձել կրկին։</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Ընտրել գույն</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Խմբագրել հետագիծը</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Տեղադիրքը բացող հավելված տեղադրված չէ</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Ավտոմատ՝ նավիգացիայի ժամանակ</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Ինչպես համակարգում</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Կիսվել հետագծով</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Ջնջե՞լ %1</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Բարդության մակարդակ</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Հեշտ</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Միջին</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Բարդ</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Թարմացում</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Թարմացնել ներբեռնված քարտեզները</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Քարտեզների թարմացումը թարմ է պահում օբյեկտների մասին տեղեկատվությունը</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Թարմացնել (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Ձեռքով թարմացնել ավելի ուշ</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Ջնջել հետագիծը</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Վստա՞հ եք, որ ցանկանում եք ջնջել այս հետագիծը։</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Հետագծի անունը</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Տեղափոխել</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Հետագիծ</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Փոխել գույնը</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Քարտեզ</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Ցանկանու՞մ եք ուղարկել սխալի մասին հաշվետվություն մշակողներին?
+Մենք ապավինում ենք մեր օգտատերերին, քանի որ Organic Maps-ը ավտոմատ կերպով չի հավաքում սխալների մասին տեղեկատվություն։ Կանխավ շնորհակալություն Organic Maps-ին աջակցելու համար!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Միացնել iCloud-ի համաժամացումը</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-ի համաժամացումը մշակման փուլում գտնվող փորձնական գործառույթ է։ Համոզվեք, որ կատարել եք ձեր բոլոր էջանիշների և հետագծերի պահուստավորում։</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud-ն անջատված է</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Այս գործառույթից օգտվելու համար խնդրում ենք միացնել iCloud-ը ձեր սարքի կարգավորումներում։</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Միացնել</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Պահուստավորել</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-ի համաժամացման ձախողում</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Սխալ. Չհաջողվեց համաժամացնել կապի խափանման պատճառով</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Սխալ. Չհաջողվեց համաժամացնել iCloud-ի քվոտայի գերազանցման պատճառով</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Սխալ. iCloud-ը հասանելի չէ</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Վերջերս ջնջված ցուցակներ</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Մաքրել</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Ջնջել բոլորը</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Վերականգնել</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Վերականգնել բոլորը</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Աջակցել OpenStreetMap-ին</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Ավելացնել վայր</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Թարմացնել քարտեզը աջակցելու համար</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap-ի տվյալներում ներդրում կատարելու համար անհրաժեշտ է թարմացնել %1 քարտեզը մինչև վերջին տարբերակը</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>ՄԲ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ԳԲ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Իմ դիրքը</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Իմ վայրերը</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Ներքին մասնավոր հիշողություն</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Ներքին ընդհանուր հիշողություն</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD քարտ</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Արտաքին ընդհանուր հիշողություն</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Փոստային ինդեքս</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Կետ քարտեզի վրա</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>մ</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>կմ</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>մղ</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ֆուտ</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Երթուղիները ցուցադրելու համար քարտեզները պետք է թարմացվեն։</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Ելք</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Մուտք</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Մետրոյի քարտեզը հասանելի չէ</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Դուք</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Ներբեռնված մանուշակագույն տարածքներ</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Երթուղի</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Հավելվածի ֆունկցիոնալությունից լիարժեք օգտվելու համար անհրաժեշտ է տեղադիրքի հայտնաբերում ֆոնային ռեժիմում։ Այն օգտագործվում է նավիգացիայի և ձեր անցած հետագծի պահպանման համար։</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Ձեր տեղադիրքի որոշումը անհրաժեշտ է նավիգացիայի և ձեր անցած հետագծի պահպանման համար։</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Մուտք գաղտնաբառով</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Մուտք գործել զննարկչի միջոցով</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Վերջին օգտագործված</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Էջանիշների գույնը փոխվեց</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Հետագծերի գույնը փոխվեց</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Սպեկտր</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Սլայդերներ</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>Կարմիր</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>Կանաչ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ԿԱՐՄԻՐ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB հեքս գույն #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Ցանց</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ia/omim.ts
+++ b/qt/translations/ia/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ia">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Light from dawn till dusk</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Dona cartas gratuite sin reclamos a milliones de usatores!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article from wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n marcapagina</numerusform>
+<numerusform>%n marcapaginas</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file esseva trovate. Tu pote vider lo post conversion.</numerusform>
+<numerusform>%n files esseva trovate. Tu pote vider los post conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n tracia</numerusform>
+<numerusform>%n tracias</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Seguer le systema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiones discargate purpree</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recently Used</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sliders</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RED</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GREEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/id/omim.ts
+++ b/qt/translations/id/omim.ts
@@ -1,0 +1,3930 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="id">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Kembali</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Batalkan</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Hapus</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Unduh Peta</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Pengunduhan gagal, sentuh untuk mencoba sekali lagi</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Sedang mengunduh…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mil</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Nanti</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Cari</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Cari Peta</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Saat ini semua Layanan Lokasi untuk perangkat atau aplikasi ini non-aktif. Mohon aktifkan lewat Setelan.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Akurasi Terbatas</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Untuk memastikan navigasi yang akurat, aktifkan Lokasi Tepat dalam pengaturan.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Tampilkan di peta</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Sedang Mengunduh telah gagal</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Coba Lagi</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Tentang Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis untuk semua orang, dibuat dengan cinta</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Tidak ada iklan, tidak ada pelacakan, tidak ada pengumpulan data</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Tidak menguras baterai, bekerja secara offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Cepat, minimalis, dikembangkan oleh komunitas</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplikasi open-source yang dibuat oleh penggemar dan sukarelawan.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Pengaturan lokasi</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Tutup</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>OpenGL yang dipercepat oleh OpenGL diperlukan. Sayangnya, perangkat Anda tidak mendukung.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Unduh</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Mohon lepas kabel USB atau masukkan kartu memori untuk menggunakan Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Mohon bebaskan sejumlah ruang pada kartu SD/penyimpanan USB terlebih dahulu untuk menggunakan aplikasi</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Sebelum Anda mulai izinkan kami mengunduh peta dunia secara umum ke perangkat Anda.
+Hal ini memerlukan data %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Pergi ke Peta</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Sedang mengunduh %1. Sekarang Anda dapat melanjutkan ke peta.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Unduh %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Perbarui %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Jeda</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Lanjutkan</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 gagal diunduh</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Tambahkan Set baru</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nama Set Penanda</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Penanda</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Penanda dan jalur</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nama</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Alamat</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Daftar</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Pengaturan</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Simpan peta di</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Pilih tempat untuk menyimpan unduhan peta</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Peta</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 bebas dari %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Pindahkan peta?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Kesalahan memindahkan file peta</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ini akan memakan waktu beberapa menit.
+Mohon tunggu…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unit Pengukuran</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Pilihlah antara mil dan kilometer</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Batalkan Pengunduhan</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Tulis Ulasan</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ya</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Unduh Peta</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Set Penanda</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Tempat makan</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Toserba</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transportasi</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Bahan bakar</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkir</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Berbelanja</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Tangan kedua</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Pemandangan</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Hiburan</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Kehidupan Malam</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Liburan keluarga</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Rumah sakit</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pos</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polisi</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Mendaur ulang</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Air</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Untuk RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Catatan</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Bagikan penanda Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Halo!
+
+Terlampir adalah bookmark saya; silakan buka di Organic Maps. Jika Anda belum memasangnya, Anda dapat mengunduhnya di sini: https://omaps.app/get?kmz
+
+Nikmati perjalanan Anda dengan Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Memuat Penanda</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Penanda berhasil dimuat! Anda dapat menemukannya pada peta atau pada layar Pengelola Penanda Lokasi.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Gagal mengunggah penanda lokasi. Berkas mungkin rusak.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Jenis file tidak dikenali oleh aplikasi:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Gagal membuka file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Sunting</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Lokasi Anda belum ditentukan</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Maaf, pengaturan Penyimpanan Peta saat ini sedang non-aktif.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Pengunduhan negara sedang berjalan.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hei, lihat lokasiku saat ini di Organic Maps! %1 atau %2 belum memiliki peta offline? Unduh di sini: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hei, lihat pinku di peta Organic Maps</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hei, lihat lokasiku saat ini di peta Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hai,
+
+Sekarang saya ada di sini: %1. Klik tautan ini %2 atau yang ini %3 untuk melihat tempatnya di peta.
+
+Terima kasih.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Bagikan</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Surel</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Telah Disalin ke Papan Klip: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Selesai</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Data OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Apakah Anda yakin ingin keluar dari akun OpenStreetMap Anda?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Jalur</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Panjang</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Bagikan Lokasi Saya</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Pengaturan umum</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informasi</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigasi</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Tombol + dan - pada peta</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Tampilkan pada layar</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Gaya malam saat menavigasi dalam gelap</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Mode Malam</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Tidak Aktif</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Aktif</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Otomatis</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Pandangan perspektif</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Bangunan 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Bangunan 3D dimatikan dalam mode hemat daya</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Petunjuk Suara</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Umumkan Nama Jalan</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Saat diaktifkan, nama jalan atau jalan keluar untuk berbelok akan diucapkan dengan keras.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Bahasa Suara</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Untuk mengunduh suara berkualitas lebih tinggi, buka app Pengaturan dan buka Aksesibilitas → VoiceOver → Ucapan → Suara.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Menguji petunjuk suara (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Periksa pengaturan volume atau pengaturan teks-ke-ucapan sistem jika anda tidak mendengar suara sekarang.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Tidak Tersedia</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Perbesar otomatis</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Jarak</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Tampilkan pada peta</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Situs Web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Berita</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Umpan balik</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Beri nilai aplikasi</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Bantuan</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Pertanyaan dan jawaban</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Menyumbangkan</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Sudah disumbang</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Ingatkan nanti</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Mendukung Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Mendukung proyek</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Hak cipta</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Laporkan gangguan</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Perbaiki arah panah dengan menggerakkan ponsel dalam gerakan angka delapan untuk mengkalibrasi kompas.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Gerakkan ponsel dengan gerakan angka delapan untuk mengkalibrasi kompas dan memperbaiki arah panah pada peta.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ketuk lama pada peta sekali lagi untuk melihat antarmuka</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Perbarui semua</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Batalkan Semuanya</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Diunduh</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Telah diantrekan</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Dekat saya</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Peta</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Unduh semua</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Mengunduh:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Untuk menghapus peta, silakan hentikan navigasi.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Rute hanya dapat dibuat dengan yang seluruhnya ada di dalam peta tunggal.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Unduh peta</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Ulangi</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Hapus Peta</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Perbarui Peta</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Layanan Lokasi Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Dengan cepat menentukan perkiraan lokasi Anda melalui Bluetooth, WiFi, atau jaringan seluler</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Unduh peta bersama rute</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Membuat rute memerlukan semua peta dari lokasi Anda ke tujuan yang diunduh dan diperbarui.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ruang simpan tidak cukup</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Mohon aktifkan Layanan Lokasi</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Simpan</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>buat</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Đỏ</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Vàng</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Xanh dương</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Xanh lục</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Tím</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Cam</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Nâu</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Hồng</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Ungu Gelap</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Biru Muda</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Biru Kehijauan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Biru Gelap</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Kuning Gelap</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Oranye Gelap</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Abu-abu</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Biru Keabu-abuan</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versi Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Tampilan</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Terang</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Gelap</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Terang dari fajar hingga senja</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Lainnya</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Hadiahkan peta gratis tanpa iklan untuk jutaan pengguna!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Melaporkan atau memperbaiki data peta yang salah</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Untuk Menjadi Relawan</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Ikuti dan hubungi kami:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Surel pelanggan belum diatur. Mohon konfigurasikan atau gunakan cara lain untuk menghubungi kami di %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Gangguan pengiriman surel</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrasi kompas</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Tersedia</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Ditemukan</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Perbarui</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Gagal</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>penanda</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Saat mengikuti rute, harap diingat:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Kondisi jalan, peraturan lalu lintas, dan marka jalan harus selalu didahulukan daripada saran navigasi;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Peta mungkin tidak akurat dan rute yang disarankan tidak mutlak merupakan cara paling optimal untuk mencapai tujuan;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Rute yang disarankan hanya untuk digunakan sebagai rekomendasi;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Berhati-hatilah dengan rute di zona perbatasan: rute yang dibuat oleh aplikasi kami terkadang mungkin saja melintasi batas negara di lokasi yang tidak sah;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Jaga selalu kewaspadaan dan keselamatan di jalan!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Periksa sinyal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Tidak dapat membuat rute. Koordinat GPS saat ini tidak dapat dikenali.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Mohon periksa sinyal GPS Anda. Mengaktifkan Wi-Fi akan meningkatkan akurasi lokasi Anda.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktifkan layanan lokasi</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>TIdak dapat menemukan koordinat GPS saat ini. Aktifkan layanan lokasi untuk mengalkulasi rute.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Tidak dapat menemukan rute</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Tidak dapat membuat rute.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Sesuaikan titik mula atau tujuan Anda.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Sesuaikan titik mula</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Rute tidak dibuat. Tidak dapat menemukan titik mula.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Pilih titik mula yang lebih dekat dengan jalan.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Sesuaikan tujuan</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Rute tidak dibuat. Tidak dapat menemukan tujuan.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Pilih titik tujuan yang lebih dekat dengan jalan.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Tidak dapat menemukan titik antara.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Harap sesuaikan titik antara Anda.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Kesalahan sistem</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Tidak dapat membuat rute karena kesalahan aplikasi.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Mohon coba lagi</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Jangan Sekarang</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Apakah Anda ingin mengunduh peta dan membuat rute yang lebih optimal yang meliputi lebih dari satu peta?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Unduh peta untuk membuat rute yang lebih optimal yang melewati ujung peta ini.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Unduh file yang diperlukan</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Unduh dan perbarui semua informasi peta dan perutean di sepanjang proyeksi jalan untuk mengalkulasi rute.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Untuk mulai mencari dan membuat rute, silakan unduh peta, dan Anda tidak akan membutuhkan koneksi internet lagi.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Pilih Peta</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Tampilkan</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Sembunyikan</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategori</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Riwayat</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Maaf, saya tidak menemukan apa pun.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Unduh wilayah tempat Anda mencari atau coba tambahkan nama kota/desa terdekat.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Riwayat Pencarian</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Akses kueri pencarian terbaru dengan cepat.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Bersihkan riwayat pencarian</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel dari wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Lokasi Anda</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Mulai</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Dari</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rute ke</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigasi tersedia hanya dari lokasi Anda saat ini.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Apakah Anda ingin kami merencanakan sebuah rute dari lokasi Anda saat ini?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Berikut</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Dari pukul</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Hingga</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Tambah Jadwal</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Hapus Jadwal</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Setiap Hari (24 jam)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Buka</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Tutup</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Tambah Jam Tutup</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Jam buka</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mode Lanjutan</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mode Sederhana</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Jam Tutup</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Contoh Nilai</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Koreksi kesalahan</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Pilih Lokasi</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Harap menggambarkan masalah secara rinci sehingga komunitas OpenStreetMap dapat memperbaiki kesalahan.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Atau Anda bisa melakukan sendiri di https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Kirim</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Masalah</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Tempat tidak ada</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Ditutup karena pemeliharaan</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Tempat ganda</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Unduhan otomatis</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Setiap Hari</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>siang dan malam</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Tutup hari ini</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Tutup</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hari ini</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Dibuka dalam %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Ditutup dalam %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Tutup</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Sunting jam kerja</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Tidak ada akun di OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Mendaftar</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Masuk</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Belum masuk</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Masuk ke OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Kata sandi</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Lupa kata sandi?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Keluar</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Sunting tempat</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Tambahkan bahasa</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Jalan</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Nomor rumah</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detail</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Media Sosial</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bangunan</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Tambahkan jalan</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Silakan masukkan nama jalan</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Pilih bahasa</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Pilih jalan</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Masakan</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Pilih Masakan</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Surel atau nama pengguna</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Tambahkan Telepon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Tingkat</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Tingkat: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Semua perubahan peta akan dihapus bersama dengan peta.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Perbarui peta</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Untuk membuat rute, Anda perlu memperbarui semua peta dan kemudian merencanakan rute tersebut lagi.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Temukan peta</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Harap memeriksa pengaturan Anda dan pastikan perangkat Anda terhubung dengan internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Tidak cukup ruang</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Harap menghapus data yang tidak diperlukan</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Kesalahan masuk.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Perubahan Terverifikasi</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Seret peta untuk menempatkan tanda silang di lokasi tempat atau bisnis.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Mengedit</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Menambahkan</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nama tempat</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Seperti yang tertulis dalam bahasa lokal</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategori</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Gambaran terperinci tentang masalah</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Masalah yang berbeda</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Tambahkan organisasi</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Objek tidak dapat diletakkan di sini</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Data OpenStreetMap yang dibuat oleh komunitas pada tanggal %1. Pelajari lebih lanjut mengenai cara mengedit dan memperbarui peta di OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) adalah sebuah proyek komunitas untuk membuat sebuah peta yang bebas dan terbuka. OSM merupakan sumber utama data peta di Organic Maps dan berfungsi mirip dengan Wikipedia. Anda dapat menambahkan atau mengedit tempat dan tempat tersebut tersedia untuk jutaan pengguna di seluruh Dunia.
+Bergabunglah dengan komunitas dan bantu membuat peta yang lebih baik untuk semua orang!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Buat akun OpenStreetMap atau masuk untuk mempublikasikan hasil editan peta Anda ke seluruh dunia.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 dari %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Unduh dengan menggunakan koneksi jaringan seluler?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Ini bisa menjadi jauh mahal pada beberapa paket atau jika roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Masukkan nomor rumah yang benar</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Jumlah lantai (maksimum %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Edit bangunan dengan maksimum %1 lantai</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Kode Pos</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Masukkan Kode Pos yang benar</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Catatan untuk relawan OpenStreetMap (opsional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Jelaskan kesalahan pada peta atau hal-hal yang tidak dapat diedit melalui Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Hasil editan Anda akan diunggah ke database &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; publik. Mohon untuk tidak menambahkan informasi pribadi atau informasi yang memiliki hak cipta.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Selengkapnya tentang OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Riwayat pengeditan Anda</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Catatan data peta Anda</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Tidak dapat menemukan kategori yang sesuai?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps hanya memungkinkan untuk menambahkan kategori titik sederhana, yang berarti tidak ada kota, jalan, danau, garis besar bangunan, dll. Silahkan tambahkan kategori tersebut secara langsung ke &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Lihat &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;panduan&lt;/a&gt; kami untuk petunjuk langkah demi langkah yang terperinci.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Tidak ada peta apa pun yang diunduh</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Lokasi saat ini tidak diketahui.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/j</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mpj</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>j</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>mnt</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>hr</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>dtk</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Lainnya</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Penanda</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Catatan pribadi (teks atau html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Atur ulang perubahan lokal?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Atur Ulang</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Hapus tempat yang ditambahkan?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Hapus</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Tempat tidak ada</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Mohon sebutkan alasan penghapusan tempat tersebut</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Masukkan nomor telepon yang benar</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Masukkan alamat web valid</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Masukkan surel valid</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Masukkan alamat web, akun, atau nama halaman Facebook yang valid</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Masukkan nama pengguna atau alamat web Instagram yang valid</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Masukkan nama pengguna Twitter atau alamat web yang valid</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Masukkan nama pengguna atau alamat web VK yang valid</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Masukkan ID LINE atau alamat web yang valid</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Menambahkan tempat ke OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Atau, sebagai alternatif, tinggalkan sebuah catatan kepada komunitas OpenStreetMap sehingga orang lain dapat menambahkan atau memperbaiki tempat di sini.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Catatan akan dikirim ke OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Apakah Anda ingin mengirimkannya ke semua pengguna?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Pastikan Anda tidak memasukkan data pribadi apa pun.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Editor OpenStreetMap akan memeriksa perubahan dan menghubungi Anda jika ada pertanyaan.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Berhenti</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Merekam jejak</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Terima</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Tolak</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Gunakan internet seluler untuk memperlihatkan informasi terperinci?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Selalu Gunakan</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Hanya Hari Ini</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Jangan Gunakan Hari Ini</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet Seluler</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Internet seluler diperlukan untuk menampilkan informasi terperinci tentang tempat, seperti foto, harga, dan ulasan.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Jangan Gunakan</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Selalu Tanya</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Untuk memperlihatkan data lalu lintas, peta harus diperbarui.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Perbesar ukuran huruf pada peta</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Perbarui Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Data lalu lintas tidak tersedia</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Aktifkan pencatatan</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Umpan Balik Umum</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Kami menggunakan TTS sistem untuk petunjuk suara. Banyak perangkat Android menggunakan Google TTS, Anda dapat mengunduhnya dari Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Untuk beberapa bahasa, Anda perlu menginstal synthesizer suara atau paket bahasa tambahan dari toko aplikasi (Google Play, Galaxy Store, App Gallery, FDroid).
+Buka pengaturan perangkat Anda → Language and input (Bahasa dan input) → Speech (Suara) → Text to speech (Teks ke suara).
+Di sini, Anda dapat mengelola pengaturan untuk sintesis suara (contohnya, mengunduh paket bahasa untuk penggunaan tanpa internet) dan memilih mesin tekske suara lain.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Untuk informasi selengkapnya, bacalah panduan ini.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterasi ke dalam bahasa Latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Pelajari selengkapnya</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Gunakan pencarian atau ketuk pada peta untuk menambahkan titik awal rute</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Gunakan pencarian atau ketuk pada peta untuk menambahkan titik tujuan</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Kelola rute</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Rencana</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Hapus pemberhentian</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Tambah perhentian</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Tersimpan</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Silahkan login ke OpenStreetMap untuk mengupload semua hasil edit peta Anda secara otomatis. Pelajari lebih lanjut &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;di sini&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Masalah akses penyimpanan</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Penyimpanan eksternal tidak tersedia, mungkin Kartu SD sudah dilepaskan, rusak, atau sistem berkasnya hanya dapat dibaca. Silakan periksa dan beri tahu kami di alamat support@ maps.me</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulasi penyimpanan yang buruk</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Harap masukkan nama yang benar</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Daftar</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Sembunyikan semua</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Perlihatkan semua</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n markah</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Buat daftar baru</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Impor penanda dan trek</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Tidak dapat berbagi karena kesalahan aplikasi</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Kesalahan dalam membagikan</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Tidak dapat membagikan daftar kosong</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Namanya tidak boleh kosong</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Silakan masukkan nama daftar</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Daftar baru</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Nama ini sudah dipakai</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Silakan pilih nama lain</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Mohon tunggu…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Nomor telepon</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file ditemukan. Anda akan melihatnya setelah konversi.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Mengembalikan</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trek</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privasi</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Kebijakan privasi</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Ketentuan penggunaan</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Lalu lintas</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Pendakian</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Bersepeda</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Kereta bawah tanah</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Gaya dan Lapisan Peta</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Daftar ini kosong</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Untuk menambahkan bookmark, ketuk satu tempat di peta lalu ketuk ikon bintang</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Ubah warna semua bookmark</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Ubah warna semua trek</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…selengkapnya</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Ekspor KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Ekspor GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Ekspor GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Hapus Daftar</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Kamera cepat</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Deskripsi Tempat</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Pengunduh peta</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Untuk memperingatkan Anda agar tidak ngebut</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Selalu peringatkan</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Jangan pernah peringatkan</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mode hemat daya</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Saat mode otomatis dipilih, aplikasi mulai menonaktifkan fitur yang menghabiskan daya baterai, bergantung pada tingkat daya baterai saat ini</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Jangan pernah</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Otomatis</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Hemat daya maksimum</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Menandai nama di peta</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Jika ada terlalu banyak penanda, menampilkan nama mereka di peta dapat memperlambat aplikasi.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Tunjukkan ke kanan</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Tampilkan di bagian bawah</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Opsi ini mengaktifkan pencatatan untuk tujuan diagnostik. Bisa amat membantu bagi staf dukungan kami yang memecahkan masalah dalam aplikasi. Aktifkan opsi ini hanya saat diminta oleh dukungan Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Pilihan berkendara</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Hindari jalan tol</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Hindari jalan tanah</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Hindari feri</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Hindari jalan raya</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Tidak dapat menghitung rute</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Sayangnya kami tidak dapat menemukan rute karena opsi pilihan Anda. Harap ubah pengaturan lalu coba lagi</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Tentukan jalan yang dihindari</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opsi perutean diaktifkan</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Jalan tol</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Jalan tanah</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Penyeberangan kapal feri</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ya</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Tidak</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ya</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Tidak</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapasitas: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Jaringan: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Anda telah tiba!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Oke</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Urutkan…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Urutkan bookmark</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Standar</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Per tipe</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Per jarak</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Per tanggal</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Berdasarkan Nama</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Seminggu yang lalu</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Sebulan yang lalu</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Lebih dari sebulan yang lalu</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Lebih dari setahun yang lalu</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Dekat dengan saya</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Lainnya</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Sudah sampai di tujuan</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Kedatangan: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Anda telah mengubah peta dunia. Jangan menyembunyikan ini! Katakan kepada teman-teman Anda, dan edit bersama.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Bagikan dengan teman-teman</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Sekarang Tutup</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Dibuka besok pada pukul %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Membuka %1 di %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Dibuka di %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Ditutup pada %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Tambah jam kerja</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Kata Sandi (minimal 8 karakter)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nama pengguna dan Kata sandi tidak valid.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Akun OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Pengunggahan terakhir</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Terima kasih</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nama tempat</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telepon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Harap diperhatikan</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Unduh kesalahan</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Pilih kategori</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populer</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Semua kategori</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Tambahkan tempat-tempat baru di peta, dan edit peta-peta yang ada langsung dari aplikasi.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Ubah lokasi</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Untuk mengunduh, Anda perlu ruang lebih banyak. Harap menghapus data yang tidak diperlukan.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Saya meningkatkan peta Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Komentar mendetail</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Saran perubahan Anda akan dikirimkan ke komunitas OpenStreetMap. Jelaskan detail yang tidak dapat diedit di Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Terjadi kesalahan saat mencari lokasi Anda. Periksa apakah perangkat Anda bekerja dengan benar dan coba lagi nanti.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Identifikasi lokasi dinonaktifkan</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Izinkan akses ke geolokasi pada pengaturan perangkat</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Buka Pengaturan</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Ketuk Lokasi</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Pilih While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Pilih Privasi</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Pilih Layanan Lokasi</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Aktifkan Layanan Lokasi</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Atau lanjutkan menggunakan Organic Maps tanpa Lokasi</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Pesan</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Hubungi</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nama Bookmark</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Hapus Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Catatan Anda akan dikirim ke OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…selebihnya</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Memperbarui</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Nonaktifkan rekaman dari rute yang baru Anda lalui?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Nonaktifkan</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Lihat</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps menggunakan geoposisi di latar belakang untuk merekam rute yang baru Anda lalui.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Setelan umum</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Untuk menampilkan data lalu lintas, aplikasi ini harus diperbarui.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Ukuran file log: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Seret ke sini untuk menghapus</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Ganti Berhenti</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Mulai dari</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Silahkan login ke OpenStreetMap untuk mengupload semua hasil edit peta Anda secara otomatis. Pelajari lebih lanjut</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>di sini</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Sembunyikan Layar</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 dari %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Mengunduh %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Menerapkan %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Nama ini terlalu panjang</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>File baru terdeteksi</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Mengubah</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Kesalahan</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Beberapa file tidak dikonversi.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Terjadi kesalahan</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populer</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Sembunyikan dari peta</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Kesalahan terjadi saat memuat tag, silakan coba lagi</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Kasus</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bawah</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Ayo</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Tujuan</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Pusatkan ulang</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Hasil pencarian</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Lalu</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Anda ingin membuat ulang rute?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Papan ketik tidak tersedia saat berkendara</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Tidak dapat membuat rute dari lokasi saat ini</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Tidak dapat membuat rute ke tujuan Anda. Pilih titik lainnya</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Tidak ada sinyal GPS. Harap pindah ke area terbuka</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Tidak dapat membuat rute. Harap tentukan titik rute lainnya</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Untuk membuat rute, unduh peta baru di perangkat anda</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Terjadi kesalahan. Harap mulai ulang aplikasi</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Rute akan dibuat ulang dari lokasi saat ini</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Rute akan diubah untuk mobil</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Tidak semua penanda ditampilkan</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Beralih ke telepon untuk melihat semua penanda</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcam</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Info kecepatan</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Silakan unduh peta di apl Organic Maps pada perangkat Anda</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Jalan keluar ke %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Urutkan standar</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Urutkan per tipe</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Urutkan per jarak</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Urutkan per tanggal</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Urutkan berdasarkan nama</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Makanan</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Tempat Rekreasi</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museum</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Taman</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Kolam renang</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Pegunungan</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Kebun binatang</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotel</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Gedung</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Uang</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Pusat perbelanjaan</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkir</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>SPBU</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Obat</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Cari dalam daftar</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Tempat ibadah</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Pilih daftar</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigasi kereta bawah tanah di wilayah ini belum tersedia</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Jalur kereta bawah tanah tidak ditemukan</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Silakan pilih titik awal atau akhir yang lebih dekat ke stasiun kereta bawah tanah</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Isometrik</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Untuk mengaktifkan dan menggunakan lapisan topografi, silakan perbarui atau unduh peta area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Lapisan topografi belum tersedia untuk wilayah ini</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Menanjak</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Menurun</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. tinggi</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. tinggi</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Kesulitan</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Jarak:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Waktu:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Perbesar untuk menjelajahi garis kontur</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Mengunduh</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Unduh peta ikhtisar dunia</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Tidak dapat membuat folder dan memindahkan file di memori perangkat internal atau sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Kesalahan disk</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Kegagalan koneksi</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Lepaskan kabel USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Biarkan layar tetap menyala</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Apabila diaktifkan, layar akan selalu menyala ketika menampilkan peta.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Menampilkan di layar kunci</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Ketika diaktifkan, aplikasi akan bekerja pada layar kunci bahkan ketika perangkat terkunci.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Bahasa peta</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Data peta dari OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/id/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Terima kasih telah menggunakan peta buatan komunitas kami!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Dengan donasi dan dukungan Anda, kami dapat membuat peta terbaik di Dunia!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Apakah Anda menyukai aplikasi kami? Silakan berdonasi untuk mendukung pengembangan! Belum menyukainya? Harap beri tahu kami, dan kami akan memperbaikinya!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Jika Anda mengenal seorang pengembang perangkat lunak, Anda dapat memintanya untuk mengimplementasikan fitur yang Anda perlukan.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Ketuk di mana saja pada peta untuk memilih apa pun. Ketuk lama untuk menyembunyikan dan menampilkan kembali antarmuka.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Tahukah Anda bahwa Anda dapat memilih lokasi Anda saat ini di peta?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Anda dapat membantu menerjemahkan aplikasi kami ke dalam bahasa Anda.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Aplikasi kami dikembangkan oleh beberapa peminat dan komunitas.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Anda dapat dengan mudah memperbaiki dan meningkatkan data peta.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Tujuan utama kami adalah membuat peta yang cepat, berfokus pada privasi, dan mudah digunakan yang akan Anda sukai.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Anda sekarang menggunakan Organic Maps pada layar ponsel</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Anda sekarang menggunakan Organic Maps pada layar mobil</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Anda terhubung ke Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Lanjutkan di telepon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Ke layar mobil</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps membutuhkan akses lokasi. Jika sudah aman, periksa notifikasi di ponsel Anda.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Aplikasi ini membutuhkan izin Anda</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps di Android Auto membutuhkan izin lokasi agar dapat bekerja secara efektif</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Memberikan Izin</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Pendakian</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Browser web tidak tersedia</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Mengekspor semua Penanda dan Trek</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Pengaturan sistem sintesis ucapan</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Pengaturan Sintesis Ucapan tidak ditemukan, apakah Anda yakin perangkat Anda mendukungnya?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Berkendara melewati</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Menghapus pencarian</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Memperbesar</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Perkecil</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Tautan menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Lihat Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Buka di Aplikasi Lain</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Layanan mandiri</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Pilih opsi</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Tempat duduk di luar ruangan</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Untuk navigasi yang paling akurat, kami sarankan untuk menonaktifkan mode hemat daya dalam pengaturan baterai ponsel.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Merekam jalur</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Hentikan perekaman jalur</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Perekaman Jalur</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Berhenti tanpa menyimpan</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Lanjutkan perekaman</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Menyimpan ke penanda dan jalur?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Jalur kosong - tidak ada yang bisa disimpan</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Tidak dapat menampilkan dialog pemilihan folder karena tidak ada aplikasi yang sesuai yang diinstal pada perangkat Anda. Instal aplikasi pengelola file dan coba lagi</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Pilih Warna</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Jalur</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Tidak ada Aplikasi yang diinstal yang dapat membuka lokasi</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Otomatis dalam navigasi</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Ikuti sistem</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Bagikan Lintasan</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Hapus %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Tingkat kesulitan</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Mudah</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Sedang</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Sulit</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Memperbarui</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Perbarui peta yang sudah Anda unduh</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Memperbarui peta membuat informasi tentang objek tetap terkini</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Pembaruan (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Perbarui secara manual nanti</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Hapus Trek</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Apakah Anda yakin ingin menghapus trek ini?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nama Trek</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Pindah</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trek</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Mengubah warna</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Peta</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Apakah Anda ingin mengirim laporan bug ke pengembang?
+Kami mengandalkan pengguna kami karena Organic Maps tidak mengumpulkan informasi kesalahan secara otomatis. Terima kasih sebelumnya karena telah mendukung Peta Organik!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Mengaktifkan Sinkronisasi iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Sinkronisasi iCloud adalah fitur eksperimental yang sedang dikembangkan. Pastikan Anda telah membuat cadangan semua penanda dan lagu Anda.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Dinonaktifkan</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aktifkan iCloud di pengaturan perangkat Anda untuk menggunakan fitur ini.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktifkan</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Cadangan</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Kegagalan sinkronisasi iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Kesalahan: Gagal menyinkronkan karena kesalahan koneksi</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Kesalahan: Gagal menyinkronkan karena kuota iCloud terlampaui</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Kesalahan: iCloud tidak tersedia</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Daftar yang Baru Saja Dihapus</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Hapus</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Hapus Semua</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Pulihkan</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Pulihkan Semua</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Berkontribusi ke OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Tambahkan Tempat</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Perbarui Peta untuk Berkontribusi</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Anda harus memperbarui peta %1 ke versi terbaru sebelum dapat berkontribusi pada data OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Posisi Saya</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Tempat-tempat Saya</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Penyimpanan pribadi internal</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Penyimpanan bersama internal</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Kartu SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Penyimpanan bersama eksternal</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Kode Pos</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Titik Peta</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mil</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>kaki</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Untuk menampilkan rute, peta harus diperbarui.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Keluar</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Tempat masuk</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Peta metro tidak tersedia</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Anda</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Wilayah unduhan berwarna ungu</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rute</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Menentukan lokasi saat ini di latar belakang diperlukan untuk menikmati fungsi aplikasi. Digunakan dalam opsi mengikuti rute dan menyimpan jalur yang telah Anda tempuh baru-baru ini.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Mendefinisikan lokasi saat ini digunakan dalam opsi-opsi mengikuti rute dan menghemat jalur yang Anda tempuh saat ini.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Masuk dengan kata sandi</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Masuk menggunakan Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Baru-baru ini digunakan</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Warna bookmark diubah</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Warna trek diubah</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Penggeser</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>MERAH</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>HIJAU</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BIRU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Warna Heksa sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Kisi</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/is/omim.ts
+++ b/qt/translations/is/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="is">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Til baka</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Hætta við</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Eyða</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Sækja landakort</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Mistókst að sækja. Ýttu til að reyna aftur.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Sæki…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kílómetrar</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mílur</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Seinna</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Leita</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Leita á korti</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Allar staðsetningarþjónustur eru óvirkar fyrir þetta forrit eða tæki. Virkjaðu þær í stillingunum.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Takmörkuð nákvæmni</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Til að tryggja nákvæma leiðsögn ættirðu að virkja nákvæma staðsetningu í stillingunum.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Birta á kortinu</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Mistókst að sækja</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Reyndu aftur</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Um Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Ókeypis fyrir alla, unnið af alúð</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Engar auglýsingar, engar njósnir, engin gagnasöfnun</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Tæmir ekki rafhlöðuna, virkar án nettengingar</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Hraðvirkt, mínímalískt, hannað af notendunum</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Forrit með opinn grunnkóða sem útbúið er af áhugafólki og sjálfboðaliðum.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Staðsetningarstillingar</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Loka</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Forritið krefst OpenGL-vélbúnaðarhröðunar. Því miður er tækið þitt ekki stutt.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Sækja</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Aftengdu USB-kapal eða settu inn minniskort til að nota Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Losaðu fyrst um eitthvað pláss á SD-minniskorti/USB-geymslu til að nota forritið</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Áður en þú byrjar skaltu sækja heims-yfirlitskortið yfir á tækið þitt.
+Það mun nota %1 af tiltæku minni.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Fara á kort</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Sæki %1. Þú getur núna
+farið yfir á landakortið.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Sækja %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Uppfæra %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Bið</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Halda áfram</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Mistókst að sækja %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Bæta við nýjum lista</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Heiti bókamerkjalista</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bókamerki</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bókamerki og ferlar</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nafn</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Heimilisfang</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Listi</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Stillingar</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Vista landakort í</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Veldu möppu til að vista kort inn í.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Sótt kort</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 laust af %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Færa landakort?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Villa kom upp við flutning á landakortaskrám</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Þetta gæti tekið nokkrar mínútur.
+Hinkraðu við.…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mælieiningar</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Veldu á milli kílómetra og mílna</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Hætta við niðurhal</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Skildu eftir umsögn</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Já</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Sækja kort</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bókamerkjalisti</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Út að borða</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Matvörur</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Samgöngur</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Bílastæði</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Verslun</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Notaðar vörur</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hótel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Skoðunarverðir staðir</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Skemmtun</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Hraðbanki</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Næturlíf</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Fjölskylduafþreying</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banki</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Lyfjabúð</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Sjúkrahús</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Salerni</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Póstur</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Lögreglustöð</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Endurvinnsla</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vatn</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Aðstaða fyrir húsbíla</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Minnispunktar</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bókamerkjum var deilt með þér</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Halló!
+
+Meðfylgjandi eru bókamerkin mín; endilega opnaðu þau í Organic Maps forritinu. Ef þú ert ekki með það uppsett geturðu sótt það hér: https://omaps.app/get?kmz&#32;
+
+Njóttu ferðarinnar með Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Hleð inn bókamerkjum</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Tókst að hlaða inn bókamerkjum! Þú getur skoðað þau á landakortinu eða í bókamerkjasafninu.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Mistókst að hlaða inn bókamerkjum. Skráin gæti verið skemmd eða gölluð.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Forritið þekkti ekki skráategundina:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Mistókst að opna skrána %1&#32;
+&#32;
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Breyta</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ekki er enn búið að ákvarða staðsetninguna þína</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Því miður, stillingar á geymslu korta eru óvirkar.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Verið er að sækja landakort.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Skoðaðu núverandi staðsetninguna mína á Organic Maps landakortinu! %1 eða %2 Ertu ekki með ónettengd kort? Sæktu þau hér: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hæ, skoðaðu staðsetninguna mína á Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hæ, skoðaðu núverandi staðsetninguna mína á Organic Maps landakortinu!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hæ,&#32;
+&#32;
+Ég er núna hérna: %1. Smelltu á þennan tengil %2 eða þennan %3 til að sjá staðinn á kortinu.&#32;
+&#32;
+Bestu þakkir.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Deila</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Tölvupóstur</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Afritað á klippispjald: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Lokið</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-gögn: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ertu viss um að þú viljir skrá þig út af OpenStreetMap-aðgangnum þínum?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Ferlar</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lengd</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Deila staðsetningu minni</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Almennar stillingar</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Upplýsingar</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Leiðsögn</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Hnapparnir „+“ og „-“ á kortinu</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Birta á kortinu</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Næturstíll þegar siglt er í myrkri</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Næturhamur</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Slökkt</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Kveikt</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Sjálfvirkt</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Fjarvíddarsýn</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-byggingar</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-byggingar eru óvirkar í orkusparnaðarham</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Talaðar leiðbeiningar</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Tilkynna götuheiti</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Þegar þetta er virkt verður nafn götu eða útafkeyrsla sem á að beygja inn á lesið upphátt.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Tungumál raddar</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Til að sækja rödd í meiri gæðum skaltu opna Stillingar-forritið og fara í Aðgengi → VoiceOver → Tal → Rödd.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Prófa raddleiðsögn (TTS, texti-í-tal)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Athugaðu hljóðstyrk eða stillingar á texti-í-tal ef þú heyrir ekkert núna.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ekki tiltækt</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Sjálfvirkur aðdráttur</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Vegalengd</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Skoða á korti</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Valmynd</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Vefsvæði</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Fréttir</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Umsagnir</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Gefðu forritinu einkunn</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hjálp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Algengar spurningar (FAQ)</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Styrkja</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Hef þegar styrkt verkefnið</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Áminna mig síðar</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Styddu við Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Styddu við verkefnið</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Höfundarréttur</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Tilkynna um villu</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Bættu nákvæmni örvarinnar með því að hreyfa símann í áttu-hreyfingu til að kvarða áttavitann.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Hreyfðu símann í áttu-hreyfingu til að kvarða áttavitann og laga þannig stefnu örvarinnar á kortinu.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ýttu á kortið og haltu til að sjá viðmótið</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Uppfæra allt</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Hætta við allt</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Niðurhalað</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Í biðröð</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Nálægt mér</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Landakort</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Sækja allt</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Sæki:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Til að eyða korti skaltu stöðva leiðsögn.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Leiðir er aðeins hægt að útbúa þar sem þær eru að fullu innan landakorts af stöku héraði.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Sækja kort</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Reyna aftur</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Eyða landakorti</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Uppfæra kort</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play staðsetningarþjónustur</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Ákvarðaðu í skyndi staðsetninguna þína með Bluetooth, WiFi eða farsímaneti</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Sækja öll landakort meðfram leiðinni þinni</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Til þess að geta útbúið leiðina, þá þarf að sækja og uppfæra öll landakortin frá staðsetningunni þinni og að ákvörðunarstað.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ekki nægilegt pláss</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Virkjaðu staðsetningarþjónustur</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Vista</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>búa til</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rautt</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Gult</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blátt</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Grænt</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purpurablátt</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Appelsínugult</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brúnt</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Bleikt</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Dökkpurpurablátt</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Ljósblátt</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Grænblátt (cyan)</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Blágrænt</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Límónugrænt</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Dimmappelsínugult</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grátt</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blágrátt</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Upplýsingar</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps útgáfa: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Útlit</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Ljóst</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dökkt</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Ljós frá dögun til kvölds</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Annað</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gefðu milljónum notenda ókeypis kort án auglýsinga!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Tilkynntu eða lagaðu röng kortagögn</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Bjóða sig fram</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Fylgjast með okkur og hafa samband:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Tölvupóstforrit hefur ekki verið sett upp. Stilltu það eða hafðu samband við okkur á %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Villa við að senda tölvupóst</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kvörðun áttavita</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Tiltækt</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Fannst</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Uppfærsla</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Mistókst</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bókamerki</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Þegar ferðast er eftir leið, skaltu hafa eftirfarandi í huga:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Ástand vega, umferðarreglur og vegmerkingar hafa alltaf forgang fram yfir ábendingar í leiðsögn;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Landakortið getur verið ónákvæmt og leiðin sem stungið er upp á þarf ekki að vera besta leiðin til að ná á ákvörðunarstað;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Leiðir sem stungið er upp á ætti einungis að skilja sem meðmæli;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Sýndu aðgætni á leiðum nálægt jaðarsvæðum: leiðirnar sem forritið útbýr gætu stundum farið yfir landamæri á stöðum sem ekki er leyfilegt að fara um.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Vertu vakandi og settu öryggið ofar öllu á vegum úti!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Athuga GPS-merki</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Tókst ekki að útbúa leið. Fyrirliggjandi GPS-hnit var ekki hægt að auðkenna.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Athugaðu GPS-merkið þitt. Ef þú virkjar Wi-Fi verður staðsetningin þín nákvæmari.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Virkjaðu staðsetningarþjónustur</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Tókst ekki að staðsetja fyrirliggjandi GPS-hnit. Virkjaðu staðsetningarþjónustur til að reikna leiðina.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Tókst ekki að staðsetja leið</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Tókst ekki að útbúa leið.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Aðlagaðu upphafsstaðinn eða ákvörðunarstað.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Aðlaga upphafsstað</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Leið var ekki útbúin. Tókst ekki að staðsetja upphafsstaðinn.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Veldu upphafsstað sem er nær vegi.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Aðlaga ákvörðunarstað</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Leið var ekki útbúin. Tókst ekki að staðsetja ákvörðunarstaðinn.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Veldu ákvörðunarstað sem er nær vegi.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Tókst ekki að staðsetja milliáfangann.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Aðlagaðu milliáfangann þinn.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Kerfisvilla</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Tókst ekki að útbúa leið vegna villu í forriti.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Endilega reyndu aftur</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ekki núna</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Myndirðu vilja sækja landakortið og útbúa þægilegri leið sem spannar fleiri en eitt landakort?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Sækja viðbótar-landakort til að útbúa þægilegri leið sem fer út fyrir mörk þessa landakorts.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Sækja nauðsynlegar skrár</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Sæktu eða uppfærðu öll landakort meðfram áætluðum ferli til að reikna leið.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Til að byrja að leita og útbúa leiðir skaltu sækja landakortið. Eftir það er internettenging ekki nauðsynleg.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Veldu kort</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Sýna</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Fela</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Flokkar</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Breytingaferill</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Úbbs, engar niðurstöður fundust.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Sæktu kortið af því svæði sem þú ert að leita á eða prófaðu að bæta við nafni á nálægum bæ eða þorpi.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Leitarferill</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Skoðaðu nýlegar leitir þínar.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Hreinsa leitarferil</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Grein frá wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Staðsetning þín</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Upphaf</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Leið frá</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Leið til</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Leiðsögn er aðeins möguleg frá fyrirliggjandi staðsetningu þinni.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Viltu skipuleggja leið frá fyrirliggjandi staðsetningu þinni?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Næsta</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Frá</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Til</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Bæta við áætlun</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Eyða áætlun</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Allan sólarhringinn (24 klst)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Opið</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Lokað</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Bæta við ekki-opnunartímum</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Opnunartímar</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Ítarlegri hamur</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Einfaldur hamur</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Ekki-opnunartímar</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Dæmi um gildi</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Leiðrétta mistök</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Veldu staðsetningu</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Lýstu vandamálinu nákvæmlega svo meðlimir OpenStreetMap samfélagsins geti lagfært það.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Eða gerðu það sjálf/ur á https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Senda</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Vandamál</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Þessi staður er ekki til</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Lokað vegna viðhalds</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Tvítekinn staður</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Sækja kort sjálfvirkt</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daglega</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Lokað í dag</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Lokað</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Í dag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opnar eftir %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Lokar eftir %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Lokað</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Breyta opnunartímum</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Ertu ekki með OpenStreetMap-aðgang?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Skráðu þig á OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Skrá inn</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Ekki skráð/ur inn</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Skrá inn á OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Lykilorð</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Gleymdirðu lykilorðinu?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Skrá út</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Breyta stað</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Bæta við tungumáli</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Gata</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Bygging númer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Nánar</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Samfélagsmiðlar</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bygging</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Bæta við götu</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Settu inn götuheiti</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Veldu tungumál</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Veldu götu</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Eldhús</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Veldu matreiðsluhefð</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Tölvupóstur eða notandanafn</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Bæta við símanúmeri</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Hæð</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Hæð: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Öllum breytingunum þínum verður eytt með kortinu.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Uppfæra kort</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Til að búa til leið þarftu að uppfæra öll kort og síðan skipuleggja leiðina aftur.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Finna kort</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Gakktu úr skugga um að tækið sé tengt við internetið.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ekki nægilegt pláss</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Eyddu öllum ónauðsynlegum gögnum</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Villa við innskráningu.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Staðfestar breytingar</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Dragðu kortið þannig að krossinn lendi á staðnum eða fyrirtækinu.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Breytingar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Bæti við</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nafn staðarins</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Eins og það er skrifað á tungumáli staðarins</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Flokkur</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Nánari lýsing á vandamálinu</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Annað vandamál</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Bæta við fyrirtæki</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ekki er hægt að staðsetja neitt atriði hér</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>OpenStreetMap-gögn gerð af þátttakendum eins og þau voru %1. Fræðstu betur um hvernig hægt sé að breyta og uppfæra landakortið á OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) er samfélagsverkefni sem stefnir að uppbyggingu á frjálsu og opnu landakorti. Þetta er meginuppistaðan í Organic Maps og virkar svipað og Wikipedia. Þú getur bætt við eð breytt stöðum, og verða þeir þá aðgengilegir milljónum notenda um víða veröld.
+Taktu þátt og hjálpaðu til við að gera betri landakort fyrir alla!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Útbúðu OpenStreetMap aðgang eða skráðu þig inn til að birta breytingarnar þínar.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 af %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Sækja í gegnum gagnatengingu farsíma?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Þetta gæti verið dýrt á sumum tegundum áskrifta eða ef verið sé á reiki.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Settu inn gilt númer byggingar</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Fjöldi hæða (hámark %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Fjöldi hæða getur ekki verið meiri en %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Póstnúmer</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Settu inn gilt póstnúmer</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Minnispunktur til sjálfboðaliða OpenStreetMap (valfrjálst)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Lýstu villum á kortinu eða atriðum sem ekki er hægt að breyta með Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Breytingarnar þínar eru sendar inn í opinbera &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-gagnagrunninn. Ekki bæta við neinum persónulegum upplýsingum eða upplýsingum með höfundarrétti.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Meira um OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Breytingaferillinn þinn</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Minnispunktar þínir við gögn korts</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Rekstraraðili</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Rekstraraðili: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Finnurðu ekki hentugan flokk?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps leyfir aðeins að bæta við flokkum eins-punkts staða, sem þýðir engin sveitarfélagamörk, vegir, vötn, útlínur bygginga o.s.frv. Bættu slíkum atriðum beint inn í &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Skoðaðu &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;leiðbeiningarnar&lt;/a&gt; okkar til að sjá hvernig það er gert, skref-fyrir-skref.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Þú hefur ekki sótt nein kort</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Sæktu landakort til að leita og rata um án nettengingar.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Fyrirliggjandi staðsetning er óþekkt.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/klst</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mi/klst</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>klst</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>mín</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>sek</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Meira</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Breyta bókamerki</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Persónulegir minnispunktar (texti eða html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Athugasemd…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Henda öllum staðværum breytingum?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Henda</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Eyða viðbættum stað?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Eyða</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Staðurinn er ekki til</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Lýstu ástæðunni fyrir því að eyða staðnum</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Settu inn gilt símanúmer</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Settu inn gilt veffang</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Settu inn gilt tölvupóstfang</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Settu inn gilt Facebook-veffang, aðgang eða heiti síðu</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Settu inn gilt notandanafn á Instagram eða veffang</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Settu inn gilt notandanafn á X/Twitter eða veffang</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Settu inn gilt notandanafn á VK eða veffang</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Settu inn gilt auðkenni á LINE eða veffang</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Bæta stað í OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Eða til dæmis skilja eftir athugasemd til þátttakenda í OpenStreetMap svo einhver annar geti bætt við stað hér eða lagfært.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Athugasemd verður send til OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Viltu senda þetta til allra notenda?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Gakktu úr skugga um að þú hafir ekki sett inn nein einkagögn eða persónulegar upplýsingar.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Ritstjórar OpenStreetMap munu yfirfara breytingarnar og hafa samband við þig ef þeir eru með spurningar.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stöðva</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Skrái ferilinn</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Samþykkja</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Hafna</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Nota farsímagögn til að birta ítarlegar upplýsingar?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Alltaf nota</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Aðeins í dag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ekki nota í dag</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Farsímagögn</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Farsímagagnatenging er nauðsynleg fyrir tilkynningar um uppfærslur á korti og til að senda inn breytingar.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Aldrei nota</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Alltaf spyrja</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Til að birta umferðargögn, þarf að uppfæra kortin.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Auka stærð á skýringum</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Endilega uppfærðu Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Umferðargögn eru ekki tiltæk</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Virkja atvikaskráningu</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Almennar umsagnir</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Við notum TTS-talgervil kerfisins fyrir talaðar leiðbeiningar. Mörg Android-tæki nota TTS-kerfi Google, þú getur sótt það eða uppfært á Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Fyrir sum tungumál þarftu að setja upp talgervil eða viðbótar-tungumálapakka úr hugbúnaðarsöfnum (Google Play, Galaxy Store, App Gallery, FDroid).
+Opnaðu stillingar tækisins þíns → Tungumál og innsláttur → Tal → Texti-í-tal úttak upplesturs.
+Hér geturðu sýslað með stillingar fyrir talgervilinn (til dæmis sótt tungumálapakka til notkunar án nettengingar) og valið önnur texti-í-tal kerfi.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Til að sjá nánari upplýsingar, ættirðu að skoða þessar leiðbeiningar.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Umrita yfir í latneskt stafróf</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Kanna nánar</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Notaðu leit, veldu bókamerki eða ýttu á kortið til að bæta við upphafspunkti leiðar</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Notaðu leit, veldu bókamerki eða ýttu á kortið til að bæta við ákvörðunarstað</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Sýsla með leið</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Skipuleggja</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Fjarlægja stopp</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Bæta við stoppi</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Vistað</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Skráðu þig inn á OpenStreetMap til að senda sjálfkrafa inn allar breytingar þínar á kortinu. Kannaðu þetta nánar &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hér&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Vandamál við aðgang að gagnageymslu</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ytra geymsluminnið er ekki aðgengilegt. SD-minniskortið gæti hafa verið fjarlægt, það skemmst eða að skráakerfið sé skrifvarið. Athugaðu SD-minniskortið þitt eða hafðu samband á support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Herma eftir skemmdu geymslurými</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Settu inn rétt nafn</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listar</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Fela allt</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Sýna allt</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bókamerki</numerusform>
+<numerusform>%n bókamerki</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Búa til nýjan lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Flytja inn bókamerki og ferla</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Tókst ekki að deila vegna villu í forriti</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Villa við deilingu</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Get ekki deilt tómum lista</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Heitið má ekki vera autt</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Settu inn heiti listans</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nýr listi</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Þetta nafn er þegar í notkun</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Veldu eitthvað annað heiti</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Bíddu aðeins…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Símanúmer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap-notandasnið</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n skrá fannst. Þú getur séð hana eftir umbreytingu.</numerusform>
+<numerusform>%n skrár fundust. Þú getur séð þær eftir umbreytingu.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Endurheimta</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ferill</numerusform>
+<numerusform>%n ferlar</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Friðhelgi</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Meðferð persónuupplýsinga</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Notkunarskilmálar</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Umferð</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Gönguleiðir</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Hjólreiðar</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Neðanjarðarlest</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stílar landakorta og þekjur</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Þessi listi er tómur</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Til að bæta við bókamerki, skaltu ýta á stað á kortinu og ýta síðan á stjörnutáknið</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Breyta lit allra bókamerkja</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Breyta lit allra ferla</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…meira</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Flytja út KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Flytja út GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Flytja út GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Eyða lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Hraðamyndavélar</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Lýsing á stað</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Niðurhal landakorta</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Áminna ef farið er of hratt</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Alltaf aðvara</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Aldrei aðvara</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Orkusparnaður</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Prófaðu að minnka orkunotkun á kostnað einhverra eiginleika.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Aldrei</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Þegar lítil rafhleðsla er eftir</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Alltaf</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nöfn bókamerkja á kortinu</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ef það eru of mörg bókamerki, getur hægt á forritinu að birta nöfn þeirra á kortinu.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Birta hægra megin</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Birta neðst</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Virkjaðu þennan valkost tímabundið til að skrá og senda síðan handvirkt nákvæma greiningarskrá um vandamálið þitt með því að nota &quot;Tilkynna um villu&quot; í hjálparglugganum. Slíkar atvikaskrár geta innihaldið upplýsingar um staðsetningu.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Valkostir leiðagerðar</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Forðast gjaldskyldu</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Forðast vegi með óbundnu slitlagi</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Forðast ferjur</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Forðast hraðbrautir</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Tókst ekki að reikna leið</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Leið fannst ekki. Það gæti stafað af stillingum þínum fyrir leiðagerð eða ófullkomnum gögnum í OpenStreetMap. Breyttu stillingum þínum fyrir leiðagerð og prófaðu aftur.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Skilgreindu vegi sem á að forðast</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Valkostir leiðagerðar virkir</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Vegur með gjaldskyldu</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Óbundið slitlag</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Þverun með ferju</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Já</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nei</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Já</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nei</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Rými: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netkerfi: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Þú hefur náð á áfangastað!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Í lagi</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Raða…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Raða bókamerkjum</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Sjálfgefið</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Eftir gerð</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Eftir vegalengd</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Eftir dagsetningu</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Eftir nafni</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Fyrir viku síðan</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Fyrir mánuði síðan</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Fyrir meira en mánuði síðan</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Fyrir meira en ári síðan</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Nálægt mér</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Annað</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Skipulagning ferðar mistókst</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Koma kl. %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Sæktu og uppfærðu öll landakort meðfram áætluðum ferli til að reikna leið.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Þú hefur breytt heimskortinu! Ekki halda því leyndu; segðu vinum þínum frá og þið getið haldið áfram að laga það saman.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Deildu með vinum</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Lokað núna</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opnar á morgun kl. %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opnar %1 kl. %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opnar %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Lokar %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Bæta við opnunartímum</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Lykilorð (lágmark 8 stafir)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Rangt notandanafn eða lykilorð.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-notandaaðgangur</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Síðasta innsending</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Bestu þakkir</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Staðarheiti</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Símanúmer</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Athugaðu</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Villa við að sækja gögn</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Veldu flokk</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Vinsælt</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Allir flokkar</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Bættu nýjum stöðum á kortið og breyttu fyrirliggjandi stöðum beint úr forritinu.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Breyta staðsetningu</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Til að sækja þarftu meira pláss. Eyddu öllum ónauðsynlegum gögnum.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ég hef bætt landakort Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Ítarleg athugasemd</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Breytingarnar á kortinu sem þú hefur stungið upp á verða sendar til þátttakenda í OpenStreetMap-verkefninu. Lýstu öllum nánari smáatriðum sem ekki er hægt að breyta í Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Villa kom upp við að ákvarða staðsetninguna þína. Athugaðu hvort tækið þitt virki rétt og reyndu aftur síðar.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Staðsetningarþjónustur eru óvirkar</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Virkjaðu aðgang að hnattstaðsetningu í stillingum tækisins</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Opna stillingar</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Ýttu á staðsetningu</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Veldu á meðan forritið er notað</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Veldu meðferð persónuupplýsinga</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Veldu staðsetningarþjónustur</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Kveiktu á staðsetningarþjónustum</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Eða haltu áfram að nota Organic Maps án staðsetningar</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Bóka</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Hringja</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Heiti bókamerkis</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Eyða bókamerki</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Minnispunkturinn þinn verður sendur til OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…meira</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Uppfæra</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Gera óvirka upptöku af leiðinni sem þú varst að ferðast eftir?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Gera óvirkt</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Kíktu á</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps notar staðsetningu þína í bakgrunni til að skrá leiðina sem þú varst að ferðast eftir.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Almennar stillingar</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Til að birta umferðargögn, þarf að uppfæra forritið.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Stærð atvikaskrár: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Dragðu hingað til að fjarlægja</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Skipta út stoppi</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Byrja frá</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Skráðu þig inn á OpenStreetMap til að senda sjálfkrafa inn allar breytingar þínar á kortinu. Kannaðu þetta nánar</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hér</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Fela skjá</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 af %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Sæki %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Virkja %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Þetta heiti er of langt</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nýjar skrár fundust</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Umbreyta</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Villa</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Sumum skrám var ekki umbreytt.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Villa kom upp</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Vinsælt</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Fela á korti</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Villa kom upp við að hlaða inn merkjum, reyndu aftur</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Hægri</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Neðst</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Hefjumst handa</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Ákvörðunarstaður</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Endurmiðja</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Leitarniðurstöður</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>síðan</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Viltu endurhanna þessa leið?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Lyklaborð er ekki tiltækt á meðan akstri stendur</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Tekst ekki að skipuleggja leið frá fyrirliggjandi staðsetningu þinni</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Tekst ekki að finna leið að ákvörðunarstaðnum þínum. Veldu einhvern annan endapunkt</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ekkert GPS-merki. Færðu þig yfir á opið svæði</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Tekst ekki að skipuleggja leið. Tilgreindu einhverja aðra leiðarpunkta</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Til að útbúa leið skaltu sækja kortin sem vantar á tækið þitt</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Villa kom upp. Endurræstu forritið</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Leiðin verður endurhönnuð frá fyrirliggjandi staðsetningu þinni</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Leiðinni verður umbreytt í leið fyrir akstur</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ekki eru öll bókamerki birt</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Skiptu yfir í símann til að sjá öll bókamerki</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Hraðamyndavélar</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Aðvaranir um hraðatakmörk</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Sæktu landakort í forritinu á snjalltækinu þínu</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 útkeyrsla</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Raða eftir sjálfgefnu</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Raða eftir tegund</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Raða eftir vegalengd</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Raða eftir dagsetningu</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Raða eftir nafni</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Matur</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Skoðunarverðir staðir</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Söfn</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Almenningsgarðar</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Sund</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Fjöll</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Dýr</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hótel</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Byggingar</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Peningar</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Verslanir</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Bílastæði</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Bensínstöðvar</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Lækningar</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Leita í listanum</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Trúarlegir staðir</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Veldu lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Leiðsögn í neðanjarðarlestum er ekki tiltæk í augnablikinu á þessu svæði</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Engin neðanjarðarlestarleið fannst</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Veldu upphafs- eða endastað sem er nær neðanjarðarlestarstöð</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Hæðarlínur</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Til að virkja hæðarlínur þarf að sækja kortagögn fyrir þetta svæði</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Hæðarlínur eru ennþá ekki tiltækar á þessu svæði</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Hækkun</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Lækkun</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Lágm.hæð</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Hám.hæð</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Erfiðleikastig</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Fjarl.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tími:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Renndu að til að skoða hæðarlínur</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Sæki</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Sækja heims-yfirlitskortið</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Gat ekki búið til möppu og færa skrár á innra minni tækis eða SD-minniskorti</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Villa á diski</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Tenging brást</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Aftengja USB-kapal</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Halda kveiktu á skjánum</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Þegar þetta er virkt verður alltaf kveikt á skjánum á meðan birtingu kortsins stendur.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Birta á læsiskjánum</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Þegar þetta er virkt mun forritið virka á læsiskjánum jafnvel þegar tækinu er læst.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Tungumál korts</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kortagögn frá OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Takk fyrir að nota landakortin frá samfélaginu okkar!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Með framlögum þínum og stuðningi getum við búið til bestu landakortin í heiminum!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Líkar þér forritið okkar? Styrktu okkur til að styðja áframhaldandi þróun þess! Líkar þér ekki eitthvað? Láttu okkur vita og við munum laga það!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ef þú þekkir einhvern hforritara/ugbúnaðarhönnuð, þá geturðu beðið hana/hann um að búa til einhvern eiginleika sem þér finnst vanta.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Ýttu einhversstaðar á kortið til að velja atriði. Að ýta lengi er notað til að sýna viðmótið.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Veist þú hvernig hægt er að velja núverandi staðsetningu þína?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Hjálpaðu við að þýða þetta forrit yfir á tungumálið þitt.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Forritið er hannað af nokkrum áhugasömum notendum og samfélaginu í kringum þá.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Þú getur auðveldlega lagfært og bætt kortagögnin.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Meginmarkmið okkar er að byggja hraðvirk og auðveld landakort sm þú kannt að meta og sem passa upp á persónuupplýsingar þínar.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Þú ert núna að nota Organic Maps á símaskjánum</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Þú ert núna að nota Organic Maps á bílskjánum</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Þú ert tengd(ur) við Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Halda áfram í símanum</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Yfir á skjá bílsins</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps þarf aðgang að staðsetningu. Við gott tækifæri, þegar það er öruggt, skaltu skoða tilkynninguna á símanum þínum.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Þetta forrit þarf heimild frá þér</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps í Android Auto þarf heimildir fyrir staðsetningar til að virka eðlilega</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Veita heimildir</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Utandyra</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Vafri er ekki tiltækur</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Hljóðstyrkur</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Flytja út öll bókamerki og ferla</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Kerfisstillingar talgervils</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Stillingar talgervils fundust ekki, ertu viss um að tækið þitt sé með stuðning við slíkt?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Bílaafgreiðsla</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Hreinsa leitina</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Renna að</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Renna frá</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Tengill í valmynd</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Skoða valmynd</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Opna í öðru forriti</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Sjálfsafgreiðsla</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Veldu valkost</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sæti utandyra</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Til að tryggja nákvæma leiðsögn ættirðu að gera orkusparnaðarham óvirkan í raflöðustillingum símans.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Skrá feril</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stöðva skráningu ferils</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Upptaka ferils</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stöðva án þess að vista</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Halda áfram skráningu</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Vista inn í bókamerki og ferla?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Ferill er tómur - ekkert til að vista</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Mistókst að birta val á möppum þar sem ekkert hentugt forrit er uppsett á tækinu þínu. Settu upp skráastjóra og prófaðu svo aftur.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Veldu lit</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Breyta ferli</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ekkert forrit er uppsett sem gæti opnað staðsetninguna</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Sjálfvirkt við leiðsögn</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Fylgja kerfi</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Deila ferli</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Eyða %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Erfiðleikastig</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Auðvelt</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Miðlungs</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Erfitt</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Uppfæri</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Uppfæra sótt kort</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Uppfærsla á landakortum viðheldur upplýsingum um aðstæður sem réttustum</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Uppfæra (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Uppfæra handvirkt síðar</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Eyða ferliDelete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ertu viss um að þú viljir eyða þessum ferli?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Heiti ferils</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Færa</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Ferill</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Breyta lit</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Landakort</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Myndirðu vilja senda villuskýrslu til hönnuðanna?
+Við reiðum okkur á notendurna þar sem Organic Maps safnar ekki sjálfkrafa neinum villuupplýsingum. Fyrirfram þakkir fyrir að styðja við Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Virkja samstillingu við iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Samstilling við iCloud synchronization er eiginleiki á tilraunastigi. Gakktu úr skugga um að þú hafir gert öryggisafrit af öllum bókamerkjum þínum og ferlum.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud er óvirkt</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Virkjaðu iCloud í stillingum tækisins þíns til að nota þennan eiginleika.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Virkja</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Öryggisafrit</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Villa í samstillingu iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Villa: Mistókst að samstilla vegna villu í tengingu</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Villa: Mistókst að samstilla þar sem kvótinn á iCloud er uppurinn</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Villa: iCloud er ekki tiltækt</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listi yfir nýlega eytt</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Hreinsa</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Eyða öllu</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Endurheimta</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Endurheimta alltRecover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Leggðu þitt af mörkum til OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Bæta við stað</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Uppfærðu kortið til að leggja af mörkum</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Þú þarft að uppfæra %1 kortið í nýjustu útgáfuna áður en þú getur lagt af mörkum til gagna í OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Staðsetning mín</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Staðirnir mínir</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Innbyggð einkageymsla</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Innbyggð sameiginleg geymsla</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-minniskort</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ytri sameiginleg geymsla</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Póstnúmer</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punktur á korti</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mí</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Til að birta leiðir þarf að uppfæra landakort.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Útgangur</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Inngangur</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Kort fyrir neðanjarðarlest er ekki tiltækt</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Þú</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Fjólublá niðurhluð svæði</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Leið</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Greining staðsetningar í bakgrunni er nauðsynleg til að njóta allra eiginleika forritsins. Það er notað við leiðsögn og vistun á nýförnum leiðum.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Greining staðsetningar í bakgrunni er nauðsynleg fyrir leiðsögn og vistun á nýförnum leiðum.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Innskráning með lykilorði</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Innskráning með vafra</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nýlega notað</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Lit bókamerkja breytt</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Litur ferla breytt</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Litróf</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Rennarar</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RAUTT</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GRÆNN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLÁTT</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB hex-litur #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rist</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/it/omim.ts
+++ b/qt/translations/it/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="it">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Indietro</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Elimina</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Scarica mappe</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download fallito. Riprova.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Scaricamento…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Chilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miglia</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Più tardi</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Cerca</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Cerca sulla mappa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Servizi di localizzazione del dispositivo o di questa app disattivati. Abilitali dalle impostazioni.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisione limitata</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Per garantire una navigazione accurata, attiva la funzione Posizione precisa nelle impostazioni.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostra sulla mappa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download fallito</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Riprova</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Informazioni su Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratuita per tutti, fatta con amore</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Nessun annuncio, nessun tracciamento, nessuna raccolta di dati</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Consuma poca batteria, funziona offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Veloce, minimalista, sviluppato dalla comunità</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Applicazione open-source creata da appassionati e volontari.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Impostazioni posizione</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Chiudi</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>L&#x27;app necessita di OpenGL con accelerazione hardware. Purtroppo, il tuo dispositivo non è supportato.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Scarica</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Scollega il cavo USB o inserisci la scheda di memoria per poter utilizzare Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Libera prima dello spazio sulla scheda SD/ memoria USB per utilizzare l&#x27;app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Prima di iniziare è necessario scaricare la mappa generale del mondo sul tuo dispositivo.
+La dimensione del download è di %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Vai alla mappa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Sto scaricando %1. Ora puoi&#32;
+procedere con la mappa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Scaricare %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Aggiornare %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausa</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continua</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Il download di %1 è fallito</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Aggiungi nuova lista</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nome lista</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Preferiti</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Preferiti e tracce</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nome</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Indirizzo</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Impostazioni</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Salva mappe in</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Seleziona la cartella in cui scaricare le mappe.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mappe scaricate</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 liberi su %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Spostare le mappe?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Errore durante lo spostamento delle mappe</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Può richiedere diversi minuti.
+Attendere prego…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unità di misura</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Scegli tra miglia e chilometri</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Annulla il download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Lascia una recensione</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sì</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Scarica mappa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Elenchi di luoghi preferiti</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Dove mangiare</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Alimentari</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Trasporto</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzinaio</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parcheggio</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Negozi</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Di seconda mano</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Albergo</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Luoghi turistici</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Intrattenimento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bancomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vita notturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Divertimento in famiglia</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banca</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Ospedale</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilette</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polizia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Riciclo</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Acqua</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Per camper</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Informazioni</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Questi sono i miei luoghi preferiti su Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Ciao!
+
+In allegato ci sono i miei luoghi preferiti. Aprili se hai installato Organic Maps. Oppure, se non ce l&#x27;hai, scarica l&#x27;app per iOS o Android seguendo questo link: https://omaps.app/
+
+Divertiti a viaggiare con Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Caricamento luoghi preferiti</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Luoghi preferiti caricati con successo! Puoi trovarli sulla mappa o nella schermata Gestione Luoghi preferiti.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Caricamento dei luoghi preferiti fallito. Il file potrebbe essere corrotto o difettoso.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Questo formato di file non è riconosciuto dall&#x27;app:&#32;
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Impossibile aprire il file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Modifica</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>La tua posizione non è stata ancora determinata</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Le impostazioni di archiviazione delle mappe sono disabilitate al momento.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Il download della mappa è in corso.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Guarda la mia posizione in Organic Maps! %1 o %2 Non hai scaricato l&#x27;app? La puoi scaricare da qui: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Dai un&#x27;occhiata a questo posto su Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Guarda dove mi trovo ora su Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Ciao,
+
+Sono qui adesso: %1. Clicca su questo link %2 oppure su questo %3 per vedere il posto sulla mappa.
+
+Grazie.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Condividi</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiato negli appunti: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Fatto</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dati OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Sei sicuro di voler uscire dal tuo account OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracce</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lunghezza</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Condividi la mia posizione</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Impostazioni generali</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informazioni</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigazione</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Pulsanti «+» e «-» sulla mappa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Mostra sulla mappa</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Stile notturno quando naviga al buio</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modalità notte</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Spento</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Su</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatico</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vista in prospettiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edifici 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Gli edifici 3D sono disattivati in modalità risparmio energetico</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Istruzioni vocali</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Annuncia i nomi delle strade</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Se abilitato, il nome della via o dell&#x27;uscita in cui svoltare verrà pronunciato ad alta voce.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Lingua per la voce</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Per scaricare una voce di qualità superiore, apri l&#x27;app Impostazioni e vai in Accessibilità → VoiceOver → Voce → Voce.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Prova le indicazioni vocali (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Controlla il volume o le impostazioni del sistema di sintesi vocale se ora non senti la voce.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Non disponibile</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automatico</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distanza</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Visualizza sulla mappa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Sito web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Notizie</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Vota l&#x27;app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Aiuto</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Domande frequenti</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Dona</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Già donato</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Ricorda più tardi</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Supporta Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Sostieni il progetto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Segnala un bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Migliora la direzione della freccia muovendo il telefono con un movimento a otto per calibrare la bussola.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Muovi il telefono con un movimento a otto per calibrare la bussola e fissare la direzione della freccia sulla mappa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Tap lungo di nuovo sulla mappa per visualizzare l&#x27;interfaccia</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aggiorna tutte</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Annulla tutto</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Scaricate</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>In coda</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Vicino a me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mappe</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Scarica tutte</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Sto scaricando:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Per eliminare una mappa interrompi la navigazione.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Si possono creare solo percorsi che siano completamente contenuti nella mappa di una singola regione.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Scarica mappa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Riprova</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Elimina mappa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aggiorna mappa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servizi di localizzazione di Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determina rapidamente la tua posizione approssimativa tramite Bluetooth, WiFi o rete mobile</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Scarica le mappe lungo il percorso</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Per creare un percorso è necessario scaricare e aggiornare tutte le mappe dalla tua posizione alla tua destinazione.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Spazio insufficiente</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Abilita i servizi di localizzazione</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Salva</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>crea</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rosso</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Giallo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Viola</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Arancione</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marrone</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Viola scuro</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Azzurro</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Ciano</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Blu tè</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Verde fluo</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Arancione scuro</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grigio</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Grigiazzurro</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informazioni</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versione di Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspetto</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Chiaro</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Scuro</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Chiaro dall&#x27;alba al tramonto</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Altro</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Regala mappe gratuite e senza pubblicità a milioni di utenti!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Segnala o correggi i dati della mappa non corretti</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Per fare il volontario</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Seguici e contattaci:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Il client di posta elettronica non è stato configurato. Per favore, configuralo o contattaci all&#x27;indirizzo %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Errore invio e-mail</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibrazione bussola</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponibile</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Trovate</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aggiorna</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Fallito</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>preferito</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Quando segui il percorso, ricorda che:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Le condizioni stradali, il codice della strada e la segnaletica hanno sempre la precedenza sulle indicazioni del navigatore;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— La mappa potrebbe essere imprecisa e il percorso suggerito potrebbe non essere sempre quello ottimale per raggiungere la destinazione;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— I percorsi suggeriti devono essere considerati solo come consigli;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Fai attenzione ai percorsi nelle zone di confine: i percorsi creati dalla nostra app possono, a volte, attraversare i confini di stato in zone non autorizzate.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Fai sempre attenzione e guida con prudenza!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Controlla il segnale GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Impossibile creare il percorso. Coordinate GPS attuali non disponibili.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Controlla il segnale GPS. Se abiliti il WiFi, migliorerà la precisione della posizione.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Abilita i servizi di localizzazione</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Impossibile individuare le coordinate GPS attuali. Per calcolare il percorso, abilita i servizi di localizzazione.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Impossibile individuare il percorso</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Impossibile creare il percorso.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Modifica il punto di partenza o la destinazione.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Modifica il punto di partenza</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Percorso non creato. Impossibile individuare il punto di partenza.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Seleziona un punto di partenza più vicino a una strada.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Modifica la destinazione</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Percorso non creato. Impossibile individuare la destinazione.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Seleziona una destinazione più vicina a una strada.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Impossibile individuare il punto intermedio.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Modifica il punto intermedio.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Errore di sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Impossibile creare il percorso a causa di un errore dell&#x27;applicazione.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Riprova</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Non ora</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Vuoi scaricare la mappa e creare un percorso migliore che si estende su più mappe?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Scarica altre mappe per creare un percorso migliore che attraversi i confini di questa mappa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Scarica i file necessari</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Per calcolare il percorso, scarica e aggiorna tutte le mappe lungo l&#x27;itinerario previsto.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Per iniziare a cercare e a creare i percorsi, scarica la mappa. Dopodiché non avrai più bisogno di una connessione a internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Seleziona mappa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostra</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Nascondi</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorie</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Cronologia</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Non ho trovato nulla.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Scarica la regione in cui stai effettuando la ricerca oppure prova ad aggiungere il nome di una città/villaggio vicino.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Cronologia delle ricerche</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Visualizza le ricerche recenti.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Elimina cronologia ricerche</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Articolo tratto da wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>La tua posizione</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Inizia</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Parti da</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Vai a</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>La navigazione è disponibile solo dalla tua posizione attuale.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Vuoi pianificare un percorso dalla tua posizione attuale?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Avanti</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Dalle</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Alle</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Aggiungi orario</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Elimina orario</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Tutto il giorno (24 ore)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Aperto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Chiuso</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Aggiungi orari di chiusura</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Orari di apertura</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modalità avanzata</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modalità semplice</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Orari di chiusura</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Esempi</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correggi errore</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Seleziona la posizione</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Descrivi il problema in dettaglio in modo che la comunità di OpenStreetMap possa correggere l’errore.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>O fallo tu stesso su https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Invia</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Questo luogo non esiste</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Chiuso per manutenzione</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Luogo duplicato</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Scaricamento automatico</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Tutti i giorni</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Oggi chiuso</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Chiuso</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Oggi</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Apre tra %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Chiude tra %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Chiuso</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Modifica orari di apertura</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Non hai un account OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Iscriviti a OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Accedi</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Accesso non effettuato</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Accedi a OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Hai dimenticato la password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Esci</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Modifica luogo</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Aggiungi una lingua</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Via</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numero civico</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Dettagli</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edificio</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Aggiungi una via</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Inserisci il nome della via</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Scegli una lingua</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Scegli una via</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cucina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Seleziona la cucina</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email o nome utente</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Aggiungi numero</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Piano</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Piano: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Tutte le tue modifiche alla mappa saranno eliminate insieme alla mappa.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Aggiorna mappe</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Per creare un percorso, devi aggiornare tutte le mappe e pianificare nuovamente il percorso.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Trova mappa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Verifica che il tuo dispositivo sia connesso a internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Spazio insufficiente</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Elimina i dati non necessari</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Errore durante l&#x27;accesso.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Modifiche approvate</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Trascina la mappa per posizionare la croce sulla posizione del luogo o dell&#x27;attività commerciale.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Modifica</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Aggiungi</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nome del luogo</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Come è scritto nella lingua locale</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descrizione dettagliata del problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Un problema diverso</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Aggiungi attività</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Nessun oggetto può essere posizionato qui</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dati OpenStreetMap creati dalla comunità aggiornati al %1. Per saperne di più su come modificare e aggiornare la mappa, visita OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) è un progetto comunitario per creare una mappa libera e aperta. È la principale fonte di dati cartografici di Organic Maps e funziona in modo simile a Wikipedia. Puoi aggiungere o modificare luoghi che diventano disponibili per milioni di utenti in tutto il mondo.&#32;
+Entra a far parte della comunità e contribuisci a creare una mappa migliore per tutti!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Crea un account OpenStreetMap o effettua il login per pubblicare le tue modifiche alla mappa in tutto il mondo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 su %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Vuoi scaricare utilizzando una connessione di rete cellulare?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Questa operazione potrebbe essere piuttosto costosa con alcuni piani telefonici o in roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Inserisci un numero civico valido</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Numero di piani (massimo %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Il numero di piani non deve superare %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Codice postale</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Inserire un codice postale valido</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota per i volontari di OpenStreetMap (opzionale)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Descrivi gli errori sulla mappa o le cose che non possono essere modificate con Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Le tue modifiche vengono caricate nel database pubblico &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/IT:About&quot;&gt;OpenStreetMap&lt;/a&gt;. Per favore, non aggiungere informazioni personali o protette da copyright.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Informazioni su OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>La tua cronologia delle modifiche</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Le tue note sulla mappa</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Gestore</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Gestore: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Non riesci a trovare una categoria adatta?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps consente di aggiungere solo punti semplici, escludendo p.es. città, strade, laghi, planimetria edifici ecc. È possibile aggiungere tali categorie direttamente su &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulta la nostra &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guida&lt;/a&gt; per istruzioni dettagliate.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Non hai scaricato mappe</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Scarica mappe per trovare luoghi e navigare offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Posizione attuale sconosciuta.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>g</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Di più</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Modifica Preferito</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Note personali (testo o html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Commenta…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Eliminare tutte le modifiche locali?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Scarta</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Eliminare il luogo aggiunto?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Elimina</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Il luogo non esiste</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Indica il motivo dell&#x27;eliminazione del luogo</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Inserisci un numero di telefono valido</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Inserisci un indirizzo web valido</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Inserisci un indirizzo email valido</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Inserisci un indirizzo web, un account o un nome di pagina Facebook valido</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Inserisci un indirizzo web o un account Instagram valido</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Inserisci un indirizzo web o un account Twitter valido</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Inserisci un indirizzo web o un account VK valido</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Inserisci un indirizzo web o un ID di LINE valido</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Aggiungi un luogo a OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Oppure, in alternativa, lascia un appunto alla community di OpenStreetMap, in modo che un utente possa aggiungere o sistemare il luogo.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>L&#x27;appunto sarà inviato ad OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Vuoi inviarlo a tutti gli utenti?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Assicurati di non aver inserito alcun dato personale.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Gli editor di OpenStreetMap controlleranno le modifiche e si metteranno in contatto con te in caso di domande.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Ferma</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Sto registrando la traccia</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accetta</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Rifiuta</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Usare una connessione mobile a internet per mostrare informazioni più dettagliate?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usa sempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Solo oggi</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Non usare oggi</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mobile</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>L&#x27;internet mobile è necessario per ricevere notifiche sugli aggiornamenti alle mappe e per caricare modifiche alla mappa.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Non usare mai</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Chiedi sempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Per visualizzare i dati sul traffico, le mappe devono essere aggiornate.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumenta dimensione etichette sulla mappa</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Aggiorna Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Dati sul traffico non disponibili</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Abilita il log</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Feedback generale</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Usiamo il TTS di sistema per le istruzioni vocali. Molti dispositivi Android utilizzano Google TTS, lo puoi scaricare o aggiornare da Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Per alcune lingue, sarà necessario installare un altro sintetizzatore vocale o un language pack aggiuntivo dall&#x27;app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Apri le impostazioni del tuo dispositivo → Lingua e inserimento → Da testo a voce → Motore sintesi vocale.
+Qui puoi gestire le impostazioni di sintesi vocale (ad esempio, scaricare una lingua per l&#x27;utilizzo offline) e selezionare un altro motore di sintesi vocale.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Per maggiori informazioni, consulta questa guida.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Traslittera in caratteri latini</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Scopri di più</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilizza &quot;Cerca&quot;, seleziona un segnalibro oppure tocca un punto sulla mappa per aggiungere un punto di partenza del percorso</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Cerca un luogo, seleziona un segnalibro o tocca la mappa per aggiungere una destinazione</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gestisci percorso</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Pianifica</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Rimuovi sosta</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Aggiungi sosta</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Salvato</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Accedi a OpenStreetMap per caricare automaticamente tutte le tue modifiche alla mappa. Per saperne di più clicca &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;qui&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema di accesso alla memoria</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Memoria esterna non disponibile. Probabilmente la scheda SD è stata rimossa, danneggiata o il file system è di sola lettura. Controlla la tua scheda SD o contattaci a support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Simula memoria danneggiata</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Inserire un nome corretto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Liste</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Nascondi tutto</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Mostra tutto</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n preferito</numerusform>
+<numerusform>%n preferiti</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Crea una nuova lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importa preferiti e tracce</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Impossibile condividere a causa di un errore dell&#x27;applicazione</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Errore durante la condivisione</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Impossibile condividere un elenco vuoto</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Il nome non può essere vuoto</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Inserisci il nome della lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nuova lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Questo nome è già stato usato</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Scegli un altro nome</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Attendi…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numero di telefono</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profilo OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file è stato trovato. Lo potrai vedere dopo la conversione.</numerusform>
+<numerusform>%n file sono stati trovati. Li potrai vedere dopo la conversione.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Ripristina</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n traccia</numerusform>
+<numerusform>%n tracce</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>La privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politica sulla privacy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Termini di utilizzo</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffico</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Escursionismo</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metropolitana</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stili e livelli della mappa</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Questa lista è vuota</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Per aggiungere un preferito, tocca un punto sulla mappa e poi tocca l&#x27;icona a forma di stella</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Cambia il colore di tutti i preferiti</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Cambia il colore di tutte le tracce</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…altro</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Esporta KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Esporta GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Esporta GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Elimina lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Autovelox</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descrizione luogo</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Scaricamento mappe</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avvisa se superi il limite di velocità</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Avvisa sempre</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Non avvisare mai</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modalità risparmio energetico</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Riduce il consumo di batteria disattivando alcune funzionalità.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Mai</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Con poca batteria</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nomi dei segnalibri sulla mappa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Se ci sono troppi segnalibri, la loro visualizzazione può rallentare l&#x27;applicazione.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostra a destra</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostra in basso</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Attiva questa opzione temporaneamente per registrare e inviarci manualmente dei log diagnostici riguardo al tuo problema usando &quot;Segnala un bug&quot; nella sezione Aiuto. I log potrebbero contenere informazioni sulla posizione.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Impostazioni del percorso</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evita le strade a pedaggio</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evita le strade non asfaltate</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evita i traghetti</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evita l&#x27;autostrada</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Impossibile calcolare il percorso</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Non è stato possibile trovare un percorso. Questo potrebbe essere per via delle opzioni che hai scelto o a causa di dati di OpenStreetMap incompleti. Prova a cambiare le impostazioni del percorso e riprova.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Scegli le strade da evitare</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Impostazioni di percorso abilitate</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Strada a pedaggio</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Strada non asfaltata</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Traghetto</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sì</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sì</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacità: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rete: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Sei arrivato!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordina…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordina i preferiti</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Predefinito</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Per tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Per distanza</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Per data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Per nome</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Una settimana fa</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Un mese fa</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Più di un mese fa</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Più di un anno fa</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Vicino a me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Altri</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Pianificazione del percorso fallita</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrivo alle %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Hai modificato la mappa del mondo. Non tenerlo per te! Dillo ai tuoi amici e modificatela insieme.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Condividi con gli amici</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Ora chiuso</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Apre domani alle %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Apre %1 alle %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Apre alle %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Chiude alle %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Aggiungi orari di apertura</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (minimo 8 caratteri)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Username o password non corretti.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Account OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Ultimo caricamento</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Grazie</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nome del luogo</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefono</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Avviso</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Errore download</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Seleziona categoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popolare</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Tutte le categorie</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Aggiungi nuovi luoghi sulla mappa e modifica quelli esistenti direttamente dall&#x27;app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Cambia posizione</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Hai bisogno di più spazio nella memoria per scaricare altri file. Per favore, elimina i dati non necessari.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ho migliorato le mappe Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Commento dettagliato</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Le modifiche alla mappa da te suggerite saranno inviate alla comunità di OpenStreetMap. Descrivi qualsiasi dettaglio aggiuntivo che non può essere modificato in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Si è verificato un errore durante la ricerca della tua posizione. Controlla che il tuo dispositivo funzioni correttamente e riprova più tardi.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>I servizi di localizzazione sono disabilitati</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Abilita l&#x27;accesso alla geolocalizzazione dalle impostazioni del dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Apri le impostazioni</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tocca su Localizzazione</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Seleziona Mentre usi l&#x27;app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Seleziona Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Seleziona Servizi di localizzazione</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Attiva i servizi di localizzazione</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Oppure continua a utilizzare Organic Maps senza servizi di localizzazione</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Prenota</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Chiama</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nome luogo preferito</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Elimina luogo preferito</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>La tua nota sarà inviata a OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…di più</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aggiorna</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disattivare la registrazione del tuo percorso effettuato di recente?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disattiva</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Controlla</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps usa la tua posizione in background per registrare la strada che hai appena percorso.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Impostazioni generali</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Per visualizzare i dati sul traffico, l&#x27;applicazione deve essere aggiornata.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Dimensione del file di log: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Trascina qui per rimuovere</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Sostituisci la fermata</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Parti da</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Accedi a OpenStreetMap per caricare automaticamente tutte le tue modifiche alla mappa. Per saperne di più</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>qui</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Nascondi schermata</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 di %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Download di %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applicazione di %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Questo nome è troppo lungo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nuovi file rilevati</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Converti</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Errore</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Alcuni file non sono stati convertiti.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Si è verificato un errore</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popolare</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Nascondi sulla mappa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Si è verificato un errore durante il caricamento delle etichette, per favore riprova</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Destra</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>In basso</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Si parte</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinazione</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrare</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Risultati di ricerca</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Poi</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vuoi ricalcolare il percorso?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tastiera non disponibile durante la guida</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Impossibile creare un percorso dalla tua posizione attuale</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Impossibile creare un percorso per raggiungere la destinazione. Scegli un&#x27;altra destinazione.</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Segnale GPS assente. Spostati in un&#x27;area all&#x27;aperto</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Impossibile creare un percorso. Specificare altri punti del percorso</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Per creare un percorso scarica le mappe mancanti sul tuo dispositivo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Si è verificato un errore. Riavvia l&#x27;applicazione</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Il percorso sarà ricalcolato a partire dalla tua posizione attuale</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Il percorso sarà convertito in un percorso per auto</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Non tutti i luoghi preferiti vengono visualizzati</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Passa al telefono per vedere tutti i luoghi preferiti</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Autovelox</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Info autovelox</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Scarica le mappe nell&#x27;applicazione Organic Maps sul tuo dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 uscita</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordina come predefinito</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordina per tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordina per distanza</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordina per data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordina per nome</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Cibo</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Luoghi turistici</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Musei</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parchi</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Nuoto</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montagne</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animali</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Alberghi</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edifici</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Denaro</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Negozi</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parcheggi</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Stazioni di servizio</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicinale</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Cerca nella lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Luoghi di culto</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Seleziona lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>La navigazione in metropolitana in questa regione non è ancora disponibile</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Percorso della metro non trovato</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Scegli un punto di partenza o di arrivo più vicino a una stazione della metropolitana</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Curve di livello</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Per attivare le curve di livello devi aggiornare o scaricare la mappa dell&#x27;area interessata</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Le curve di livello per questa regione non sono ancora disponibili</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Salita</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Discesa</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevazione minima</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevazione massima</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficoltà</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tempo:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Ingrandisci la mappa per vedere le curve di livello</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Scaricamento</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Scarica la mappa generale del mondo</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Impossibile creare la cartella e spostare i file nella memoria interna del dispositivo o sulla scheda SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Errore di memoria</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Errore di connessione</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Scollega il cavo USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Tieni lo schermo acceso</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Se abilitato, lo schermo sarà sempre acceso quando si visualizza la mappa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostra sulla schermata di blocco</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Se abilitato, l&#x27;app continuera a funzionare nella schermata di blocco, anche con dispositivo bloccato.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Lingua della mappa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dati della mappa da OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/it/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/it/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/IT:About</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Grazie per utilizzare le nostre mappe create dalla comunità!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Con le tue donazioni e il tuo supporto, possiamo creare le migliori mappe del mondo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Ti piace la nostra app? Dona per sostenerne lo sviluppo! Non ti piace ancora? Facci sapere perché e risolveremo il problema!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Se conosci uno sviluppatore di software, puoi chiedergli di implementare una funzionalità di cui hai bisogno.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tocca un punto qualsiasi della mappa per selezionare qualsiasi cosa. Toccare a lungo per nascondere e mostrare l&#x27;interfaccia.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Lo sapevi che puoi selezionare la tua posizione attuale sulla mappa?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Puoi aiutare a tradurre la nostra app nella tua lingua.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>La nostra app è sviluppata da alcuni appassionati e dalla comunità.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Puoi correggere e migliorare facilmente i dati della mappa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Il nostro obiettivo principale è creare mappe veloci, incentrate sulla privacy e facili da usare che adorerai.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Stai utilizzando Organic Maps sullo schermo del telefono</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Stai utilizzando Organic Maps sullo schermo dell&#x27;auto</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Sei connesso ad Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continua sul telefono</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Passa allo schermo dell&#x27;auto</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps ha bisogno di accedere alla posizione. Quando puoi farlo in sicurezza, controlla la notifica sul tuo telefono.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Questa app ha bisogno della tua autorizzazione</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto ha bisogno di accedere alla posizione per funzionare efficacemente</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Concedi il permesso</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Escursioni</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Il browser web non è disponibile</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Esporta tutti i preferiti e le tracce</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Impostazioni del sistema di sintesi vocale</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Le impostazioni della sintesi vocale non sono state trovate, sei sicuro che il tuo dispositivo la supporti?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Accesso con auto</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Pulisci la ricerca</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Ingrandisci</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Rimpicciolisci</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link al menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Visualizza menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Apri in un&#x27;altra app</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Seleziona l&#x27;opzione</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Posti a sedere all&#x27;aperto</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Per una navigazione più accurata, disabilita la modalità risparmio energetico nelle impostazioni del telefono.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Registra traccia</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Interrompi registrazione della traccia</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Registrazione traccia</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Interrompi senza salvare</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continua a registrare</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Salvare in preferiti e tracce?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>La traccia è vuota - non c&#x27;è nulla da salvare</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Impossibile visualizzare la finestra di selezione delle cartelle perché sul tuo dispositivo non è installata alcuna app adatta. Installa un&#x27;app di gestione dei file e riprova.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Scegli il colore</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Modifica traccia</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Non trovo app che possano aprire la posizione</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automatica durante la navigazione</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Segui il sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Condividi traccia</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Cancellare %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Livello di difficoltà</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Facile</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderato</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difficile</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Aggiornamento in corso</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Aggiorna le mappe scaricate</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>L&#x27;aggiornamento delle mappe mantiene attuali le informazioni sugli oggetti</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Aggiorna (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Aggiorna manualmente più tardi</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Elimina traccia</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Sei sicuro di voler eliminare questa traccia?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nome traccia</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Sposta</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Percorso</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Cambia colore</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mappa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Vuoi inviare una segnalazione di bug agli sviluppatori?
+Ci affidiamo ai nostri utenti perché Organic Maps non raccoglie automaticamente informazioni sugli errori. Ti ringraziamo in anticipo per il supporto a Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Abilita la sincronizzazione con iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>La sincronizzazione con iCloud è una funzione sperimentale in fase di sviluppo. Assicurati di aver fatto un backup di tutti i tuoi luoghi preferiti e tracce.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud è disabilitato</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Per utilizzare questa funzione, attiva iCloud nelle impostazioni del tuo dispositivo.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Abilitazione</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Mancata sincronizzazione di iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Errore: Impossibile sincronizzare a causa di un errore di connessione</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Errore: Impossibile sincronizzare a causa del superamento della quota iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Errore: iCloud non è disponibile</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Elenchi eliminati di recente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Cancella</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Cancella tutto</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recupera</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recupera tutto</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuisci a OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Aggiungi luogo</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Aggiorna la mappa per contribuire</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Devi aggiornare la mappa %1 all&#x27;ultima versione prima di poter contribuire ai dati di OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>La mia posizione</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>I miei luoghi</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Memoria interna privata</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Memoria interna condivisa</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Scheda SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Memoria esterna condivisa</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Codice postale</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punto della mappa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Aggiornare le mappe per visualizzare i percorsi.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Uscita</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ingresso</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>La mappa della metropolitana non è disponibile</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Voi</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regioni scaricate in viola</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Linea</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Il rilevamento della posizione corrente in background è necessario per godere appieno delle funzionalità dell&#x27;app. Viene utilizzato per la navigazione e il salvataggio della traccia percorsa di recente.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>La definizione della posizione corrente viene utilizzata nelle opzioni di tracciamento del percorso e salvataggio del percorso effettuato di recente.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Accesso con password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Effettuare il login con il browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Usati di recente</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Colore dei preferiti modificato</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Colore delle tracce modificato</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spettro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Slider</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROSSO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Colore esadecimale sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Griglia</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ja/omim.ts
+++ b/qt/translations/ja/omim.ts
@@ -1,0 +1,3932 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ja">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>戻る</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>キャンセル</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>削除</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>マップをダウンロード</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>ダウンロードが失敗しました。もう一度試すには画面をタップしてください。</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>ダウンロード中…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>キロメートル</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>マイル</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>後で</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>検索</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>マップを検索</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>位置情報サービスが無効になっているか、このアプリからの位置情報利用が制限されています。端末の設定を有効化してください。</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>限られた精度</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>正確なナビゲーションを実現するには、設定で「正確な位置情報」を有効にしてください。</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>地図に表示</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>ダウンロードに失敗しました</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>再実行</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Mapsについて</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>すべての人のために無料で、愛を込めて作られています</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• 広告、追跡なし、データ収集なし</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• バッテリーの消耗がなく、オフラインで動作する</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• 高速、ミニマリスト、コミュニティによる開発</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>愛好家とボランティアによって作成されたオープンソースアプリケーション。</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>ロケーション設定</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>閉じる</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>ハードウェアアクセラレーションされたOpenGLが必要です。残念ながらご利用中のデバイスではサポートされていません。</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>ダウンロード</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Mapsを利用するにはUSBケーブルを抜くかメモリーカードを挿入してください</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>アプリを起動するにはSDカード/USBストレージの空き容量を確保する必要があります</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>利用を開始する前におおまかな世界地図をダウンロードします。
+これには%1の空き容量が必要です。</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>マップを表示</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1をダウンロードしました
+マップを表示可能です</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1をダウンロードしますか？</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1を更新しますか？</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>一時停止</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>続行</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1のダウンロードが失敗しました</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>新しいセットを作成</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>ブックマークセット名称</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>ブックマーク</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>ブックマークとトラック</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>名称</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>住所</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>一覧</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>設定</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>地図の保存先</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>マップのダウンロード先を選択してください</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>マップ</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2 のうち %1 の空き容量</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>マップを移動しますか？</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>マップ移動中にエラーが発生</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>数分かかる場合があります。
+しばらくお待ち下さい…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>距離の単位</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>マイルまたはキロメートルを選択</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>ダウンロードをキャンセル</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>評価する</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>はい</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>地図をダウンロード</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>ブックマークセット</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>食事場所</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>食料雑貨</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>交通機関</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>ガソリンスタンド</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>駐車場</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>ショッピング</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>中古品</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>ホテル</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>観光</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>エンターテイメント</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>ナイトライフ</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>家族の休日</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>銀行</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>薬局</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>病院</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>トイレ</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>郵便局</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>警察</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>リサイクル</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>水</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV用</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>メモ</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Mapsのお気に入りリストが共有されました</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>こんにちは！
+
+添付ファイルOrganic Mapsのお気に入りリストです。もしインストールされていない場合はここからダウンロードができます： https://omaps.app/get?kmz
+
+旅行を楽しむときはOrganic Mapsを使用してください!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>お気に入りをロード中</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>お気に入りをロードできました。 お気に入りはマップ上、またはお気に入り管理画面に表示されます。</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>お気に入りのロードに失敗しました。ファイルが破損していた、または問題があった可能性があります。</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>ファイルタイプがアプリに認識されない：
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>ファイルを開けなかった %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>編集</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>現在の座標が未確定です</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>恐れ入りますが、マップストレージ設定が無効になっています。</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>ダウンロード中です</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Organic Maps で私の現在地が見れます！%1 または %2 オフラインマップはまだインストールしていないですか？ここからダウンロード： https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Organic Mapsでピン情報を確認</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Organic Mapsで現在地を確認</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>私の現在地はここ: %1
+
+リンクをクリックすると詳細がマップに表示されます。
+
+%2
+
+%3</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>共有</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Eメール</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>クリップボードにコピーしました: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>完了</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMapデータ：%1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>本当にOpenStreetMapアカウントからログアウトしますか？</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>トラック</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>距離</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>現在地を共有する</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>一般</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>情報</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>ナビゲーション</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>地図上の「+」と「-」ボタン</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>画面上に表示</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>暗闇でナビゲートする際のナイトスタイル</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>夜間モード</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>オフ</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>オン</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>自動</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>パースペクティブ表示</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3Dビル</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>省電力モードで建物の 3D 表示がオフになっている</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>音声指示</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>通りの名前をアナウンスする</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>有効にすると、右折する通りまたは出口の名前が読み上げられます。</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>音声言語</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>高品質の音声をダウンロードするには、「設定」アプリを開き、アクセシビリティ → VoiceOver → 読み上げ → 声 に移動します。</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>音声案内をテストする（TTS、Text-To-Speech）</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>音声が聞こえない場合は、音量またはシステムの音声合成設定を確認する。</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>利用不可</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>自動ズーム</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>距離</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>地図に表示</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>メニュー</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>ウェブサイト</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>ニュース</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>フィードバック</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>アプリを評価</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>ヘルプ</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>よくある質問</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>寄付</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>寄付済み</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>後でリマインド</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps を応援してください</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>プロジェクトを支援する</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>著作権</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>バグを報告</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>携帯電話を8の字に動かしてコンパスを較正することで、矢印の方向を改善します。</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>携帯電話を8の字に動かしてコンパスを校正し、地図上の矢印の方向を固定します。</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>インターフェイスを見るには、もう一度地図をロングタップする。</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>全てをアップデート</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>すべてキャンセル</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>ダウンロード済み</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>キューに追加済み</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>現在地付近</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>地図</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>全てをダウンロード</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>ダウンロード中：</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>地図を削除するにはナビゲーションを停止してください。</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>一つの地図に完全に収まるルートのみ作成可能です。</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>地図をダウンロード</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>再試行</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>地図を削除</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>地図を更新</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play位置情報サービス</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bluetooth、WiFi、またはモバイルネットワーク経由で、おおよその位置を素早く特定する</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>ルート上の地図をダウンロード</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>ルートの作成には現在位置から目的地までのすべての地図をダウンロードし、最新のものにする必要があります。</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>空き容量が足りません</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>位置情報サービスを有効化してください</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>保存</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>作成</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>赤</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>黄色</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>青</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>緑</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>紫</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>オレンジ</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>茶色</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>ピンク</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>濃い紫</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>空色</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>青緑</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>ティール</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>ライム</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>濃いオレンジ</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>灰色</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>青灰色</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>情報</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Mapsバージョン: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>外観</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>ライト</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>ダーク</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>夜明けから夕暮れまでライト</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>その他</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>何百万人ものユーザーに広告なしの無料地図を贈ろう！</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>誤った地図データを報告または修正する</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>ボランティアに参加する</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>フォローして連絡しよう：</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>メールアプリは設定されていません。設定するか、%1にご連絡ください。</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>メール送信エラー</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>コンパスの調整</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>利用可能</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>見つかりました</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>を更新</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>失敗</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>お気に入り</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>案内ルートに従う際は、以下の点にご留意ください：</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— 道路の状況や道路交通法、道路標識をナビゲーションよりも常に優先してください;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— マップは必ずしも正確であるとは限らず、また案内ルートが常に目的地までの最適なルートであるとは限りません。;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— 表示されるルートはあくまでも推奨ルートとしてご利用ください。;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— 国境付近のルートにご注意ください。アプリの作成したルートは時々入国の許可されていない国への国境を超える場合があります;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>よく注意して安全運転を心がけましょう！</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS信号をご確認ください</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>案内ルートを作成できません。現在のGPS座標が認識できません。</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>GPS信号をご確認ください。Wi-Fiを有効にするとより正確な位置情報を取得できます。</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>位置情報サービスを有効にしてください</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>現在地のGPSコードを確認できません。案内ルートを作成するには、位置情報サービスを有効にしてください。</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>ルートの位置を確認できません</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>案内ルートを作成できません。</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>出発地または目的地を調整してください。</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>出発地を調整</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>案内ルートを作成できません。出発地が確認できませんでした。</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>道路に近い位置にある出発地を設定してください。</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>目的地を調整</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>案内ルートを作成できません。目的地を確認できませんでした。</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>道路に近い位置にある目的地を設定してください。</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>中間地点を確認できませんでした。</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>中間地点を調整してください。</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>システムエラー</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>エラーにより案内ルートを作成できませんでした。</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>もう一度お試しください</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>後で</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>マップをダウンロードし、複数マップを利用してより最適なルートを作成しますか？</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>このマップの境界を越えて複数マップを利用し、より最適なルートを作成するには、マップをダウンロードしてください。</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>必要なファイルをダウンロード</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>案内ルートを作成するには、表示されたパスに従ってすべてのマップ、ルート情報をダウンロードまたはアップデートしてください。</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>検索とルート作成を開始するには、地図をダウンロードしてください。地図をダウンロードすると、インターネット接続は不要です。</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>地図を選択</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>表示する</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>隠す</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>カテゴリー</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>履歴</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>該当するものは見つかりませんでした。</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>検索する地域をダウンロードするか、近隣の町村名を追加してみてください。</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>検索履歴</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>最近の検索を表示します。</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>検索履歴を消去</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>ウィキペディア</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org の記事</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>ウィキメディア・コモンズ</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>現在位置</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>開始</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>出発地</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>目的地</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>ナビゲーションは現在位置からのみ利用できます。</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>現在位置からのルートを作成しますか？</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>次へ</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>から</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>まで</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>スケジュール追加</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>スケジュール削除</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>終日 (24時間)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>営業中</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>閉店</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>閉店時間追加</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>営業時間</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>詳細モード</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>シンプルモード</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>閉店時間</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>値の例</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>間違いの訂正</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>場所を選択</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>OpenStreetMapコミュニティがエラーを修正できるように、問題の詳細を説明してください。</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>または、このURLでご自身で修正してください https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>送信</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>問題</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>この場所は存在しません</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>メンテナンスのため使えません</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>重複している場所</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>自動ダウンロード</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>毎日</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>昼と夜</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>本日終業</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>終業</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>今日は</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>あと %1 に営業</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>あと %1 に閉店</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>閉店</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>営業時間を編集</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>OpenStreetMapのアカウントをお持ちではないですか？</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>OpenStreetMapのアカウントを登録</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>ログイン</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>サインインしていません</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMapにログイン</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>パスワード</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>パスワードをお忘れですか？</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>ログアウト</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>場所を編集</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>言語を追加</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>通り</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>番地</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>詳細</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>ソーシャルメディア</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>建物</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>通りを追加</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>通りの名前を入力してください。</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>言語を選択</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>通りを選択</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>料理</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>料理を選択</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>メールアドレスまたはユーザー名</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>電話番号を追加</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>階</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>レベル: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>すべてのマップの変更はマップとともに削除されます。</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>地図を更新</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>ルートを作成するには、全ての地図を更新した後で再びルート計画を行う必要があります。</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>地図を検索</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>デバイスがインターネットに接続されているか確認してください。</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>十分な空き容量がありません</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>不要データを削除してください</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>ログインエラー。</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>確認された変更</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>地図をドラッグして、場所や企業の場所に十字を配置します。</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>編集中</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>追加中</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>場所の名前</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>現地の言葉でこう書かれている。</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>カテゴリ</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>問題の詳細な説明</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>異なる問題</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>ビジネスを追加</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>ここにはオブジェクトを配置できません</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>コミュニティが作成した%1時点の OpenStreetMap のデータ。地図の編集や更新の方法については、OpenStreetMap.org を参照してください。</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org(OSM)は、フリーでオープンな地図を構築するコミュニティ・プロジェクトです。OSMは、Organic Mapsの地図データの主要なソースであり、ウィキペディアと同じように機能します。あなたが場所を追加したり編集したりすると、世界中の何百万人ものユーザーがその場所を利用できるようになります！</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>OpenStreetMapのアカウントを作成するかログインして、あなたの地図編集を世界中に公開しましょう。</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%2のうち%1</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>モバイル通信でダウンロードしますか？</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>プランによって、またはローミングしている場合、非常に高額になる可能性があります。</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>正しい番地を入力してください</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>フロアの数（最大%1）</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>最高%1階までのビルを編集</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>郵便番号</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>正しい郵便番号を入力してください</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMapボランティアへの注意（オプション）</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>地図上のエラーやOrganic Mapsで編集できないものについて説明します。</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>あなたの編集は公開されている&lt;a href=&quot;https://wiki.openstreetmap.org/wiki/JA:参加する&quot;&gt;OpenStreetMap&lt;/a&gt;データベースにアップロードされます。個人情報や著作権のある情報は追加しないでください。</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMapについての詳細</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>編集履歴</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>地図データのメモ</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>オペレーター</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>運営者: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>適切なカテゴリーが見つからない？</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps このアプリでは、シンプルな地点カテゴリのみを追加できます。つまり、町、道路、湖、建物の輪郭などは追加できません。そのようなカテゴリは、&lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;に直接追加してください。詳細な手順については、&lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;ガイド&lt;/a&gt;をご確認ください。</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>マップをダウンロードしていません</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>現在地は不明です。</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>時間</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>分</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>日</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>秒</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>さらに詳しく</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>ブックマークを編集</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>パーソナルメモ（テキストまたはHTML）</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>コメント…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>ローカル編集をすべてリセットしますか?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>リセット</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>追加された場所を削除しますか？</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>削除</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>場所が存在しません</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>場所を削除する理由を教えてください</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>正しい電話番号を入力してください</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>有効なURLを入力してください</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>有効なメールアドレスを入力してください</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>有効な Facebook URL、アカウント、またはページ名を入力してください</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>有効な Instagram ユーザー名またはURLを入力してください</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>有効なTwitterユーザー名またはURLを入力してください</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>有効なVKユーザー名またはURLを入力してください</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>有効なLINEユーザー名またはURLを入力してください</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>OpenStreetMapに場所を追加する</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>あるいは、OpenStreetMapコミュニティにメモを残し、誰かがここに場所を追加または修正できるようにしてください。</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>メモがOpenStreetMapに送信されます。</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>全てのユーザーに送信しますか？</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>個人情報を入力していないことを確認してください。</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap の編集者が変更を確認し、質問があれば連絡します。</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>停止</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>トラックの記録</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>了解</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>拒否</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>モバイル通信を使用して詳細な情報を表示しますか？</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>常に使用</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>今日だけ</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>今日は使用しない</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>モバイル通信</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>モバイル通信は場所、写真、価格やレビューのような詳細情報を表示するのに必要です。</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>使用しない</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>常に確認</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>交通データを表示するには、地図を更新する必要があります。</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>地図上のフォントサイズを大きくする</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Organic Maps をアップデートしてください</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>交通データは利用できません</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>ログを有効化</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>一般的なフィードバック</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>音声案内にはシステムの TTS を使用します。多くの Android 端末が Google の TTS を使用しており、Google Play からダウンロードや更新を行うことができます。</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>いくつかの言語では、アプリストア(Google Play、Galaxy Store 、App Gallery、FDroid)から音声合成または追加の言語パックをインストールする必要があります。
+お使いのデバイスで [設定] → [言語と入力] → [音声] → [音声出力] を開いてください。
+ここで音声合成の設定 (たとえば、オフラインで使用する言語パックのダウンロードなど) を管理し、別の音声合成エンジンを選択できます。</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>詳細については、このガイドをご確認ください。</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>ラテン文字への翻字</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>詳細情報</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>検索を使うか、地図上をタップしてルートの出発点を追加する</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>検索を使うか、地図上をタップして目的地を追加する</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>ルートを編集</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>プラン</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>停留所を削除</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>中間地点を追加</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>保存</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>すべてのマップ編集を自動的にアップロードするには、OpenStreetMapにログインしてください。詳しくは &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;こちら&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>ストレージアクセスの問題</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>外部ストレージは使用できません。おそらく SD カードが取り外されたか、破損しているか、あるいはファイルシステムが読み取り専用になっています。SD カードを確認するか、support@organicmaps.app までご連絡ください。</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>壊れたストレージをシミュレートする</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>正しい名前を入力してください</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>リスト</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>すべて非表示</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>すべて表示</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n個のブックマーク</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>新しいリストを作成する</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>ブックマークとトラックをインポートする</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>エラーのため共有できません</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>共有エラー</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>空のリストは共有できません</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>名前を空にすることはできません</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>リスト名を入力してください</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>新しいリスト</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>この名前はすでに使用されています</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>別の名前を選んでください</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>お待ちください…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>電話番号</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap プロフィール</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>ファイルが%n個見つかりました。変換後にそれを見ることができます。</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>復元</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n件の経路</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>プライバシー</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>プライバシーポリシー</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>利用規約</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>交通状況</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>ハイキング</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>サイクリング</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>地下鉄</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>マップのスタイルとレイヤー</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>このリストは空です</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>ブックマークを追加するには、地図上の場所をタップし、星のアイコンをタップしてください。</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>すべてのブックマークの色を変更</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>すべてのトラックの色を変更</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>詳細</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZをエクスポートする</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPXをエクスポートする</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSONをエクスポートする</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>リストを削除</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>自動速度違反取締装置</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>場所の説明</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>マップダウンローダー</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>スピード違反を警告する</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>自動速度違反取締装置について常に警告します</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>自動速度違反取締装置を警告しません</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>電力節約モード</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>自動モードが選択されている場合、このアプリケーションは現在のバッテリーの充電状態に応じてバッテリー消費の激しい機能の無効化を開始します</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>無効</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>自動</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>最大電力節約</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>地図上のブックマーク名</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>ブックマークが多すぎる場合、地図上にブックマーク名を表示すると、アプリの動作が遅くなることがあります。</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>右に表示</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>下部に表示</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>このオプションは診断目的でのデータ記録を有効にします。これはこのアプリケーションのトラブルシューティングを担当する当社のサポートスタッフの助けになります。このオプションはOrganic Mapsにリクエストされた場合にのみ有効にしてください。</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>経路オプション</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>有料道路を避ける</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>未舗装道路を使わない</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>フェリーを利用しない</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>高速道路を避ける</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>ルートを計算できません</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>ルートが計算できませんでした。 これは、経路オプションまたは不完全な OpenStreetMap データが原因である可能性があります。 経路オプションを変更して再試行してください。</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>迂回ルートを設定する</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>経路オプションは有効になっています</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>有料道路</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>未舗装道路</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>フェリー</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>はい</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>いいえ</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>はい</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>いいえ</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>定員：%1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>ネットワーク： %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>到着しました!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>並べ替え…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>ブックマークの並べ替え</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>デフォルトで</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>タイプで</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>距離で</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>日付で</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>名前で</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>1週間前</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>1ケ月前</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>1ケ月以上前</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>1年以上前</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>近隣</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>その他</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>ルート検索に失敗</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>到着予測: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>世界地図を変更しました。この変更を秘密にしないでください! 友達に教えて一緒に編集しましょう。</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>友達にシェア</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>現在閉店</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>明日の %1 から営業</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 の %2 から営業</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1 から営業</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1 に閉店</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>営業時間を追加</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>パスワード(最低8文字)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>ユーザー名またはパスワードが無効です。</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSMアカウント</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>最終更新</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>ありがとうございます</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>場所の名前</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>電話</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>ご注意ください</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>ダウンロードエラー</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>カテゴリを選択</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>人気</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>全てのカテゴリ</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>アプリから直接地図に新しい場所を追加したり、既存の場所を編集できます。</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>位置を変更してください</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>ダウンロードするには空き容量が必要です。不要なデータを削除してください。</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Organic Mapsの地図を改善しました</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>詳細コメント</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>提案した変更は、OpenStreetMapのコミュニティに送信されます。Organic Mapsで編集できない詳細を説明してください。</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>現在地の検索中にエラーが発生しました。 デバイスが正常に動作していることを確認して、もう一度お試しください。</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>位置情報が無効になっています</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>デバイスの設定で位置情報へのアクセスを有効にしてください</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. 「設定」を開きます</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. 「位置情報」をタップします</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. 「アプリの使用中」を選択してください</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2.プライバシーを選択する</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3.位置情報サービスを選択する</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4.位置情報サービスをオンにする</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>または、位置情報を使用せずにOrganic Mapsを引き続きご利用ください</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>予約</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>電話をかける</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>ブックマーク名</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>ブックマークを削除</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>あなたのメモはOpenStreetMapに送られる</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…続き</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>更新</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>最近の走行ルートの記録を無効にしますか？</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>無効にする</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>ご覧ください</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Mapsは、あなたの位置情報をバックグラウンドで使用して最近の走行ルートを記録します。</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>一般設定</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>交通データを表示するには、アプリケーションをアップデートする必要があります。</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>ログファイルのサイズ: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>ここにドラッグして削除</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>リプレースストップ</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>出発地</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>すべてのマップ編集を自動的にアップロードするには、OpenStreetMapにログインしてください。詳しくは</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>こちら</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>画面を非表示</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 をダウンロードしています…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 を適用中です…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>この名前は長すぎます</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>新しいファイルが検出されました</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>変換</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>エラー</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>一部のファイルは変換されませんでした。</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>エラーが発生しました</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>人気</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>マップから隠す</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>タグのロード中にエラーが起きました発生しました。もう一度やり直してください</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>右</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>ボトム</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>出発</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>目的地</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>リセンター</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>検索結果</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>その後</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>ルートを再計算しますか?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>運転中はキーボードを使用できません</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>現在位置からはルートを計算できません</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>目的地へのルートは計算できません。別の地点を選択してください</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS信号がありません。開けた場所へ移動してください</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>ルートが計算できません。別のルート地点を設定して下さい</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>ルートを作成するには、不足しているマップを端末でダウンロードしてください</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>エラーが発生しました。アプリを再起動してください</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>ルートは現在位置から再計算されます</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>車ルートに変更されます</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>すべてのブックマークが表示されるわけではない</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>携帯電話に切り替えてすべてのブックマークを見る</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>速度警告</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>速度警告</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>端末のOrganic Mapsのアプリにマップをダウンロードしてください</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>第%1出口</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>デフォルトで並べ替え</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>タイプで並べ替え</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>距離で並べ替え</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>日付で並べ替え</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>名前で並べ替え</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>食べ物</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>観光地</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>博物館</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>公園</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>水泳</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>山</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>動物</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>ホテル</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>ビル</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>お金</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>ショップ</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>駐車場</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>ガソリンスタンド</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>医薬品</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>リスト内で検索</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>礼拝所</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>リストを選択</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>この地域の地下鉄ナビはまだ利用できません</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>地下鉄ルートが見つかりませんでした</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>もっと地下鉄駅に近い出発地または目的地を選択してください</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>地形</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>地形レイヤーを使用するには、このエリアのマップを更新もしくはダウンロードしてください</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>地形レイヤーはこの地域ではまだ利用できません</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>上昇</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>下降</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>最小標高</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>最大標高</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>難易度</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>距離：</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>時間：</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>等高線を調べるようにズームインしてください</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>ダウンロード中</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>おおまかな世界地図をダウンロード</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>フォルダーの作成と内部ストレージまたはSDカードへのファイルの移動に失敗しました</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>ディスクエラー</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>接続エラー</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USBケーブルを抜いてください</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>画面を表示したままにする</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>有効にすると、地図を表示するときにスクリーンが常にオンになる。</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>ロック画面に表示</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>有効にすると、デバイスがロックされている場合でもアプリはロック画面で動作します。</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>マップ言語</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMapからの地図データ</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/JA:参加する</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>私たちのコミュニティが作った地図をご利用いただき、ありがとうございます！</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>あなたの寄付とサポートがあれば、世界で最高の地図を作成できます。</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>私たちのアプリは気に入っていますか? 開発をサポートするために寄付をお願いします！ まだ気に入らないですか？ お知らせください。修正させていただきます。</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>ソフトウェア開発者を知っている場合は、必要な機能を実装するように依頼できます。</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>地図上の任意の場所をタップして、何かを選択します。ロングタップでインターフェイスを非表示にしたり、表示したりできます。</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>地図上で現在地を選択できることをご存知ですか?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>私たちのアプリをあなたの言語に翻訳するのを手伝ってください。</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>私たちのアプリは数人の愛好家とコミュニティによって開発されました。</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>地図データを簡単に修正および改善できます。</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>私たちの主な目標は、ユーザーに気に入っていただける、プライバシーを重視した使いやすいマップを高速に構築することです。</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>端末の画面でOrganic Mapsを使用している</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>現在、車の画面でOrganic Mapsをご利用中です</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>アンドロイド・オートに接続している</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>電話で続ける</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>車のスクリーンへ</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps 位置情報のアクセスが必要です。安全な場所にいる際は、スマートフォンの通知をご確認ください。</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>このアプリはあなたの許可を必要とする</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android AutoのOrganic Mapsを有効に機能させるには、位置情報の許可が必要です</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>許可を与える</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>ハイキング</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>ウェブブラウザが利用できない</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>音量</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>すべてのブックマークとトラックをエクスポートする</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>音声合成システムの設定</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>音声合成の設定が見つからなかった。</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>ドライブスルー</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>検索をクリアする</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>ズームイン</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>ズームアウト</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>メニューリンク</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>メニューを見る</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>別のアプリで開く</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>セルフサービス</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>オプションを選択する</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>屋外席</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>最も正確なナビゲーションのためには、携帯電話のバッテリー設定で省電力モードを無効にすることをお勧めする。</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>トラックを記録する</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>トラック記録を停止しますか</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>トラック記録</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>保存せずに停止</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>録画を続ける</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>ブックマークとトラックに保存しますか？</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>ルートが空です - 保存するものがありません</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>デバイスに適切なアプリがインストールされていないため、フォルダ選択ダイアログを表示できません。ファイルマネージャーアプリをインストールして再度お試しください。</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>色を選択</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>ルートを編集</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>場所を開けるアプリがインストールされていません</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>ナビゲーションオート</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>システムに従う</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>シェアトラック</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>を削除しますか %1？</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>難易度</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>簡単</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>普通</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>困難</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>更新中</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>ダウンロード済みのマップを更新してください</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>地図を更新することで物件情報を最新の状態に保ちます</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>更新 (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>後で手動で更新</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>トラックを削除</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>このトラックを削除してもよろしいですか？</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>トラック名</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>移動</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>トラック</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>色を変える</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>地図</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>開発者にバグレポートを送りたいか？
+オーガニック・マップはエラー情報を自動収集しないため、我々はユーザーに依存している。Organic Mapsを応援してくださりありがとう！</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud同期を有効にする</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud同期は開発中の実験的機能である。すべてのブックマークとトラックのバックアップをとっておくこと。</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloudが無効になっています</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>この機能を使うには、デバイスの設定でiCloudを有効にしてほしい。</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>有効にする</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>バックアップ</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud同期の失敗</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>エラー：接続エラーにより同期に失敗した</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>エラー：iCloudのクォータが超過したため、同期に失敗しました。</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>エラー：iCloudが利用できない</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>最近削除されたリスト</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>クリア</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>すべて削除する</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>復元</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>すべて復元</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap に貢献する</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>場所を追加</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>地図を更新して貢献する</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap データに貢献する前に、%1 の地図を最新バージョンに更新する必要があります</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>現在地</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>マイプレイス</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>アプリ固有のストレージ</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>共有ストレージ</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SDカード</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>外部ストレージ</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>無線LAN</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>郵便番号</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>マップポイント</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>ルートを表示するには、地図を更新する必要がある。</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>出口</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>入口</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>地下鉄路線図はご利用いただけません</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>君</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>紫色のダウンロード済み地域</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>経路</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>バックグラウンドでの位置情報の取得は、アプリの機能を十分に利用するために必要です。ナビゲーションと最近移動したトラックの保存に使用されます。</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>位置情報の取得は、ナビゲーションと最近移動したトラックの保存に使用されます。</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>パスワードでログイン</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ブラウザでログイン</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>最近使用</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>ブックマークの色が変更されました</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>トラックの色が変更されました</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>スペクトル</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>スライダー</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>赤</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>グリーン</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>青</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB 16進カラー #.</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>グリッド</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ko/omim.ts
+++ b/qt/translations/ko/omim.ts
@@ -1,0 +1,3930 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ko">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>뒤로</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>취소하기</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>삭제하기</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>지도 다운로드받기</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>다운로드에 실패하였습니다. 다시 시도하려면 터치하세요.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>다운로드 중…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>킬로미터</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>마일</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>나중에</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>검색하기</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>지도 검색하기</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>현재 이 기기 또는 애플리케이션에 대한 모든 위치 서비스가 비활성화되어 있습니다. 설정에서 활성화하십시오.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>제한된 정확도</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>정확한 탐색을 위해 설정에서 정확한 위치를 활성화합니다.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>지도에 표시</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>다운로드에 실패하였습니다</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>다시 시도</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps 정보</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>사랑으로 만든 모든 사람에게 무료</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• 광고 없음, 추적 없음, 데이터 수집 없음</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• 배터리 소모 없음, 오프라인에서 작동</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• 빠르고 미니멀한, 커뮤니티가 개발한</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>애호가와 자원 봉사자가 만든 오픈 소스 응용 프로그램.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>위치 설정</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>닫기</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>하드웨어 촉진 OpenGL이 요구됩니다. 애석하게도 귀하의 장치는 지원되지 않습니다.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>다운로드</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps를 사용하려면 USB 케이블이나 삽입 메모리 카드를 분리하십시오</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>앱을 사용하려면 먼저 SD 카드/USB 저장소의 여유 공간을 확보하세요</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>시작하시기 전에 일반 세계 지도를 귀하의 장치로 다운로드하겠습니다.
+%1 데이터가 필요합니다。</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>지도로 이동</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1다운로드. 이제지도를 진행할 수 있습니다.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1다운로드?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1업데이트?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>중지</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>계속</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1다운로드가 실패했습니다</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>새로운 목록 추가</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>집합 이름을 즐겨찾기에 추가</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>북마크</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>북마크 및 트랙</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>이름</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>주소</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>목록</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>설정</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>지도 저장 위치:</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>지도가 다운로드될 곳을 선택합니다</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>지도</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2 중 %1 여유</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>지도를 이동합니까?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>지도 파일 이동 중 오류 발생</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>이 작업은 수 분 소요될 수 있습니다.
+잠시 기다리세요…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>측정 단위</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>마일과 킬로미터 중에서 선택하십시오</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>다운로드 취소하기</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>리뷰 남기기</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>네</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>지도 다운로드</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>세트를 즐겨찾기에 추가</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>어디서 먹을까</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>식료품들</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>수송</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>연료</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>주차</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>쇼핑</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>중고</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>호텔</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>관광</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>엔터테인먼트</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>유흥</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>가족 기념일</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>은행</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>약국</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>병원</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>화장실</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>우편</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>경찰</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>재활용</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>물</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV용</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>메모</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>귀하와 공유된 Organic Maps 즐겨찾기</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>안녕하세요!
+
+제 북마크를 첨부했습니다. Organic Maps에서 열어주세요. 설치되어 있지 않다면 여기에서 다운로드할 수 있습니다: https://omaps.app/get?kmz
+
+Organic Maps와 함께 즐거운 여행 되세요!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>즐겨찾기 로드</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>즐겨찾기가 성공적으로 로드되었습니다! 지도 또는 즐겨찾기 관리자 화면에서 찾으실 수 있습니다.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>즐겨찾기 업로드가 실패했습니다. 파일이 훼손되었거나 결함이 있을지도 모릅니다.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>파일 형식이 앱에서 인식되지 않습니다:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>파일을 열지 못했습니다 %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>편집</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>귀하의 위치를 아직 알아내지 못 했습니다</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>죄송합니다, 지도 스토리지 설정이 비활성화되어 있습니다.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>국가 다운로드가 지금 진행 중입니다.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Organic Maps에서 현재 위치를 확인해 보세요! %1 또는 %2 오프라인 지도가 없으신가요? 여기에서 다운로드하세요: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Organic Maps 지도에서 내 핀 보기</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Organic Maps 지도에서 제 현재 위치를 살펴 보시기 바랍니다</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>안녕하세요.
+
+지금 다음 위치에 있습니다: %1. %2 또는 %3 링크를 클릭하여 지도상에서 해당 장소를 살펴보시기 바랍니다.
+
+감사합니다.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>공유</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>이메일</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>클립보드에 복사됨: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>완료</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap 데이터: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>오픈스트리트맵 계정에서 로그아웃하시겠습니까?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>트랙</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>길이</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>내 위치 공유</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>일반 설정</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>정보</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>내비게이션</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>지도에서 + 및 - 버튼</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>화면에 표시</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>어두운 곳에서 내비게이션할 때의 야간 스타일</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>나이트 모드</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>끄기</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>켜기</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>자동</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>원근 보기</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>주변 건물 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D 빌딩은 절전 모드에서 꺼집니다.</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>음성 지침</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>거리 이름 말하기</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>사용하도록 설정하면 회전할 거리 또는 출구의 이름을 소리 내어 말합니다.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>음성 언어</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>더 높은 품질의 음성을 다운로드하려면 설정 앱을 열고 손쉬운 사용 → VoiceOver → 말하기 → 음성으로 이동하세요.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>음성 길 안내 테스트(TTS, 텍스트 음성 변환)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>지금 음성이 들리지 않으면 볼륨 또는 시스템 텍스트 음성 변환 설정을 확인하세요.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>사용할 수 없음</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>자동 줌</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>거리</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>지도 보기</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>메뉴</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>웹사이트</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>소식</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>피드백</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>앱 평가</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>도움말</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>질문과 답변</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>기부</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>기부완료</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>나중에 알림</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps를 지원해주세요</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>프로젝트 지원</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>저작권</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>오류 신고</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>나침반을 보정하기 위해 휴대폰을 8자 모양으로 움직여 화살표 방향을 개선하세요.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>휴대폰을 8자 모양으로 움직여 나침반을 보정하고 지도에서 화살표 방향을 수정합니다.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>지도를 다시 길게 탭하면 인터페이스가 표시됩니다.</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>모두 업데이트</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>모두 취소</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>다운로드</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>대기</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>내 근처</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>지도</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>모두 다운로드</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>다운로드 중:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>지도를 삭제하시려면 길 찾기를 멈추세요.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>경로는 하나의 지도에 완전히 포함되도록만 생성할 수 있습니다.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>지도 다운로드</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>반복</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>지도 삭제</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>지도 업데이트</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play 위치 서비스</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>블루투스, WiFi 또는 모바일 네트워크를 통해 대략적인 위치를 빠르게 파악할 수 있습니다</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>경로를 따라 지도 다운로드</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>경로를 만드는 것은 사용자의 위치에서의 모든 지도를 다운로드되고 업데이트된 대상으로 필요합니다.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>여유 공간 부족</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>위치 서비스를 작동시켜 주십시요.</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>저장</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>만들기</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>빨간색</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>노란색</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>파란색</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>녹색</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>보라색</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>오렌지색</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>갈색</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>분홍색</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>진보라색</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>하늘색</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>시안</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>틸</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>라임</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>진주황색</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>회색</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>청회색</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>정보</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps 버전: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>모양</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>라이트</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>다크</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>새벽부터 해질녘까지 라이트</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>다른 언어</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>수백만 명의 사용자에게 광고 없는 무료 지도를 선물하세요!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>잘못된 지도 데이터 신고 또는 수정</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>자원봉사에 참여하려면</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>팔로우하고 문의하세요:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>이메일 클라이언트가 설정되지 않았습니다. 이를 구성하거나 %1로 연락할 다른 방법을 사용하십시오.</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>메일 전송 중 오류</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>나침반 보정</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>사용 가능</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>검색 결과</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>업데이트</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>실패함</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>북마크</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>경로를 따라갈 때는 다음 사항에 주의해 주세요:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— 도로 상황, 교통법, 도로 표지판을 항상 내비게이션 안내보다 먼저 고려하세요;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— 지도는 부정확할 수 있으며, 제안된 경로보다 나은 경로가 존재할 수도 있습니다;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— 제안된 경로는 권장 사항으로만 참고하세요;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— 국경 지역에서 경로를 주의하십시오: 앱에 의해 생성된 경로는 허가받지 않은 장소에서 국가 경계에 걸쳐 종종 일어날 수 있습니다;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>항상 안전에 주의하세요!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS 신호 확인</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>경로를 설정할 수 없습니다. 현재 GPS 좌표를 확인할 수 없습니다.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>GPS 신호를 확인해주세요. Wi-Fi를 켜면 위치 정확도가 높아집니다.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>위치 서비스 활성화</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>현재 GPS 좌표를 찾을 수 없습니다. 경로를 계산하려면 위치 서비스를 활성화하세요.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>경로를 찾을 수 없습니다</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>경로를 찾을 수 없습니다.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>출발지나 목적지를 조정하세요.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>출발지 조정</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>경로가 설정되지 않았습니다. 출발지를 찾을 수 없습니다.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>도로와 가까운 출발지를 지정해주세요.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>목적지 조정</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>경로가 설정되지 않았습니다. 목적지를 찾을 수 없습니다.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>도로와 가까운 목적지를 지정해주세요.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>중간 지점을 찾을 수 없습니다.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>중간 지점을 조정하세요.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>시스템 오류</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>애플리케이션 오류로 인해 경로를 설정하지 못했습니다.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>다시 시도해주세요.</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>나중에</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>지도를 다운로드하여, 두 개 이상의 지도를 통과하는 더 최적화된 경로를 설정하시겠습니까?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>이 지도의 경계를 통과하는 더 최적화된 경로를 설정하려면 지도를 다운로드하세요.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>필수 파일 다운로드</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>경로를 계산하려면 모든 지도와 예상 경로 정보를 다운로드하고 업데이트하세요.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>경로를 검색하고 만들기시작하려면, 지도를 다운로드하십시오. 그러면, 더 이상 인터넷 연결이 필요하지 않습니다.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>지도 선택</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>표시</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>숨기기</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>범주</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>내역</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>죄송합니다. 아무것도 찾지 못했습니다.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>검색하려는 지역을 다운로드하거나 가까운 도시/마을 이름을 추가해 보세요.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>검색 기록</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>최근 검색 쿼리에 신속하게 액세스할 수 있습니다.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>이력 검색 지우기</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>위키백과</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org의 문서</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>위키미디어 공용</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>위치</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>시작</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>출발지</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>목적지</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>현재 위치에서만 네비게이션을 사용할 수 있습니다.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>현재 위치에서 경로를 계획하시겠습니까?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>다음</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>부터</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>까지</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>스케줄 추가</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>스케줄 삭제</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>종일 영업(24시간)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>개점</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>폐점</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>폐점 시간 추가</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>영업 시간</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>고급 모드</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>기본 모드</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>폐점 시간</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>예제</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>입력 수정</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>위치 선택</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>OpenStreetMap 커뮤니티가 오류를 수정할 수 있도록 상세하게 문제를 설명하십시오.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>아니면, 다음에서 스스로 가능: https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>전송</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>문제</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>장소가 존재하지 않음</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>유지 보수를 위해 닫음</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>중복된 장소</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>자동 다운로드</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>일별</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24 시간</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>오늘 영업 종료됨</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>종료됨</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>오늘</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>%1에서 열립니다</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>%1로 마감</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>닫음</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>영업일 편집</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>OpenStreetMap에서 계정이 없습니까?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>등록</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>로그인</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>로그인되지 않음</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMap에 로그인</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>암호</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>암호를 잊으셨나요?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>로그 아웃</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>장소 편집</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>언어 추가</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>거리</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>집 번호</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>세부 정보</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>소셜 미디어</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>빌딩</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>거리 추가</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>도로명을 입력하세요.</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>언어 선택</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>거리 선택</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>요리</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>요리 선택</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>이메일 또는 사용자 이름</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>전화 추가</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>층</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>레벨: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>모든 지도의 변경 사항은 지도와 함께 삭제됩니다.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>지도 업데이트</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>경로를 만들려면, 모든 지도를 업데이트한 다음, 다시 경로를 계획해야 합니다.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>지도 찾기</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>설정을 확인하고 장치가 인터넷에 연결되어 있는지 확인하십시오.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>충분하지 않은 여유 공간</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>불필요한 데이터를 제거하십시오.</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>로그인 오류.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>변경사항 승인</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>지도를 드래그하여 장소 또는 비즈니스의 위치에 십자가를 배치합니다.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>편집 중</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>첨가 중</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>장소 이름</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>현지 언어</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>범주</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>문제에 대한 자세한 설명</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>다른 문제</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>조직 추가</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>목적지를 이곳에서 찾을 수 없습니다</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>커뮤니티에서 만든 오픈스트리트맵 데이터(%1 기준). 지도를 편집하고 업데이트하는 방법에 대한 자세한 내용은 OpenStreetMap.org에서 확인하세요.</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org(OSM)는 무료 개방형 지도를 구축하기 위한 커뮤니티 프로젝트입니다. 이 프로젝트는 Organic Maps의 주요 지도 데이터 소스이며, 위키백과와 유사한 방식으로 운영됩니다. 사용자는 장소를 추가하거나 편집할 수 있으며, 이러한 정보는 전 세계 수백만 명의 사용자가 이용할 수 있게 됩니다.
+커뮤니티에 참여하여 모두를 위한 더 나은 지도를 만드는 데 힘을 보태주세요!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>오픈스트리트맵 계정을 만들거나 로그인하여 지도 편집 내용을 전 세계에 공개하세요.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%2중의 %1</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>셀룰러 네트워크 접속을 사용하여 다운로드하시겠습니까?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>이는 일부 플랜이나 로밍할 경우에 비싸다고 간주될 수 있습니다.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>올바른 집 번호 입력</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>층 수(최대 %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>최대 %1층까지 입력하세요</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>우편번호</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>올바른 우편번호를 입력하세요</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>오픈스트리트맵 자원 봉사자 참고 사항(선택 사항)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Organic Maps를 사용하여 지도상의 오류나 편집할 수 없는 항목을 설명하십시오</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>수정한 내용은 공개 &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Ko:OpenStreetMap_소개&quot;&gt;OpenStreetMap&lt;/a&gt; 데이터베이스에 업로드됩니다. 개인 정보나 저작권이 있는 정보는 추가하지 마세요.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap 정보</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>편집 기록</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>지도 데이터 노트</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>연산자</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>연산자: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>적합한 카테고리를 찾을 수 없나요?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps 단순한 지점 카테고리만 추가할 수 있습니다. 즉, 도시, 도로, 호수, 건물 윤곽선 등은 추가할 수 없습니다. 이러한 카테고리는 &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;에 직접 추가해 주십시오. 자세한 단계별 안내는 &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;가이드를&lt;/a&gt; 확인해 주세요.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>지도를 다운로드하지 않았습니다</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>오프라인으로 위치를 검색하려면 지도를 다운로드하세요.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>현재 위치를 알 수 없습니다.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>분</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>일</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>초</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>자세히</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>즐겨찾기 편집</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>개인 메모 (글자 혹은 html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>설명…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>지역 변경 사항을 재설정하시겠습니까?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>재설정</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>추가한 장소를 삭제하시겠습니까?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>삭제</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>존재하지 않는 장소입니다.</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>장소를 삭제하는 이유를 알려주세요.</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>올바른 전화 번호 입력</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>유효한 웹 주소 입력</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>유효한 이메일 주소 입력</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>유효한 Facebook 웹 주소, 계정 또는 페이지 이름을 입력합니다.</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>유효한 Instagram 사용자 아이디 또는 웹 주소를 입력합니다.</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>유효한 트위터 사용자 아이디 또는 웹 주소를 입력합니다.</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>유효한 VK 사용자 아이디 또는 웹 주소를 입력합니다.</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>유효한 LINE ID 또는 웹 주소를 입력하세요.</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>오픈스트리트맵에 장소 추가</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>또는 다른 사람이 이곳에 장소를 추가하거나 수정할 수 있도록 오픈스트리트맵 커뮤니티에 메모를 남기세요.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>오픈스트리트맵에 메모가 전송됩니다.</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>이를 모든 사용자에게 전송하시겠습니까?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>개인 정보를 입력하지 않았는지 확인하십시오.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap 편집자가 변경 사항을 확인하고 질문이 있는 경우 귀하에게 연락할 것입니다.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>중지</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>트랙 기록하기</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>동의</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>거부</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>모바일 인터넷을 사용하여 자세한 정보를 표시하시겠습니까?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>항상 사용</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>오늘만</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>오늘 사용 안 함</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>모바일 인터넷</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>모바일 인터넷은 사진, 가격, 리뷰 등 장소에 대한 자세한 정보를 표시하는 데 필요합니다.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>전혀 사용 안 함</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>항상 표시</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>교통 데이터를 표시하려면 지도를 업데이트해야 합니다.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>지도에서 글꼴 크기 늘리기</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Organic Maps를 업데이트하세요.</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>교통 데이터를 사용할 수 없습니다</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>로깅 사용</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>일반 피드백</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>당사는 음성 지침을 위해 시스템 TTS를 사용합니다. 많은 Android 장치에서 Google TTS를 사용합니다. Google Play 에서 Google TTS를 다운로드하거나 업데이트할 수 있습니다.</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>일부 언어의 경우 앱 스토어(Google Play, Galaxy Store, App Gallery, FDroid)에서 다른 음성 합성기 또는 추가 언어 팩을 설치해야 합니다.
+장치의 설정 → 언어 및 입력 → 음성 → 텍스트-음성 변환 출력을 엽니다.
+여기서 음성 합성에 대한 설정을 관리하고(예: 오프라인 사용을 위한 언어 팩 다운로드) 다른 텍스트-음성 변환 엔진을 선택할 수 있습니다.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>자세한 내용을 보려면 이 가이드를 확인하세요.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>라틴어로 음역</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>자세히 알아보기</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>검색을 사용하거나 지도를 탭하여 경로 시작점을 추가합니다</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>검색을 사용하거나 지도를 탭하여 목적지 지점을 추가합니다</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>경로 관리</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>계획</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>정류장 제거</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>스톱 추가</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>저장됨</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>모든 지도 편집 내용을 자동으로 업로드하려면 오픈스트리트맵에 로그인하세요. 자세히 알아보기 &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;여기&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>저장소 액세스 문제</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>외부 저장소를 사용할 수 없습니다. SD 카드가 제거되었거나 손상되었거나 파일 시스템이 읽기 전용일 수 있습니다. 확인 후 support@organicmaps.app로 문의하세요.</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>불량 저장소 에뮬레이션</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>올바른 이름을 입력하세요.</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>목록</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>모두 숨기기</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>모두 표시</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n 북마크</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>새 목록 만들기</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>북마크 및 트랙 가져오기</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>애플리케이션 오류로 인해 공유할 수 없습니다</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>공유 오류</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>빈 목록을 공유 할 수 없습니다</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>이름을 비워 둘 수는 없습니다.</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>목록 이름을 입력하십시오.</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>새 목록</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>이 이름은 이미 사용 중입니다.</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>다른 이름을 선택하십시오.</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>잠시만 기다려주십시오…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>전화 번호</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap 프로필</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n 개의 파일이 발견되었습니다. 변환 후 확인할 수 있습니다.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>복원</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n 추적</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>개인정보 보호</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>개인정보 보호 방침</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>사용 약관</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>트래픽</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>하이킹</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>사이클링</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>지하철</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>맵 스타일 및 레이어</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>이 목록은 비어있습니다.</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>북마크를 추가하려면 맵에서 장소를 탭하고 별 모양 아이콘을 탭하세요.</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>모든 북마크 색상 변경</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>모든 트랙 색상 변경</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…기타 정보</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZ 내보내기</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPX 내보내기</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSON 내보내기</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>리스트 삭제</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>속도 감시 카메라</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>장소 묘사</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>맵 다운로더</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>과속 경고</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>항상 경고하기</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>경고하지 않기</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>전력 절약 모드</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>자동 모드가 선택되면 어플리케이션은 현재 배터리 충전 정도에 따라 배터리를 많이 쓰는 기능이 불가하게 됩니다</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>안함</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>자동</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>최대 전력 절약</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>지도에 북마크 이름 표시</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>북마크가 너무 많을 경우 지도에 북마크 이름을 표시하면 앱 속도가 느려질 수 있습니다.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>오른쪽에 표시</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>하단에 표시</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>이 옵션은 진단을 목적으로 로그를 엽니다 이를 통해 앱에 대한 문제를 분석하는 우리의 스탭을 도울 수 있습니다 이 옵션은 오직 Organic Maps 지원 요청에서만 가능합니다.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>운전 옵션</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>유료 도로 피하기</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>비포장 도로 피하기</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>여객선 횡단길 피하기</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>고속도로 피하기</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>루트를 계산할 수 없습니다</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>아쉽게도 귀하가 정의한 옵션으로는 루트를 찾을 수가 없습니다. 설정을 바꾸신다음 다시 시도해주세요</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>피할 도로 정의하기</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>운전 옵션이 가능합니다</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>유료 도로</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>비포장 도로</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>여객선 횡단길</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>네</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>아니오</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>네</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>아니오</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>수용 인원: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>네트워크: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>도착했습니다!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>확인</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>분류…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>북마크 분류하기</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>기본 값</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>유형 별</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>거리 별</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>날짜 별</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>이름별</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>일주일 전</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>한달 전</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>한달 그 이상 전</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>1년 그 이상 전</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>나와 가까운 곳</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>기타</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>경로 계획 실패</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>도착: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>세계 지도를 변경했습니다. 이를 숨기지 마십시오! 친구에게 말하고, 이를 함께 편집합니다.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>친구들과 공유</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>지금 닫힘</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>내일 %1에 오픈</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%2에서 %1을(를) 엽니다.</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1에 열림</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1에서 닫힘</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>영업일 추가</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>암호(최소 8자)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>잘못된 사용자 이름 또는 암호.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM 계정</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>마지막 업로드</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>고맙습니다.</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>지명</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>전화</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>참고 사항</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>다운로드 오류</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>범주 선택</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>인기있는</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>모든 카테고리</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>지도에 새로운 장소를 추가하고 응용 프로그램에서 직접 기존 편집 할 수 있습니다.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>위치 변경</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>다운로드하려면, 더 많은 여유 공간이 필요합니다. 불필요한 데이터를 삭제하십시오.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>나는 Organic Maps 지도를 향상함</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>상세 설명</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>귀하가 제안한 변경 사항은 OpenStreetMap 커뮤니티로 전송됩니다. Organic Maps에서 편집할 수 없는 세부정보를 작성해 주세요.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>위치 검색 중 오류가 발생했습니다. 장치가 올바르게 작동되는지 확인하고 다시 시도하세요.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>위치 식별 사용할 수 없음</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>장치 설정에서 위치 정보에 액세스할 수 있음</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. 설정 열기</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. 위치 누르기</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. 앱 사용 중에 선택</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. 개인정보 보호 선택</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. 위치 서비스 선택</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. 위치 서비스 켜기</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>또는 위치 정보 없이 Organic Maps을 계속 사용하세요</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>예약</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>전화</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>즐겨찾기 이름</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>즐겨찾기 삭제</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>메모가 오픈스트리트맵으로 전송됩니다</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…기타</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>최신 정보</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>최근 여행한 경로 녹음을 비활성화하시겠습니까?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>비활성화</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>체크아웃</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps는 최근 여행한 경로를 녹음하기 위해 배경 화면에서 지역 위치 서비스를 사용합니다.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>일반 설정</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>교통 데이터를 표시하려면 응용 프로그램을 업데이트해야 합니다.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>로그 파일 크기: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>여기로 끌어와서 제거</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>교체 중지</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>시작 위치:</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>모든 지도 편집 내용을 자동으로 업로드하려면 오픈스트리트맵에 로그인하세요. 자세히 알아보기</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>여기</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>화면 숨기기</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1(%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 다운로드 중…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 적용 중…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>이 이름이 너무 깁니다.</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>새 파일이 감지되었습니다.</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>변하게 하다</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>오류</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>일부 파일은 변환되지 않았습니다.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>오류가 발생했습니다.</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>인기</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>지도에서 숨기기</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>태그를 불러오는 중 에러가 발생했습니다. 다시 시도해보세요</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>오른쪽</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>하단</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>가자</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>목적지</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>내 위치 조정하기</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>검색 결과</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>그 다음</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>루트를 재구축하길 원하시나요?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>운전 중에는 키보드를 사용할 수 없습니다</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>현재 위치에서 루트를 만들 수 없습니다</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>목적지 경로를 만들 수 없습니다. 다른 지점을 선택해주세요</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS 신호가 없습니다. 열린 장소로 이동해주세요</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>루트를 만들 수 없습니다. 또 다른 루트 지점을 지정해주세요</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>루트를 만들려면, 빠진 맵을 기기에 다운로드하세요</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>오류 발생. 어플리케이션을 재실행해주시길 바랍니다</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>루트가 귀하의 현재 위치로부터 재생성됩니다</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>루트가 차량에 맞춰 수정됩니다</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>모든 북마크가 표시되는 것은 아닙니다.</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>모든 북마크를 보려면 휴대폰으로 전환하세요.</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>과속 경고</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>속도단속 카메라</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Organic Maps 앱 안의 지도들을 디바이스에 다운로드하세요</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1번 출구</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>기본 값으로 분류</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>유형으로 분류</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>거리로 분류</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>날짜로 분류</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>이름별로 정렬</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>음식</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>명소</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>박물관</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>공원</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>수영</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>산</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>동물원</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>호텔</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>빌딩</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>돈</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>상점</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>주차장</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>주유소</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>의료</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>리스트에서 검색</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>종교적 장소</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>목록 선택</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>이 지역의 지하철 노선 기능이 아직 없습니다</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>지하철 루트가 발견되지 않았습니다</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>지하철역에서 가까운 출발점 또는 종점을 선택하세요</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>지형</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>지형 레이어를 활성화하고 사용하려면 해당 지역의 지도를 업데이트하거나 다운로드하십시오</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>이 지역의 지형 레이어는 아직 사용할 수 없습니다</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>올라가기</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>내려가기</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>최소 높이</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>최대 높이</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>난이도</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>거리:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>소비 시간:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>등치선 탐색을 위한 확대</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>다운로드 중</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>세계 개요 지도 다운로드</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>내부 장치의 메모리 또는 sdcard에 폴더를 생성하고 파일을 이동할 수 없습니다.</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>디스크 오류</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>연결 실패</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB 케이블 분리</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>화면 켜짐 유지</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>활성화하면 지도를 표시할 때 화면이 항상 켜져 있습니다.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>잠금 화면에 표시</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>활성화하면 기기가 잠겨 있어도 앱은 잠금 화면에서 작동합니다.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>지도 언어</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap의 지도 데이터</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Ko:OpenStreetMap_소개</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>커뮤니티에서 제작한 지도를 이용해 주셔서 감사합니다!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>여러분의 기부와 지원으로 우리는 세계 최고의 지도를 만들 수 있습니다!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>우리 앱이 마음에 드시나요? 발전을 위해 기부해주세요! 아직 마음에 들지 않으세요? 알려주시면 수정하겠습니다!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>소프트웨어 개발자를 알고 있다면 필요한 기능을 구현하도록 요청할 수 있습니다.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>지도의 아무 곳이나 탭하여 원하는 항목을 선택합니다. 길게 탭하면 인터페이스를 숨기고 다시 표시할 수 있습니다.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>지도에서 현재 위치를 선택할 수 있다는 것을 알고 계셨나요?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>우리 앱을 귀하의 언어로 번역하는 데 도움을 줄 수 있습니다.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>우리 앱은 소수의 열성팬과 커뮤니티에 의해 개발되었습니다.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>지도 데이터를 쉽게 수정하고 개선할 수 있습니다.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>우리의 주요 목표는 귀하가 좋아할 빠르고 개인 정보 보호에 중점을 두고 사용하기 쉬운 지도를 구축하는 것입니다.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>현재 휴대폰 화면에서 Organic Maps을 이용 중입니다</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>현재 차량 화면에서 Organic Maps을 이용 중입니다</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Android Auto에 연결되어 있습니다.</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>전화기에서 계속</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>차량 화면으로 이동</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps 위치 정보 접근 권한이 필요합니다. 안전한 환경에서 휴대폰의 알림을 확인해 주세요.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>이 앱은 사용자의 승인이 필요합니다.</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps Android Auto에서 이 앱이 제대로 작동하려면 위치 권한이 필요합니다</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>권한 부여</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>하이킹</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>웹 브라우저를 사용할 수 없습니다.</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>볼륨</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>모든 북마크 및 트랙 내보내기</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>음성 합성 시스템 설정</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>음성 합성 설정을 찾을 수 없었는데, 기기에서 이를 지원하는 것이 맞나요?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>드라이브 스루</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>검색 지우기</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>확대</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>축소</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>메뉴 링크</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>메뉴 보기</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>다른 앱에서 열기</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>셀프 서비스</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>옵션 선택</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>야외 좌석</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>가장 정확한 내비게이션을 위해 휴대폰의 배터리 설정에서 절전 모드를 비활성화하는 것이 좋습니다.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>트랙 기록</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>트랙 기록 중지</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>트랙 기록</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>저장하지 않고 중지</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>기록 계속하기</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>북마크 및 트랙에 저장하시겠습니까?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>경로가 비어 있음 - 저장할 항목이 없음</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>장치에 적합한 앱이 설치되어 있지 않아 폴더 선택 대화 상자를 표시할 수 없습니다. 파일 관리자 앱을 설치한 후 다시 시도하세요</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>색상 선택</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>경로 편집</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>위치를 열 수 있는 앱이 설치되어 있지 않습니다.</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>내비게이션 중 자동</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>시스템 설정 따름</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>트랙 공유</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>삭제 %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>난이도</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>쉬움</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>보통</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>어려움</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>업데이트 중</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>다운로드한 지도를 업데이트해야 합니다</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>지도를 업데이트하면 개체에 대한 정보가 최신 상태로 유지됩니다.</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>업데이트(%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>나중에 수동으로 업데이트</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>트랙 삭제</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>이 트랙을 삭제하시겠습니까?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>트랙 이름</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>이동</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>길</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>색상 변경</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>지도</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>개발자에게 버그 보고서를 보내시겠습니까?
+Organic Maps는 오류 정보를 자동으로 수집하지 않으므로, 저희는 사용자 여러분의 협조에 의존하고 있습니다. Organic Maps을 이용해 주셔서 미리 감사드립니다!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud 동기화 활성화</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud 동기화는 개발 중인 실험적 기능입니다. 모든 북마크와 트랙을 백업해 두었는지 확인하세요.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud가 비활성화됨</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>이 기능을 사용하려면 기기 설정에서 iCloud를 활성화하세요.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>사용</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>백업</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud 동기화 실패</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>오류입니다: 연결 오류로 인해 동기화하지 못했습니다.</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>오류입니다: iCloud 할당량이 초과되어 동기화하지 못했습니다.</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>오류: iCloud를 사용할 수 없습니다.</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>최근 삭제한 목록</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>지우기</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>모두 삭제</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>복구</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>모두 복구</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap에 기여하기</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>장소 추가</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>기여하려면 지도를 업데이트하세요</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap 데이터에 기여하기 전에 %1 지도를 최신 버전으로 업데이트해야 합니다</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>나의 위치</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>내 장소</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>내부 비공개 저장소</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>내부 공유 스토리지</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD 카드</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>외부 공유 스토리지</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi 인터넷</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>우편 번호</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>지도 지점</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>풋</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>경로를 표시하려면 지도를 업데이트해야 합니다.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>끝내기</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>입구</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>지하철 지도가 가용하지 않습니다.</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>당신</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>보라색 다운로드 지역</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>경로</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>백그라운드에서 위치를 감지하는 것은 앱의 모든 기능을 온전히 이용하는 데 필요합니다. 내비게이션과 최근 이동한 트랙 저장에 사용됩니다.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>현재 위치를 확인하는 것은 내비게이션과 최근 이동한 트랙 저장에 필요합니다.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>비밀번호로 로그인</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>브라우저를 사용하여 로그인</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>최근 사용</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>북마크 색상이 변경됨</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>트랙 색상이 변경됨</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>스펙트럼</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>슬라이더</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>빨강</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>초록</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB 16진수 색상 #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>그리드</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/lo/omim.ts
+++ b/qt/translations/lo/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="lo">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>ກັບຄືນ</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>ຍົກເລີກ</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>ລຶບ</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>ດາວໂຫລດແຜນທີ່</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>ການດາວໂຫລດລົ້ມເຫຼວ. ແຕະເພື່ອລອງໃໝ່.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>ກຳລັງດາວໂຫລດ…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>ກິໂລແມັດ</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>ໄມລ໌</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>ພາຍຫຼັງ</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>ຄົ້ນຫາ</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>ຄົ້ນຫາແຜນທີ່</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>ໃນປັດຈຸບັນທ່ານໄດ້ປິດການບໍລິການຕຳແໜ່ງທີ່ຕັ້ງທັງໝົດສຳລັບອຸປະກອນ ຫຼື ແອັບພລິເຄຊັນນີ້. ກະລຸນາເປີດການໃຊ້ງານໃນການຕັ້ງຄ່າ.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>ຄວາມຊັດເຈນຈຳກັດ</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>ເພື່ອໃຫ້ການນຳທາງຊັດເຈນ, ກະລຸນາເປີດຕຳແໜ່ງທີ່ຕັ້ງຊັດເຈນໃນການຕັ້ງຄ່າ.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>ສະແດງໃນແຜນທີ່</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>ການດາວໂຫລດລົ້ມເຫຼວ</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>ລອງໃໝ່</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>ກ່ຽວກັບ Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>ຟຣີສຳລັບທຸກຄົນ, ສ້າງດ້ວຍຄວາມຮັກ</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• ບໍ່ມີໂຄສະນາ, ບໍ່ມີການຕິດຕາມ, ບໍ່ມີການເກັບກຳຂໍ້ມູນ</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• ບໍ່ເປືອງແບັດເຕີຣີ, ໃຊ້ງານໄດ້ແບບອອບລາຍ</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• ໄວ, ງ່າຍດາຍ, ພັດທະນາໂດຍຊຸມຊົນ</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>ແອັບພລິເຄຊັນໂອເພັນຊອດທີ່ສ້າງໂດຍຜູ້ມີໃຈຮັກ ແລະ ອາສາສະໝັກ.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>ການຕັ້ງຄ່າຕຳແໜ່ງທີ່ຕັ້ງ</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>ປິດ</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>ແອັບນີ້ຕ້ອງການການເລັ່ງຮາດແວ OpenGL. ໜ້າເສຍດາຍ, ອຸປະກອນຂອງທ່ານບໍ່ຮອງຮັບ.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>ດາວໂຫລດ</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>ກະລຸນາຖອດສາຍ USB ຫຼື ສຽບກາດໜ່ວຍຄວາມຈຳເພື່ອໃຊ້ Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>ກະລຸນາເພີ່ມພື້ນທີ່ວ່າງໃນ SD ກາດ/ບ່ອນເກັບຂໍ້ມູນ USB ກ່ອນເພື່ອໃຊ້ແອັບ</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>ກ່ອນຈະເລີ່ມໃຊ້ແອັບ, ກະລຸນາດາວໂຫລດແຜນທີ່ພາບລວມຂອງໂລກລົງໃນອຸປະກອນຂອງທ່ານ.
+ມັນຈະໃຊ້ພື້ນທີ່ %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>ໄປທີ່ແຜນທີ່</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>ກຳລັງດາວໂຫລດ %1. ທ່ານສາມາດ
+ໄປທີ່ແຜນທີ່ໄດ້ເລີຍ.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>ດາວໂຫລດ %1 ບໍ່?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>ອັບເດດ %1 ບໍ່?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>ພັກ</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>ຕໍ່ໄປ</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>ການດາວໂຫລດ %1 ລົ້ມເຫຼວ</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>ເພີ່ມລາຍການໃໝ່</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>ຊື່ລາຍການບຸກມາກ</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>ບຸກມາກ</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>ບຸກມາກ ແລະ ເສັ້ນທາງ</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>ຊື່</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>ທີ່ຢູ່</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>ລາຍການ</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>ການຕັ້ງຄ່າ</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>ບັນທຶກແຜນທີ່ໄວ້ທີ່</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>ເລືອກໂຟນເດີເພື່ອດາວໂຫລດແຜນທີ່ໄວ້.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>ແຜນທີ່ທີ່ດາວໂຫລດແລ້ວ</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>ວ່າງ %1 ຈາກ %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>ຍ້າຍແຜນທີ່ບໍ່?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການຍ້າຍໄຟລ໌ແຜນທີ່</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>ອາດໃຊ້ເວລາຫຼາຍນາທີ.
+ກະລຸນາລໍຖ້າ…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>ຫົວໜ່ວຍວັດແທກ</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>ເລືອກລະຫວ່າງໄມລ໌ ແລະ ກິໂລແມັດ</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>ຍົກເລີກການດາວໂຫຼດ</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>ຂຽນຄຳວິຈານ</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>ແມ່ນ</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>ດາວໂຫຼດແຜນທີ່</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>ລາຍການບຸກມາກ</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>ບັນທຶກ</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>ມີການແບ່ງປັນບຸກມາກ Organic Maps ໃຫ້ທ່ານ</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>ສະບາຍດີ!
+
+ນີ້ແມ່ນບຸກມາກຂອງຂ້ອຍ; ກະລຸນາເປີດໃນ Organic Maps. ຫາກທ່ານຍັງບໍ່ໄດ້ຕິດຕັ້ງ, ສາມາດດາວໂຫລດໄດ້ທີ່ນີ້: https://omaps.app/get?kmz
+
+ຂໍໃຫ້ມ່ວນກັບການເດີນທາງດ້ວຍ Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>ກຳລັງໂຫລດບຸກມາກ</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>ໂຫລດບຸກມາກສຳເລັດແລ້ວ! ທ່ານສາມາດຊອກຫາພວກມັນໄດ້ໃນແຜນທີ່ ຫຼື ໃນໜ້າຈໍຈັດການບຸກມາກ.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>ໂຫລດບຸກມາກບໍ່ສຳເລັດ. ໄຟລ໌ອາດເສຍຫາຍ ຫຼື ບົກພ່ອງ.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>ແອັບບໍ່ຮູ້ຈັກປະເພດໄຟລ໌ນີ້:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>ເປີດໄຟລ໌ບໍ່ສຳເລັດ %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>ແກ້ໄຂ</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>ຍັງບໍ່ທັນສາມາດລະບຸຕຳແໜ່ງຂອງທ່ານໄດ້</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>ຂໍອະໄພ, ການຕັ້ງຄ່າບ່ອນເກັບຂໍ້ມູນແຜນທີ່ຖືກປິດການໃຊ້ງານໃນຂະນະນີ້.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>ພວມຢູ່ໃນຂະນະດາວໂຫລດແຜນທີ່.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>ເບິ່ງຕຳແໜ່ງປັດຈຸບັນຂອງຂ້ອຍໃນ Organic Maps! %1 ຫຼື %2 ຫາກບໍ່ມີແຜນທີ່ອອບລາຍ? ດາວໂຫລດໄດ້ທີ່ນີ້: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>ເຮີ້ຍ, ເບິ່ງປັກໝຸດຂອງຂ້ອຍໃນ Organic Maps ແມ້!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>ເຮີ້ຍ, ເບິ່ງຕຳແໜ່ງປັດຈຸບັນຂອງຂ້ອຍໃນແຜນທີ່ Organic Maps ແມ້!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>ສະບາຍດີ,
+
+ຕອນນີ້ຂ້ອຍຢູ່ທີ່ນີ້: %1. ຄລິກລິ້ງນີ້ %2 ຫຼື ອັນນີ້ %3 ເພື່ອເບິ່ງສະຖານທີ່ໃນແຜນທີ່.
+
+ຂອບໃຈ.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>ແບ່ງປັນ</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>ອີເມລ</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>ຄັດລອກໄປທີ່ຄລິບບອດແລ້ວ: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>ສຳເລັດ</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>ຂໍ້ມູນ OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການອອກຈາກລະບົບ OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>ເສັ້ນທາງ</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>ຄວາມຍາວ</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>ແບ່ງປັນຕຳແໜ່ງຂອງຂ້ອຍ</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>ການຕັ້ງຄ່າທົ່ວໄປ</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>ຂໍ້ມູນ</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>ການນຳທາງ</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>ປຸ່ມ “+” ແລະ “-” ໃນແຜນທີ່</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>ສະແດງໃນແຜນທີ່</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>ຮູບແບບກາງຄືນເມື່ອນຳທາງໃນບ່ອນມືດ</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>ໂໝດກາງຄືນ</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>ປິດ</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>ເປີດ</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>ອັດຕະໂນມັດ</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>ມຸມມອງເປີສະເປັກທິບ</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>ອາຄານ 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>ອາຄານ 3D ຖືກປິດໃຊ້ງານໃນໂໝດປະຢັດພະລັງງານ</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>ຄຳແນະນຳດ້ວຍສຽງ</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>ປະກາດຊື່ຖະໜົນ</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>ເມື່ອເປີດໃຊ້, ຊື່ຖະໜົນ ຫຼື ທາງອອກທີ່ຈະລ້ຽວເຂົ້າຈະຖືກອ່ານອອກສຽງ.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>ພາສາຂອງສຽງ</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>ເພື່ອດາວໂຫຼດສຽງຄຸນນະພາບສູງກວ່າ, ເປີດແອັບ ການຕັ້ງຄ່າ ແລ້ວໄປທີ່ ການເຂົ້າເຖິງ → VoiceOver → ການເວົ້າ → ສຽງ.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>ທົດສອບຄຳແນະນຳດ້ວຍສຽງ (TTS)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>ກະລຸນາກວດເບິ່ງລະດັບສຽງ ຫຼື ການຕັ້ງຄ່າ Text-To-Speech ຂອງລະບົບ ຫາກທ່ານບໍ່ໄດ້ຍິນສຽງໃນຕອນນີ້.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>ບໍ່ສາມາດໃຊ້ງານໄດ້</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>ຊູມອັດຕະໂນມັດ</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>ໄລຍະທາງ</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>ເບິ່ງໃນແຜນທີ່</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>ເມນູ</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>ເວັບໄຊ</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>ຂ່າວສານ</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>ຄຳຕິຊົມ</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>ໃຫ້ຄະແນນແອັບ</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>ຊ່ວຍເຫຼືອ</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>ຄຳຖາມທີ່ພົບເລື້ອຍ</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>ບໍລິຈາກ</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>ບໍລິຈາກແລ້ວ</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>ເຕືອນພາຍຫຼັງ</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>ສະໜັບສະໜູນ Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>ສະໜັບສະໜູນໂຄງການ</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>ລິຂະສິດ</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>ລາຍງານຂໍ້ຜິດພາດ</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>ປັບປຸງທິດທາງຂອງລູກສອນໂດຍການເຄື່ອນຍ້າຍໂທລະສັບເປັນຮູບເລກແປດເພື່ອຄາລິເບຣດເຂັມທິດ.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>ເຄື່ອນຍ້າຍໂທລະສັບເປັນຮູບເລກແປດເພື່ອຄາລິເບຣດເຂັມທິດ ແລະ ແກ້ໄຂທິດທາງລູກສອນໃນແຜນທີ່.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>ແຕະຄ້າງໃນແຜນທີ່ອີກຄັ້ງເພື່ອເບິ່ງອິນເຕີເຟດ</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>ອັບເດດທັງໝົດ</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>ຍົກເລີກທັງໝົດ</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>ດາວໂຫລດແລ້ວ</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>ຢູ່ໃນຄິວ</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>ໃກ້ຂ້ອຍ</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>ແຜນທີ່</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>ດາວໂຫລດທັງໝົດ</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>ກຳລັງດາວໂຫລດ:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>ເພື່ອລຶບແຜນທີ່, ກະລຸນາຢຸດການນຳທາງ.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>ເສັ້ນທາງສາມາດສ້າງໄດ້ສະເພາະພາຍໃນແຜນທີ່ຂອງພາກພື້ນດຽວກັນເທົ່ານັ້ນ.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>ດາວໂຫລດແຜນທີ່</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>ລອງໃໝ່</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>ລຶບແຜນທີ່</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>ອັບເດດແຜນທີ່</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>ບໍລິການຕຳແໜ່ງທີ່ຕັ້ງຂອງ Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>ລະບຸຕຳແໜ່ງໂດຍປະມານຂອງທ່ານຢ່າງວ່ອງໄວໂດຍໃຊ້ Bluetooth, WiFi, ຫຼື ເຄືອຂ່າຍມືຖື</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>ດາວໂຫລດແຜນທີ່ທັງໝົດຕາມເສັ້ນທາງຂອງທ່ານ</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>ເພື່ອສ້າງເສັ້ນທາງ, ພວກເຮົາຕ້ອງດາວໂຫລດ ແລະ ອັບເດດແຜນທີ່ທັງໝົດຕັ້ງແຕ່ຕຳແໜ່ງຂອງທ່ານໄປຈົນຮອດປາຍທາງ.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>ພື້ນທີ່ບໍ່ພໍ</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>ກະລຸນາເປີດບໍລິການຕຳແໜ່ງທີ່ຕັ້ງ</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>ບັນທຶກ</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>ສ້າງ</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>ສີແດງ</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>ສີເຫຼືອງ</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>ສີຟ້າ</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>ສີຂຽວ</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>ສີມ່ວງ</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>ສີສົ້ມ</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>ສີນ້ຳຕານ</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>ສີບົວ</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>ສີມ່ວງເຂັ້ມ</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>ສີຟ້າອ່ອນ</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>ສີຟ້າຂຽວ</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>ສີຂຽວນົກເປັດນ້ຳ</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>ສີຂຽວໝາກນາວ</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>ສີສົ້ມເຂັ້ມ</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>ສີເທົາ</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>ສີເທົາຟ້າ</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>ຂໍ້ມູນ</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>ເວີຊັນ Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>ຮູບລັກສະນະ</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>ແຈ້ງ</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>ມືດ</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>ໂໝດສະຫວ່າງຈາກອາລຸນເຖິງຕອນແລງ</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>ອື່ນໆ</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>ມອບແຜນທີ່ຟຣີທີ່ບໍ່ມີໂຄສະນາໃຫ້ກັບຜູ້ໃຊ້ຫຼາຍລ້ານຄົນ!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>ແຈ້ງ ຫຼື ແກ້ໄຂຂໍ້ມູນແຜນທີ່ທີ່ບໍ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>ອາສາສະໝັກ</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>ຕິດຕາມ ແລະ ຕິດຕໍ່ພວກເຮົາ:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>ຍັງບໍ່ທັນໄດ້ຕັ້ງຄ່າແອັບອີເມລ. ກະລຸນາຕັ້ງຄ່າ ຫຼື ຕິດຕໍ່ພວກເຮົາທີ່ %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການສົ່ງອີເມລ</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>ການປັບຕັ້ງເຂັມທິດ</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>ມີໃຫ້ໃຊ້</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>ພົບ</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>ອັບເດດ</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>ຫຼົ້ມເຫຼວ</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>ບຸກມາກ</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>ເມື່ອເດີນທາງຕາມເສັ້ນທາງ, ກະລຸນາຈື່ໄວ້ວ່າ:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— ສະພາບຖະໜົນ, ກົດໝາຍຈະລາຈອນ, ແລະ ປ້າຍຈະລາຈອນ ມີຄວາມສຳຄັນກວ່າຄຳແນະນຳໃນການນຳທາງສະເໝີ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— ແຜນທີ່ອາດບໍ່ຊັດເຈນ, ແລະ ເສັ້ນທາງທີ່ແນະນຳອາດບໍ່ແມ່ນທາງທີ່ດີທີ່ສຸດສະເໝີໄປ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— ເສັ້ນທາງທີ່ແນະນຳຄວນຖືວ່າເປັນພຽງຄຳແນະນຳເທົ່ານັ້ນ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— ລະມັດລະວັງກັບເສັ້ນທາງໃນເຂດຊາຍແດນ: ເສັ້ນທາງທີ່ສ້າງໂດຍແອັບຂອງພວກເຮົາອາດຂ້າມຊາຍແດນປະເທດໃນຈຸດທີ່ບໍ່ໄດ້ຮັບອະນຸຍາດ.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>ກະລຸນາມີສະຕິ ແລະ ປອດໄພໃນການເດີນທາງ!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>ກວດເບິ່ງສັນຍານ GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>ບໍ່ສາມາດສ້າງເສັ້ນທາງໄດ້. ບໍ່ສາມາດລະບຸພິກັດ GPS ປັດຈຸບັນໄດ້.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>ກະລຸນາກວດເບິ່ງສັນຍານ GPS ຂອງທ່ານ. ການເປີດ Wi-Fi ຈະຊ່ວຍໃຫ້ຕຳແໜ່ງທີ່ຕັ້ງຊັດເຈນຂຶ້ນ.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>ເປີດບໍລິການຕຳແໜ່ງທີ່ຕັ້ງ</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>ບໍ່ສາມາດລະບຸພິກັດ GPS ປັດຈຸບັນໄດ້. ເປີດບໍລິການຕຳແໜ່ງທີ່ຕັ້ງເພື່ອຄິດໄລ່ເສັ້ນທາງ.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>ບໍ່ສາມາດຊອກຫາເສັ້ນທາງໄດ້</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>ບໍ່ສາມາດສ້າງເສັ້ນທາງໄດ້.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>ກະລຸນາປັບປຸງຈຸດເລີ່ມຕົ້ນ ຫຼື ປາຍທາງຂອງທ່ານ.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>ປັບປຸງຈຸດເລີ່ມຕົ້ນ</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>ເສັ້ນທາງບໍ່ຖືກສ້າງ. ບໍ່ສາມາດລະບຸຈຸດເລີ່ມຕົ້ນໄດ້.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>ກະລຸນາເລືອກຈຸດເລີ່ມຕົ້ນໃຫ້ໃກ້ກັບຖະໜົນ.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>ປັບປຸງປາຍທາງ</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>ເສັ້ນທາງບໍ່ຖືກສ້າງ. ບໍ່ສາມາດລະບຸປາຍທາງໄດ້.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>ກະລຸນາເລືອກຈຸດປາຍທາງໃຫ້ໃກ້ກັບຖະໜົນ.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>ບໍ່ສາມາດລະບຸຈຸດແວ່ພັກໄດ້.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>ກະລຸນາປັບປຸງຈຸດແວ່ພັກຂອງທ່ານ.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>ຂໍ້ຜິດພາດຂອງລະບົບ</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>ບໍ່ສາມາດສ້າງເສັ້ນທາງໄດ້ເນື່ອງຈາກຂໍ້ຜິດພາດຂອງແອັບພລິເຄຊັນ.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>ກະລຸນາລອງໃໝ່</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>ບໍ່ແມ່ນຕອນນີ້</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>ທ່ານຕ້ອງການດາວໂຫລດແຜນທີ່ ແລະ ສ້າງເສັ້ນທາງທີ່ດີກວ່າເຊິ່ງກວມເອົາຫຼາຍກວ່າໜຶ່ງແຜນທີ່ບໍ່?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>ດາວໂຫລດແຜນທີ່ເພີ່ມເຕີມເພື່ອສ້າງເສັ້ນທາງທີ່ດີກວ່າເຊິ່ງຂ້າມຂອບເຂດຂອງແຜນທີ່ນີ້.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>ດາວໂຫຼດໄຟລ໌ທີ່ຈຳເປັນ</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>ດາວໂຫຼດ ຫຼື ອັບເດດແຜນທີ່ທັງໝົດຕາມເສັ້ນທາງເພື່ອຄິດໄລ່ເສັ້ນທາງ.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>ເພື່ອເລີ່ມການຄົ້ນຫາ ແລະ ສ້າງເສັ້ນທາງ, ກະລຸນາດາວໂຫລດແຜນທີ່. ຫຼັງຈາກນັ້ນ, ທ່ານຈະບໍ່ຈຳເປັນຕ້ອງໃຊ້ການເຊື່ອມຕໍ່ອິນເຕີເນັດອີກ.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>ເລືອກແຜນທີ່</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>ສະແດງ</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>ເຊື່ອງ</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>ໝວດໝູ່</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>ປະຫວັດ</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>ຂໍອະໄພ, ບໍ່ພົບຜົນການຄົ້ນຫາ.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>ດາວໂຫລດພາກພື້ນທີ່ທ່ານກຳລັງຄົ້ນຫາ ຫຼື ລອງເພີ່ມຊື່ເມືອງ/ບ້ານທີ່ຢູ່ໃກ້ຄຽງ.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>ປະຫວັດການຄົ້ນຫາ</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>ເບິ່ງການຄົ້ນຫາຫຼ້າສຸດຂອງທ່ານ.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>ລຶບປະຫວັດການຄົ້ນຫາ</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>ວິກິພີເດຍ</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>ບົດຄວາມຈາກ wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>ວິກິມີເດຍ ຄອມມອນສ໌</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>ຕຳແໜ່ງຂອງທ່ານ</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>ເລີ່ມ</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>ເສັ້ນທາງຈາກ</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>ເສັ້ນທາງໄປຫາ</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>ການນຳທາງສາມາດໃຊ້ໄດ້ສະເພາະຈາກຕຳແໜ່ງປັດຈຸບັນຂອງທ່ານເທົ່ານັ້ນ.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>ທ່ານຕ້ອງການວາງແຜນເສັ້ນທາງຈາກຕຳແໜ່ງປັດຈຸບັນຂອງທ່ານບໍ່?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>ຕໍ່ໄປ</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>ຈາກ</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>ຫາ</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>ເພີ່ມຕາຕະລາງ</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>ລຶບຕາຕະລາງ</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>ທັງໝົດມື້ (24 ຊົ່ວໂມງ)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>ເປີດ</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>ປິດ</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>ເພີ່ມຊົ່ວໂມງທີ່ບໍ່ແມ່ນເວລາທຳການ</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>ເວລາທຳການ</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>ໂໝດຂັ້ນສູງ</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>ໂໝດງ່າຍດາຍ</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>ຊົ່ວໂມງທີ່ບໍ່ແມ່ນເວລາທຳການ</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>ຕົວຢ່າງຄ່າ</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>ແກ້ໄຂຂໍ້ຜິດພາດ</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>ເລືອກຕຳແໜ່ງທີ່ຕັ້ງ</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>ກະລຸນາອະທິບາຍບັນຫາໂດຍລະອຽດເພື່ອໃຫ້ຊຸມຊົນ OpenStreetMap ສາມາດແກ້ໄຂໄດ້.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>ຫຼື ເຮັດດ້ວຍຕົນເອງໄດ້ທີ່ https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>ສົ່ງ</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>ບັນຫາ</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>ສະຖານທີ່ນີ້ບໍ່ມີຢູ່ແທ້</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>ປິດເພື່ອປັບປຸງ</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>ສະຖານທີ່ຊ້ຳຊ້ອນ</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>ດາວໂຫລດແຜນທີ່ອັດຕະໂນມັດ</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>ທຸກມື້</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>ປິດມື້ນີ້</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>ປິດ</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>ມື້ນີ້</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>ຈະເປີດໃນອີກ %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>ຈະປິດໃນອີກ %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>ປິດ</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>ແກ້ໄຂເວລາທຳການ</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>ຍັງບໍ່ມີບັນຊີ OpenStreetMap ບໍ່?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>ລົງທະບຽນທີ່ OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>ເຂົ້າສູ່ລະບົບ</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>ຍັງບໍ່ທັນໄດ້ເຂົ້າສູ່ລະບົບ</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>ເຂົ້າສູ່ລະບົບ OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>ລະຫັດຜ່ານ</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>ລືມລະຫັດຜ່ານບໍ່?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>ອອກຈາກລະບົບ</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>ແກ້ໄຂສະຖານທີ່</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>ເພີ່ມພາສາ</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>ຖະໜົນ</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>ເລກທີອາຄານ</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>ລາຍລະອຽດ</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>ສື່ສັງຄົມອອນລາຍ</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>ອາຄານ</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>ເພີ່ມຖະໜົນ</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>ກະລຸນາປ້ອນຊື່ຖະໜົນ</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>ເລືອກພາສາ</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>ເລືອກຖະໜົນ</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>ປະເພດອາຫານ</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>ເລືອກປະເພດອາຫານ</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>ອີເມລ ຫຼື ຊື່ຜູ້ໃຊ້</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>ເພີ່ມເບີໂທລະສັບ</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>ຊັ້ນ</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>ຊັ້ນ: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>ການແກ້ໄຂແຜນທີ່ທັງໝົດຂອງທ່ານຈະຖືກລຶບໄປພ້ອມກັບແຜນທີ່.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>ອັບເດດແຜນທີ່</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>ເພື່ອສ້າງເສັ້ນທາງ, ທ່ານຕ້ອງອັບເດດແຜນທີ່ທັງໝົດ ແລ້ວຈຶ່ງວາງແຜນເສັ້ນທາງໃໝ່ອີກຄັ້ງ.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>ຊອກຫາແຜນທີ່</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>ກະລຸນາໃຫ້ແນ່ໃຈວ່າອຸປະກອນຂອງທ່ານໄດ້ເຊື່ອມຕໍ່ອິນເຕີເນັດແລ້ວ.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>ພື້ນທີ່ບໍ່ພໍ</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>ກະລຸນາລຶບຂໍ້ມູນທີ່ບໍ່ຈຳເປັນອອກ</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການເຂົ້າສູ່ລະບົບ.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>ການປ່ຽນແປງທີ່ໄດ້ຮັບການຢືນຢັນແລ້ວ</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>ລາກແຜນທີ່ເພື່ອວາງເຄື່ອງໝາຍບວກໃສ່ຕຳແໜ່ງຂອງສະຖານທີ່ ຫຼື ທຸລະກິດ.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>ກຳລັງແກ້ໄຂ</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>ກຳລັງເພີ່ມ</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>ຊື່ຂອງສະຖານທີ່</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>ຕາມທີ່ຂຽນໃນພາສາທ້ອງຖິ່ນ</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>ໝວດໝູ່</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>ລາຍລະອຽດຂອງບັນຫາ</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>ບັນຫາອື່ນໆ</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>ເພີ່ມທຸລະກິດ</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>ບໍ່ມີວັດຖຸໃດສາມາດຕັ້ງຢູ່ບ່ອນນີ້ໄດ້</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>ຂໍ້ມູນ OpenStreetMap ທີ່ສ້າງໂດຍຊຸມຊົນ ນັບຕັ້ງແຕ່ %1. ສຶກສາເພີ່ມເຕີມກ່ຽວກັບວິທີແກ້ໄຂ ແລະ ອັບເດດແຜນທີ່ໄດ້ທີ່ OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) ແມ່ນໂຄງການຊຸມຊົນເພື່ອສ້າງແຜນທີ່ທີ່ຟຣີ ແລະ ເປີດກວ້າງ. ມັນເປັນແຫຼ່ງຂໍ້ມູນແຜນທີ່ຫຼັກໃນ Organic Maps ແລະ ເຮັດວຽກຄ້າຍຄືກັບ Wikipedia. ທ່ານສາມາດເພີ່ມ ຫຼື ແກ້ໄຂສະຖານທີ່ ແລະ ພວກມັນຈະພ້ອມໃຫ້ຜູ້ໃຊ້ຫຼາຍລ້ານຄົນທົ່ວໂລກໄດ້ໃຊ້.
+ມາເຂົ້າຮ່ວມຊຸມຊົນ ແລະ ຊ່ວຍກັນສ້າງແຜນທີ່ທີ່ດີກວ່າສຳລັບທຸກຄົນ!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>ສ້າງບັນຊີ OpenStreetMap ຫຼື ເຂົ້າສູ່ລະບົບເພື່ອເຜີຍແຜ່ການແກ້ໄຂແຜນທີ່ຂອງທ່ານໃຫ້ໂລກໄດ້ເຫັນ.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 ຈາກ %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>ດາວໂຫລດຜ່ານການເຊື່ອມຕໍ່ເຄືອຂ່າຍມືຖືບໍ່?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>ນີ້ອາດຈະມີຄ່າໃຊ້ຈ່າຍສູງສຳລັບບາງແພັກເກັດ ຫຼື ຫາກໃຊ້ບໍລິການໂຣມມິ່ງ.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>ປ້ອນເລກທີອາຄານທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>ຈຳນວນຊັ້ນ (ສູງສຸດ %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>ຈຳນວນຊັ້ນຕ້ອງບໍ່ເກີນ %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ລະຫັດໄປສະນີ</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>ປ້ອນລະຫັດໄປສະນີທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>ບັນທຶກເຖິງອາສາສະໝັກ OpenStreetMap (ບໍ່ບັງຄັບ)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>ອະທິບາຍຂໍ້ຜິດພາດໃນແຜນທີ່ ຫຼື ສິ່ງທີ່ບໍ່ສາມາດແກ້ໄຂໄດ້ດ້ວຍ Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>ການແກ້ໄຂຂອງທ່ານຈະຖືກອັບໂຫລດໄປຍັງຖານຂໍ້ມູນສາທາລະນະ &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. ກະລຸນາຢ່າເພີ່ມຂໍ້ມູນສ່ວນຕົວ ຫຼື ຂໍ້ມູນທີ່ມີລິຂະສິດ.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>ເພີ່ມເຕີມກ່ຽວກັບ OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>ປະຫວັດການແກ້ໄຂຂອງທ່ານ</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>ບັນທຶກຂໍ້ມູນແຜນທີ່ຂອງທ່ານ</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>ຜູ້ດູແລ</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>ຜູ້ດຳເນີນການ: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>ບໍ່ພົບໝວດໝູ່ທີ່ເໝາະສົມບໍ່?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps ອະນຸຍາດໃຫ້ເພີ່ມສະເພາະໝວດໝູ່ຈຸດທີ່ງ່າຍດາຍເທົ່ານັ້ນ, ນັ້ນໝາຍຄວາມວ່າບໍ່ລວມເຖິງ ຕົວເມືອງ, ຖະໜົນ, ໜອງນ້ຳ, ຂອບເຂດອາຄານ ແລະ ອື່ນໆ. ກະລຸນາເພີ່ມໝວດໝູ່ດັ່ງກ່າວໂດຍກົງທີ່ &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. ກວດເບິ່ງ &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;ຄຳແນະນຳ&lt;/a&gt; ຂອງພວກເຮົາສຳລັບຂັ້ນຕອນໂດຍລະອຽດ.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>ທ່ານຍັງບໍ່ໄດ້ດາວໂຫລດແຜນທີ່ໃດໆ</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>ດາວໂຫລດແຜນທີ່ເພື່ອຄົ້ນຫາ ແລະ ນຳທາງແບບອອບລາຍ.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>ບໍ່ຮູ້ຕຳແໜ່ງປັດຈຸບັນ.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>ກມ/ຊມ</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ໄມ/ຊມ</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ຊມ</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>ນາທີ</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>ມື້</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>ວິ</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>ເພີ່ມເຕີມ</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>ແກ້ໄຂບຸກມາກ</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>ບັນທຶກສ່ວນຕົວ (ຂໍ້ຄວາມ ຫຼື html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>ສະແດງຄວາມຄິດເຫັນ…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>ຍົກເລີກການປ່ຽນແປງພາຍໃນທັງໝົດບໍ່?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>ຍົກເລີກ</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>ລຶບສະຖານທີ່ທີ່ເພີ່ມເຂົ້າໄປບໍ່?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>ລຶບ</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>ສະຖານທີ່ນີ້ບໍ່ມີຢູ່ແທ້</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>ກະລຸນາລະບຸເຫດຜົນໃນການລຶບສະຖານທີ່</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>ປ້ອນເບີໂທລະສັບທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>ປ້ອນທີ່ຢູ່ເວັບທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>ປ້ອນອີເມລທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>ປ້ອນທີ່ຢູ່ເວັບ Facebook, ບັນຊີ ຫຼື ຊື່ເພຈທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>ປ້ອນຊື່ຜູ້ໃຊ້ ຫຼື ທີ່ຢູ່ເວັບ Instagram ທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>ປ້ອນຊື່ຜູ້ໃຊ້ ຫຼື ທີ່ຢູ່ເວັບ Twitter ທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>ປ້ອນຊື່ຜູ້ໃຊ້ ຫຼື ທີ່ຢູ່ເວັບ VK ທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>ປ້ອນ LINE ID ຫຼື ທີ່ຢູ່ເວັບທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>ເພີ່ມສະຖານທີ່ໃສ່ OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>ຫຼື ອີກທາງເລືອກໜຶ່ງ, ຝາກບັນທຶກໄວ້ໃຫ້ຊຸມຊົນ OpenStreetMap ເພື່ອໃຫ້ຄົນອື່ນສາມາດເພີ່ມ ຫຼື ແກ້ໄຂສະຖານທີ່ບ່ອນນີ້ໄດ້.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>ບັນທຶກຈະຖືກສົ່ງໄປຫາ OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>ທ່ານຕ້ອງການສົ່ງໃຫ້ຜູ້ໃຊ້ທັງໝົດບໍ່?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>ໃຫ້ແນ່ໃຈວ່າທ່ານບໍ່ໄດ້ປ້ອນຂໍ້ມູນສ່ວນຕົວໃດໆ.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>ຜູ້ກວດແກ້ OpenStreetMap ຈະກວດສອບການປ່ຽນແປງ ແລະ ຕິດຕໍ່ຫາທ່ານຫາກພວກເຂົາມີຄຳຖາມໃດໆ.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>ຢຸດ</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>ກຳລັງບັນທຶກເສັ້ນທາງ</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>ຍອມຮັບ</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>ປະຕິເສດ</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>ໃຊ້ ອິນເຕີເນັດມືຖື ເພື່ອສະແດງຂໍ້ມູນລະອຽດບໍ່?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>ໃຊ້ສະເໝີ</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>ສະເພາະມື້ນີ້</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>ບໍ່ໃຊ້ໃນມື້ນີ້</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>ອິນເຕີເນັດມືຖື</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>ຕ້ອງການອິນເຕີເນັດມືຖືສຳລັບການແຈ້ງເຕືອນອັບເດດແຜນທີ່ ແລະ ການອັບໂຫລດການແກ້ໄຂ.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>ບໍ່ໃຊ້ເລີຍ</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>ຖາມທຸກຄັ້ງ</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>ເພື່ອສະແດງຂໍ້ມູນການຈະລາຈອນ, ຕ້ອງອັບເດດແຜນທີ່ກ່ອນ.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>ເພີ່ມຂະໜາດສຳລັບປ້າຍຊື່ໃນແຜນທີ່</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>ກະລຸນາອັບເດດ Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>ຂໍ້ມູນການຈະລາຈອນບໍ່ພ້ອມໃຊ້ງານ</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>ເປີດການບັນທຶກລັອກ</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>ຄຳຕິຊົມທົ່ວໄປ</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>ພວກເຮົາໃຊ້ TTS ຂອງລະບົບສຳລັບຄຳແນະນຳດ້ວຍສຽງ. ອຸປະກອນ Android ຫຼາຍລຸ້ນໃຊ້ Google TTS, ທ່ານສາມາດດາວໂຫລດ ຫຼື ອັບເດດໄດ້ຈາກ Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>ສຳລັບບາງພາສາ, ທ່ານຈະຕ້ອງຕິດຕັ້ງເຄື່ອງສັງເຄາະສຽງ ຫຼື ຊຸດພາສາເພີ່ມເຕີມຈາກແອັບສະໂຕ (Google Play, Galaxy Store, App Gallery, FDroid).
+ເປີດການຕັ້ງຄ່າອຸປະກອນຂອງທ່ານ → ພາສາ ແລະ ການປ້ອນຂໍ້ມູນ → ສຽງ → ການອອກສຽງ Text to speech.
+ຢູ່ບ່ອນນີ້ທ່ານສາມາດຈັດການການຕັ້ງຄ່າສຳລັບການສັງເຄາະສຽງ (ຕົວຢ່າງ: ດາວໂຫລດຊຸດພາສາສຳລັບໃຊ້ແບບອອບລາຍ) ແລະ ເລືອກເຄື່ອງຈັກ text-to-speech ອື່ນ.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>ສຳລັບຂໍ້ມູນເພີ່ມເຕີມ ກະລຸນາກວດເບິ່ງຄຳແນະນຳນີ້.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>ຖອດອັກສອນເປັນພາສາລາແຕັງ</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>ຮຽນຮູ້ເພີ່ມເຕີມ</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>ໃຊ້ການຄົ້ນຫາ, ເລືອກບຸກມາກ, ຫຼື ແຕະໃນແຜນທີ່ເພື່ອເພີ່ມຈຸດເລີ່ມຕົ້ນຂອງເສັ້ນທາງ</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>ໃຊ້ການຄົ້ນຫາ, ເລືອກບຸກມາກ, ຫຼື ແຕະໃນແຜນທີ່ເພື່ອເພີ່ມຈຸດປາຍທາງ</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>ຈັດການເສັ້ນທາງ</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>ວາງແຜນ</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>ເອົາຈຸດແວ່ພັກອອກ</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>ເພີ່ມຈຸດແວ່ພັກ</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>ບັນທຶກແລ້ວ</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>ກະລຸນາເຂົ້າສູ່ລະບົບ OpenStreetMap ເພື່ອອັບໂຫລດການແກ້ໄຂແຜນທີ່ທັງໝົດຂອງທ່ານໂດຍອັດຕະໂນມັດ. ສຶກສາເພີ່ມເຕີມ &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ທີ່ນີ້&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>ບັນຫາການເຂົ້າເຖິງບ່ອນເກັບຂໍ້ມູນ</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>ບໍ່ສາມາດເຂົ້າເຖິງບ່ອນເກັບຂໍ້ມູນພາຍນອກໄດ້. SD ກາດອາດຖືກຖອດອອກ, ເສຍຫາຍ, ຫຼື ລະບົບໄຟລ໌ເປັນແບບອ່ານຢ່າງດຽວ. ກະລຸນາກວດເບິ່ງ SD ກາດຂອງທ່ານ ຫຼື ຕິດຕໍ່ຫາພວກເຮົາໄດ້ທີ່ support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>ຈຳລອງບ່ອນເກັບຂໍ້ມູນທີ່ເສຍຫາຍ</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>ກະລຸນາປ້ອນຊື່ທີ່ຖືກຕ້ອງ</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>ລາຍການ</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>ເຊື່ອງທັງໝົດ</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>ສະແດງທັງໝົດ</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmarks</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>ສ້າງລາຍການໃໝ່</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>ນຳເຂົ້າບຸກມາກ ແລະ ເສັ້ນທາງ</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>ບໍ່ສາມາດແບ່ງປັນໄດ້ເນື່ອງຈາກຂໍ້ຜິດພາດຂອງແອັບພລິເຄຊັນ</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>ຂໍ້ຜິດພາດໃນການແບ່ງປັນ</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>ບໍ່ສາມາດແບ່ງປັນລາຍການທີ່ວ່າງເປົ່າໄດ້</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>ຊື່ຕ້ອງບໍ່ວ່າງເປົ່າ</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>ກະລຸນາປ້ອນຊື່ລາຍການ</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>ລາຍການໃໝ່</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>ຊື່ນີ້ຖືກໃຊ້ແລ້ວ</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>ກະລຸນາເລືອກຊື່ອື່ນ</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>ກະລຸນາລໍຖ້າ…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>ເບີໂທລະສັບ</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>ໂປຣໄຟລ໌ OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>ພົບເຫັນ %n ໄຟລ໌. ທ່ານສາມາດເບິ່ງມັນໄດ້ຫຼັງຈາກການແປງ.</numerusform>
+<numerusform>ພົບເຫັນ %n ໄຟລ໌. ທ່ານສາມາດເບິ່ງມັນໄດ້ຫຼັງຈາກການແປງ.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>ກູ້ຄືນ</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ຕິດຕ່າງໆ</numerusform>
+<numerusform>%n ຕິດຕ່າງໆ</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>ຄວາມເປັນສ່ວນຕົວ</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>ນະໂຍບາຍຄວາມເປັນສ່ວນຕົວ</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>ເງື່ອນໄຂການໃຊ້ງານ</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>ການຈະລາຈອນ</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>ການຍ່າງປ່າ</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>ການຂີ່ລົດຖີບ</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>ລົດໄຟໃຕ້ດິນ</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>ຮູບແບບແຜນທີ່ ແລະ ເລເຢີ້</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>ລາຍການນີ້ວ່າງເປົ່າ</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>ເພື່ອເພີ່ມບຸກມາກ, ໃຫ້ແຕະໃສ່ສະຖານທີ່ໃນແຜນທີ່ ແລ້ວແຕະທີ່ໄອຄອນຮູບດາວ</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>ປ່ຽນສີຂອງບຸກມາກທັງໝົດ</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>ປ່ຽນສີຂອງເສັ້ນທາງທັງໝົດ</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…ເພີ່ມເຕີມ</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>ສົ່ງອອກ KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>ສົ່ງອອກ GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>ສົ່ງອອກ GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>ລຶບລາຍການ</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>ກ້ອງກວດຈັບຄວາມໄວ</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>ລາຍລະອຽດສະຖານທີ່</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>ຕົວດາວໂຫລດແຜນທີ່</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>ເຕືອນຫາກເກີນຄວາມໄວ</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>ເຕືອນສະເໝີ</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>ບໍ່ຕ້ອງເຕືອນ</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>ໂໝດປະຢັດພະລັງງານ</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>ພະຍາຍາມຫຼຸດການໃຊ້ພະລັງງານໂດຍແລກກັບບາງຟັງຊັນການໃຊ້ງານ.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>ບໍ່ເລີຍ</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>ເມື່ອແບັດເຕີຣີຕ່ຳ</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>ສະເໝີ</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>ຊື່ບຸກມາກໃນແຜນທີ່</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>ຫາກມີບຸກມາກຫຼາຍເກີນໄປ, ການສະແດງຊື່ຂອງພວກມັນໃນແຜນທີ່ອາດເຮັດໃຫ້ແອັບຊ້າລົງ.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>ສະແດງທາງເບື້ອງຂວາ</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>ສະແດງທາງເບື້ອງລຸ່ມ</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>ເປີດໃຊ້ຕົວເລືອກນີ້ຊົ່ວຄາວເພື່ອບັນທຶກ ແລະ ສົ່ງລັອກການວິນິດໄສໂດຍລະອຽດກ່ຽວກັບບັນຫາຂອງທ່ານໃຫ້ພວກເຮົາໂດຍໃຊ້ &quot;ລາຍງານຂໍ້ຜິດພາດ&quot; ໃນສ່ວນຊ່ວຍເຫຼືອ. ລັອກອາດຈະລວມມີຂໍ້ມູນຕຳແໜ່ງທີ່ຕັ້ງ.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>ຕົວເລືອກການສ້າງເສັ້ນທາງ</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>ເລ່ຽງທາງເສຍຄ່າທຳນຽມ</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>ເລ່ຽງທາງບໍ່ປູຢາງ</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>ເລ່ຽງເຮືອຂ້າມຟາກ</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>ເລ່ຽງທາງດ່ວນ</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>ບໍ່ສາມາດຄິດໄລ່ເສັ້ນທາງໄດ້</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>ບໍ່ພົບເສັ້ນທາງ. ນີ້ອາດຈະເກີດຈາກຕົວເລືອກການສ້າງເສັ້ນທາງຂອງທ່ານ ຫຼື ຂໍ້ມູນ OpenStreetMap ບໍ່ສົມບູນ. ກະລຸນາປ່ຽນຕົວເລືອກການສ້າງເສັ້ນທາງຂອງທ່ານ ແລະ ລອງໃໝ່.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>ກຳນົດຖະໜົນທີ່ຕ້ອງການເລ່ຽງ</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>ເປີດໃຊ້ຕົວເລືອກການສ້າງເສັ້ນທາງແລ້ວ</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>ທາງເສຍຄ່າທຳນຽມ</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>ທາງບໍ່ປູຢາງ</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>ຈຸດຂ້າມເຮືອຟາກ</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>ແມ່ນ</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>ບໍ່</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>ມີ</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>ບໍ່ມີ</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>ຄວາມຈຸ: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>ເຄືອຂ່າຍ: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>ທ່ານມາຮອດແລ້ວ!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>ຕົກລົງ</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>ຈັດລຽງ…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>ຈັດລຽງບຸກມາກ</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>ຕາມຄ່າເລີ່ມຕົ້ນ</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>ຕາມປະເພດ</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>ຕາມໄລຍະທາງ</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>ຕາມວັນທີ</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>ຕາມຊື່</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>ໜຶ່ງອາທິດຜ່ານມາ</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>ໜຶ່ງເດືອນຜ່ານມາ</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>ຫຼາຍກວ່າໜຶ່ງເດືອນຜ່ານມາ</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>ຫຼາຍກວ່າໜຶ່ງປີຜ່ານມາ</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>ໃກ້ຂ້ອຍ</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>ອື່ນໆ</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>ວາງແຜນເສັ້ນທາງບໍ່ສຳເລັດ</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>ມາຮອດໃນເວລາ %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>ດາວໂຫຼດ ແລະ ອັບເດດແຜນທີ່ທັງໝົດຕາມເສັ້ນທາງເພື່ອຄິດໄລ່ເສັ້ນທາງ.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>ທ່ານໄດ້ຊ່ວຍປ່ຽນແປງແຜນທີ່ໂລກແລ້ວ! ຢ່າເກັບໄວ້ຄົນດຽວ; ບອກໝູ່ເພື່ອນຂອງທ່ານໃຫ້ມາຊ່ວຍກັນແກ້ໄຂນຳກັນ.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>ແບ່ງປັນກັບໝູ່ເພື່ອນ</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>ປິດຢູ່ໃນຂະນະນີ້</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>ຈະເປີດມື້ອື່ນເວລາ %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>ຈະເປີດວັນ%1 ເວລາ %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>ຈະເປີດເວລາ %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>ຈະປິດເວລາ %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>ເພີ່ມເວລາເປີດ-ປິດ</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>ລະຫັດຜ່ານ (ຢ່າງໜ້ອຍ 8 ຕົວອັກສອນ)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>ຊື່ຜູ້ໃຊ້ ຫຼື ລະຫັດຜ່ານບໍ່ຖືກຕ້ອງ.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>ບັນຊີ OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>ອັບໂຫຼດຫຼ້າສຸດ</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>ຂອບໃຈ</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>ຊື່ສະຖານທີ່</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>ເບີໂທລະສັບ</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>ກະລຸນາໝາຍເຫດ</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການດາວໂຫຼດ</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>ເລືອກໝວດໝູ່</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>ຍອດນິຍົມ</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>ໝວດໝູ່ທັງໝົດ</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>ເພີ່ມສະຖານທີ່ໃໝ່ລົງໃນແຜນທີ່ ແລະ ແກ້ໄຂສະຖານທີ່ທີ່ມີຢູ່ແລ້ວໄດ້ໂດຍກົງຈາກແອັບ.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>ປ່ຽນຕຳແໜ່ງ</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>ທ່ານຕ້ອງການພື້ນທີ່ຈັດເກັບເພີ່ມເຕີມເພື່ອດາວໂຫຼດ. ກະລຸນາລຶບຂໍ້ມູນທີ່ບໍ່ຈຳເປັນອອກ.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>ຂ້ອຍໄດ້ຊ່ວຍປັບປຸງແຜນທີ່ໃນ Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>ຄວາມຄິດເຫັນລະອຽດ</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>ການປ່ຽນແປງທີ່ທ່ານແນະນຳຈະຖືກສົ່ງໄປຫາຊຸມຊົນ OpenStreetMap. ກະລຸນາອະທິບາຍລາຍລະອຽດເພີ່ມເຕີມທີ່ບໍ່ສາມາດແກ້ໄຂໄດ້ໃນ Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການລະບຸຕຳແໜ່ງຂອງທ່ານ. ກະລຸນາກວດສອບວ່າອຸປະກອນເຮັດງານປົກກະຕິ ແລະ ລອງໃໝ່ອີກຄັ້ງ.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>ບໍລິການຕຳແໜ່ງຖືກປິດຢູ່</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>ເປີດໃຊ້ການເຂົ້າເຖິງຕຳແໜ່ງໃນການຕັ້ງຄ່າອຸປະກອນ</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. ເປີດການຕັ້ງຄ່າ</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. ແຕະທີ່ ຕຳແໜ່ງ</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. ເລືອກ ໃນລະຫວ່າງການໃຊ້ແອັບ</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. ເລືອກ ຄວາມເປັນສ່ວນຕົວ</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. ເລືອກ ບໍລິການຕຳແໜ່ງ</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. ເປີດ ບໍລິການຕຳແໜ່ງ</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>ຫຼື ໃຊ້ Organic Maps ຕໍ່ໄປໂດຍບໍ່ໃຊ້ຕຳແໜ່ງ</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>ຈອງ</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>ໂທ</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>ຊື່ບຸກມາກ</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>ລຶບບຸກມາກ</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>ໝາຍເຫດຂອງທ່ານຈະຖືກສົ່ງໄປຫາ OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…ເພີ່ມເຕີມ</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>ອັບເດດ</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>ປິດການບັນທຶກເສັ້ນທາງການເດີນທາງຫຼ້າສຸດຂອງທ່ານຫຼືບໍ່?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>ປິດໃຊ້ງານ</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>ເບິ່ງທີ່ນີ້</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps ໃຊ້ຕຳແໜ່ງຂອງທ່ານໃນເບື້ອງຫຼັງເພື່ອບັນທຶກເສັ້ນທາງການເດີນທາງຫຼ້າສຸດຂອງທ່ານ.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>ການຕັ້ງຄ່າທົ່ວໄປ</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>ເພື່ອສະແດງຂໍ້ມູນການຈໍລະຈອນ, ຕ້ອງອັບເດດແອັບພລິເຄຊັນ.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>ຂະໜາດໄຟລ໌ລັອກ: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>ລາກມາທີ່ນີ້ເພື່ອລຶບ</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>ປ່ຽນແທນຈຸດແວ່ພັກ</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>ເລີ່ມຕົ້ນຈາກ</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>ກະລຸນາເຂົ້າສູ່ລະບົບ OpenStreetMap ເພື່ອອັບໂຫຼດການແກ້ໄຂແຜນທີ່ທັງໝົດຂອງທ່ານໂດຍອັດຕະໂນມັດ. ສຶກສາເພີ່ມເຕີມ</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ທີ່ນີ້</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>ເຊື່ອງໜ້າຈໍ</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 ຈາກ %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>ກຳລັງດາວໂຫຼດ %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>ກຳລັງຕິດຕັ້ງ %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>ຊື່ນີ້ຍາວເກີນໄປ</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>ກວດພົບໄຟລ໌ໃໝ່</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>ແປງໄຟລ໌</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>ຂໍ້ຜິດພາດ</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>ບາງໄຟລ໌ບໍ່ໄດ້ຖືກແປງ.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>ເກີດຂໍ້ຜິດພາດ</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>ຍອດນິຍົມ</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>ເຊື່ອງຈາກແຜນທີ່</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>ເກີດຂໍ້ຜິດພາດໃນການໂຫຼດແທັກ, ກະລຸນາລອງໃໝ່</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>ຂວາ</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>ລຸ່ມ</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>ໄປກັນເລີຍ</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>ຈຸດໝາຍປາຍທາງ</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>ຈັດຕຳແໜ່ງກາງໃໝ່</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>ຜົນການຄົ້ນຫາ</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>ຈາກນັ້ນ</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>ທ່ານຕ້ອງການສ້າງເສັ້ນທາງໃໝ່ຫຼືບໍ່?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>ແປ້ນພິມບໍ່ສາມາດໃຊ້ໄດ້ໃນລະຫວ່າງການຂັບຂີ່</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>ບໍ່ສາມາດສ້າງເສັ້ນທາງຈາກຕຳແໜ່ງປັດຈຸບັນຂອງທ່ານໄດ້</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>ຫາເສັ້ນທາງໄປຫາຈຸດໝາຍປາຍທາງບໍ່ພົບ. ກະລຸນາເລືອກຈຸດໝາຍປາຍທາງອື່ນ</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>ບໍ່ມີສັນຍານ GPS. ກະລຸນາຍ້າຍໄປບ່ອນທີ່ໂລ່ງແຈ້ງ</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>ບໍ່ສາມາດສ້າງເສັ້ນທາງໄດ້. ກະລຸນາລະບຸຈຸດອື່ນໆໃນເສັ້ນທາງ</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>ເພື່ອສ້າງເສັ້ນທາງ, ກະລຸນາດາວໂຫຼດແຜນທີ່ທີ່ຍັງຂາດຢູ່ໃນອຸປະກອນຂອງທ່ານ</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>ເກີດຂໍ້ຜິດພາດ. ກະລຸນາເລີ່ມແອັບໃໝ່</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>ເສັ້ນທາງຈະຖືກສ້າງໃໝ່ຈາກຕຳແໜ່ງປັດຈຸບັນຂອງທ່ານ</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>ເສັ້ນທາງຈະຖືກປ່ຽນເປັນເສັ້ນທາງສຳລັບລົດຍົນ</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>ບຸກມາກບາງອັນບໍ່ໄດ້ຖືກສະແດງ</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>ກະລຸນາເບິ່ງໃນໂທລະສັບເພື່ອເບິ່ງບຸກມາກທັງໝົດ</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>ກ້ອງກວດຈັບຄວາມໄວ</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>ການເຕືອນຄວາມໄວ</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>ກະລຸນາດາວໂຫຼດແຜນທີ່ໃນແອັບເທິງອຸປະກອນມືຖືຂອງທ່ານ</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>ທາງອອກທີ %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>ຈັດລຽງຕາມຄ່າມາດຕະຖານ</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>ຈັດລຽງຕາມປະເພດ</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>ຈັດລຽງຕາມໄລຍະທາງ</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>ຈັດລຽງຕາມວັນທີ</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>ຈັດລຽງຕາມຊື່</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>ອາຫານ</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>ສະຖານທີ່ທ່ອງທ່ຽວ</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>ພິພິທະພັນ</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>ສວນສາທາລະນະ</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>ບ່ອນລອຍນ້ຳ</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>ພູເຂົາ</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>ສັດ</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>ໂຮງແຮມ</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>ອາຄານ</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>ການເງິນ</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>ຮ້ານຄ້າ</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>ບ່ອນຈອດລົດ</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>ປ້ຳນ້ຳມັນ</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>ການແພດ</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>ຄົ້ນຫາໃນລາຍການ</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>ສະຖານທີ່ທາງສາດສະໜາ</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>ເລືອກລາຍການ</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>ການນຳທາງດ້ວຍລົດໄຟໃຕ້ດິນໃນພາກພື້ນນີ້ຍັງບໍ່ທັນມີເທື່ອ</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>ບໍ່ພົບເສັ້ນທາງລົດໄຟໃຕ້ດິນ</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>ກະລຸນາເລືອກຈຸດເລີ່ມຕົ້ນ ຫຼື ປາຍທາງໃຫ້ໃກ້ກັບສະຖານີລົດໄຟໃຕ້ດິນ</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>ເສັ້ນລະດັບຄວາມສູງ</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>ການເປີດໃຊ້ເສັ້ນລະດັບຄວາມສູງຕ້ອງດາວໂຫລດຂໍ້ມູນແຜນທີ່ສຳລັບພາກພື້ນນີ້</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>ເສັ້ນລະດັບຄວາມສູງຍັງບໍ່ທັນມີເທື່ອໃນເຂດນີ້</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>ທາງຂຶ້ນ</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>ທາງລົງ</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>ລະດັບຄວາມສູງຕ່ຳສຸດ</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>ລະດັບຄວາມສູງສູງສຸດ</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>ຄວາມຍາກ</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>ໄລຍະ:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>ເວລາ:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>ຊູມເຂົ້າເພື່ອເບິ່ງເສັ້ນລະດັບຄວາມສູງ</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>ກຳລັງດາວໂຫລດ</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>ດາວໂຫລດແຜນທີ່ພາບລວມຂອງໂລກ</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>ບໍ່ສາມາດສ້າງໂຟນເດີ ແລະ ຍ້າຍໄຟລ໌ໃນໜ່ວຍຄວາມຈຳພາຍໃນຂອງອຸປະກອນ ຫຼື sdcard ໄດ້</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>ຂໍ້ຜິດພາດຂອງດິສກ໌</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>ການເຊື່ອມຕໍ່ຫຼົ້ມເຫຼວ</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>ຖອດສາຍ USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>ເປີດໜ້າຈໍຄ້າງໄວ້</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>ເມື່ອເປີດໃຊ້, ໜ້າຈໍຈະເປີດຄ້າງໄວ້ສະເໝີເມື່ອສະແດງແຜນທີ່.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>ສະແດງໃນໜ້າຈໍລັອກ</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>ເມື່ອເປີດໃຊ້, ແອັບຈະເຮັດວຽກໃນໜ້າຈໍລັອກ ເຖິງແມ່ນວ່າອຸປະກອນຈະຖືກລັອກຢູ່ກໍຕາມ.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>ພາສາຂອງແຜນທີ່</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>ຂໍ້ມູນແຜນທີ່ຈາກ OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>ຂອບໃຈທີ່ໃຊ້ແຜນທີ່ທີ່ສ້າງໂດຍຊຸມຊົນຂອງພວກເຮົາ!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>ດ້ວຍການບໍລິຈາກ ແລະ ການສະໜັບສະໜູນຂອງທ່ານ, ພວກເຮົາສາມາດສ້າງແຜນທີ່ທີ່ດີທີ່ສຸດໃນໂລກໄດ້!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>ທ່ານມັກແອັບຂອງພວກເຮົາບໍ່? ກະລຸນາບໍລິຈາກເພື່ອສະໜັບສະໜູນການພັດທະນາ! ຫາກຍັງບໍ່ມັກ? ກະລຸນາບອກໃຫ້ພວກເຮົາຮູ້ເຫດຜົນ, ແລ້ວພວກເຮົາຈະແກ້ໄຂໃຫ້!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>ຫາກທ່ານຮູ້ຈັກນັກພັດທະນາຊອບແວ, ທ່ານສາມາດຂໍໃຫ້ລາວຊ່ວຍພັດທະນາຟີເຈີທີ່ທ່ານຕ້ອງການໄດ້.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>ແຕະບ່ອນໃດກໍໄດ້ໃນແຜນທີ່ເພື່ອເລືອກສິ່ງຕ່າງໆ. ການແຕະຄ້າງແມ່ນໃຊ້ເພື່ອເຊື່ອງ ແລະ ສະແດງອິນເຕີເຟດ.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>ທ່ານຮູ້ບໍ່ວ່າຕຳແໜ່ງປັດຈຸບັນຂອງທ່ານໃນແຜນທີ່ສາມາດຖືກເລືອກໄດ້?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>ທ່ານສາມາດຊ່ວຍແປແອັບຂອງພວກເຮົາເປັນພາສາຂອງທ່ານໄດ້.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>ແອັບຂອງພວກເຮົາຖືກພັດທະນາໂດຍຜູ້ມີໃຈຮັກພຽງບໍ່ເທົ່າໃດຄົນ ແລະ ຊຸມຊົນ.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>ທ່ານສາມາດແກ້ໄຂ ແລະ ປັບປຸງຂໍ້ມູນແຜນທີ່ໄດ້ຢ່າງງ່າຍດາຍ.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>ເປົ້າໝາຍຫຼັກຂອງພວກເຮົາແມ່ນເພື່ອສ້າງແຜນທີ່ທີ່ໄວ, ເນັ້ນຄວາມເປັນສ່ວນຕົວ, ແລະ ໃຊ້ງານງ່າຍທີ່ທ່ານຈະມັກ.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>ຕອນນີ້ທ່ານກຳລັງໃຊ້ Organic Maps ໃນໜ້າຈໍໂທລະສັບ</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>ຕອນນີ້ທ່ານກຳລັງໃຊ້ Organic Maps ໃນໜ້າຈໍລົດ</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>ທ່ານໄດ້ເຊື່ອມຕໍ່ກັບ Android Auto ແລ້ວ</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>ຕໍ່ໄປໃນໂທລະສັບ</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>ໄປທີ່ໜ້າຈໍລົດ</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps ຕ້ອງການການເຂົ້າເຖິງຕຳແໜ່ງທີ່ຕັ້ງ. ເມື່ອປອດໄພແລ້ວ, ໃຫ້ກວດເບິ່ງການແຈ້ງເຕືອນໃນໂທລະສັບຂອງທ່ານ.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>ແອັບນີ້ຕ້ອງການການອະນຸຍາດຈາກທ່ານ</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps ໃນ Android Auto ຕ້ອງການການອະນຸຍາດຕຳແໜ່ງທີ່ຕັ້ງເພື່ອໃຫ້ເຮັດວຽກໄດ້ຢ່າງມີປະສິດທິພາບ</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>ໃຫ້ການອະນຸຍາດ</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>ກາງແຈ້ງ</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>ເວັບບຣາວເຊີບໍ່ພ້ອມໃຊ້ງານ</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>ລະດັບສຽງ</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>ສົ່ງອອກບຸກມາກ ແລະ ເສັ້ນທາງທັງໝົດ</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>ການຕັ້ງຄ່າລະບົບການສັງເຄາະສຽງ</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>ບໍ່ພົບການຕັ້ງຄ່າການສັງເຄາະສຽງ, ທ່ານແນ່ໃຈບໍ່ວ່າອຸປະກອນຂອງທ່ານຮອງຮັບ?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>ໄດຣຟ໌ທຣູ</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>ລຶບການຄົ້ນຫາ</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>ຊູມເຂົ້າ</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>ຊູມອອກ</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>ລິ້ງເມນູ</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>ເບິ່ງເມນູ</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>ເປີດໃນແອັບອື່ນ</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>ບໍລິການຕົນເອງ</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>ເລືອກຕົວເລືອກ</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>ບ່ອນນັ່ງກາງແຈ້ງ</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>ເພື່ອການນຳທາງທີ່ຊັດເຈນທີ່ສຸດ, ພວກເຮົາແນະນຳໃຫ້ປິດໂໝດປະຢັດພະລັງງານໃນການຕັ້ງຄ່າແບັດເຕີຣີຂອງໂທລະສັບ.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>ບັນທຶກເສັ້ນທາງ</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>ຢຸດການບັນທຶກເສັ້ນທາງ</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>ການບັນທຶກເສັ້ນທາງ</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>ຢຸດໂດຍບໍ່ບັນທຶກ</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>ບັນທຶກຕໍ່ໄປ</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>ບັນທຶກລົງໃນບຸກມາກ ແລະ ເສັ້ນທາງບໍ່?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>ເສັ້ນທາງວ່າງເປົ່າ - ບໍ່ມີຫຍັງໃຫ້ບັນທຶກ</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>ບໍ່ສາມາດສະແດງໜ້າຈໍເລືອກໂຟນເດີໄດ້ເນື່ອງຈາກບໍ່ມີແອັບທີ່ເໝາະສົມຕິດຕັ້ງໃນອຸປະກອນຂອງທ່ານ. ກະລຸນາຕິດຕັ້ງແອັບຈັດການໄຟລ໌ ແລະ ລອງໃໝ່ອີກຄັ້ງ.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>ເລືອກສີ</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>ແກ້ໄຂເສັ້ນທາງ</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>ບໍ່ມີແອັບທີ່ຕິດຕັ້ງໄວ້ເຊິ່ງສາມາດເປີດຕຳແໜ່ງທີ່ຕັ້ງນີ້ໄດ້</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>ອັດຕະໂນມັດໃນການນຳທາງ</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>ຕາມລະບົບ</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>ແບ່ງປັນເສັ້ນທາງ</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>ລຶບ %1 ບໍ່?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>ລະດັບຄວາມຍາກ</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>ງ່າຍ</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>ປານກາງ</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>ຍາກ</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>ກຳລັງອັບເດດ</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>ອັບເດດແຜນທີ່ທີ່ດາວໂຫຼດໄວ້</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>ການອັບເດດແຜນທີ່ຊ່ວຍໃຫ້ຂໍ້ມູນສະຖານທີ່ຕ່າງໆເປັນປັດຈຸບັນຢູ່ສະເໝີ</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>ອັບເດດ (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>ອັບເດດເອງພາຍຫຼັງ</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>ລຶບເສັ້ນທາງ</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>ທ່ານແນ່ໃຈຫຼືບໍ່ວ່າຕ້ອງການລຶບເສັ້ນທາງນີ້?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>ຊື່ເສັ້ນທາງ</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>ຍ້າຍ</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>ເສັ້ນທາງ</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>ປ່ຽນສີ</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>ແຜນທີ່</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>ທ່ານຕ້ອງການສົ່ງລາຍງານບັນຫາໃຫ້ກັບນັກພັດທະນາຫຼືບໍ່?
+ເນື່ອງຈາກ Organic Maps ບໍ່ໄດ້ເກັບກຳຂໍ້ມູນຂໍ້ຜິດພາດໂດຍອັດຕະໂນມັດ ພວກເຮົາຈຶ່ງຕ້ອງອາໄສຂໍ້ມູນຈາກຜູ້ໃຊ້. ຂອບໃຈລ່ວງໜ້າທີ່ສະໜັບສະໜູນ Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>ເປີດໃຊ້ການຊິງໂຄໄນຊ໌ກັບ iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>ການຊິງໂຄໄນຊ໌ກັບ iCloud ເປັນຟີເຈີທົດລອງທີ່ກຳລັງພັດທະນາ. ກະລຸນາກວດສອບໃຫ້ແນ່ໃຈວ່າທ່ານໄດ້ສຳຮອງຂໍ້ມູນບຸກມາກ ແລະ ເສັ້ນທາງທັງໝົດໄວ້ແລ້ວ.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud ຖືກປິດໃຊ້ງານຢູ່</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>ກະລຸນາເປີດໃຊ້ iCloud ໃນການຕັ້ງຄ່າອຸປະກອນຂອງທ່ານເພື່ອໃຊ້ຟີເຈີນີ້.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>ເປີດໃຊ້ງານ</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>ສຳຮອງຂໍ້ມູນ</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>ການຊິງໂຄໄນຊ໌ກັບ iCloud ຫຼົ້ມເຫຼວ</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>ຂໍ້ຜິດພາດ: ຊິງໂຄໄນຊ໌ບໍ່ສຳເລັດເນື່ອງຈາກຂໍ້ຜິດພາດໃນການເຊື່ອມຕໍ່</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>ຂໍ້ຜິດພາດ: ຊິງໂຄໄນຊ໌ບໍ່ສຳເລັດເນື່ອງຈາກພື້ນທີ່ iCloud ເຕັມ</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>ຂໍ້ຜິດພາດ: iCloud ບໍ່ພ້ອມໃຊ້ງານ</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>ລາຍການທີ່ຖືກລຶບຫຼ້າສຸດ</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>ລ້າງຂໍ້ມູນ</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>ລຶບທັງໝົດ</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>ກູ້ຄືນ</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>ກູ້ຄືນທັງໝົດ</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>ຊ່ວຍເຫຼືອ OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>ເພີ່ມສະຖານທີ່</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>ອັບເດດແຜນທີ່ເພື່ອຊ່ວຍເຫຼືອຂໍ້ມູນ</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>ທ່ານຕ້ອງອັບເດດແຜນທີ່ %1 ເປັນເວີຊັນຫຼ້າສຸດກ່ອນ ຈຶ່ງຈະສາມາດຊ່ວຍເພີ່ມຂໍ້ມູນ OpenStreetMap ໄດ້</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>ຕຳແໜ່ງຂອງຂ້ອຍ</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>ສະຖານທີ່ຂອງຂ້ອຍ</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>ບ່ອນເກັບຂໍ້ມູນພາຍໃນສ່ວນຕົວ</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>ບ່ອນເກັບຂໍ້ມູນພາຍໃນທີ່ໃຊ້ຮ່ວມກັນ</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>ກາດ SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>ບ່ອນເກັບຂໍ້ມູນພາຍນອກທີ່ໃຊ້ຮ່ວມກັນ</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>ລະຫັດໄປສະນີ</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>ຈຸດໃນແຜນທີ່</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>ມ</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>ກມ</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ໄມລ໌</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ຟຸດ</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>ເພື່ອສະແດງເສັ້ນທາງ, ຕ້ອງໄດ້ອັບເດດແຜນທີ່.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>ທາງອອກ</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>ທາງເຂົ້າ</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>ບໍ່ມີຂໍ້ມູນແຜນທີ່ລົດໄຟໃຕ້ດິນ</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>ສະແດງພື້ນທີ່ທີ່ດາວໂຫລດແລ້ວເປັນສີມ່ວງ</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>ໃຊ້ບໍ່ດົນມານີ້</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>ສີຂອງບຸກມາກໄດ້ປ່ຽນແລ້ວ</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>ສີຂອງເສັ້ນທາງໄດ້ປ່ຽນແລ້ວ</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>ຕົວເລື່ອນ</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ສີແດງ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ຂຽວ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ສີຟ້າ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex ສີ #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>ຕາຂ່າຍ</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/lt/omim.ts
+++ b/qt/translations/lt/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="lt">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Grįžti</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Atsisakyti</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Šalinti</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Atsisiųsti žemėlapius</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Atsiuntimas nepavyko. Bakstelėkite, kad būtų pabandyta dar kartą.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Atsiunčiama…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometrai</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mylios</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Vėliau</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Ieškoti</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Ieškoti žemėlapyje</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Šiuo metu jūsų įrenginyje arba šiai programėlei visos vietovės tarnybos yra išjungtos. Įjunkite jas nustatymuose.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ribotas tikslumas</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Jeigu norite užtikrinti tikslią navigaciją, nustatymuose įjunkite galimybę nustatyti tikslią vietą.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Rodyti žemėlapyje</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Atsiuntimas nepavyko</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Bandyti dar kartą</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Apie „Organic Maps“</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Nemokama visiems, sukurta su meile</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Jokių reklamų, sekimo, duomenų rinkimo</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Neiškrauna akumuliatoriaus, nes veikia neprisijungus prie interneto</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Sparti, minimalistinė, vystoma bendruomenės</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Atvirojo kodo programėlė, sukurta entuziastų ir savanorių.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Vietos nustatymai</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Užverti</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Šiai programėlei reikia aparatinio „OpenGL“ spartinimo. Deja, jūsų įrenginys nepalaikomas.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Atsiųsti</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Jeigu norite naudotis „Organic Maps“, atjunkite USB kabelį arba įdėkite atminties kortelę</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Jeigu norite naudotis programėle, atlaisvinkite vietos SD kortelėje ar USB atmintinėje</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Prieš pradėdami naudotis programėle, leiskite atsiųsti bendrąjį pasaulio žemėlapį į jūsų įrenginį.&#32;
+Jis užims %1 vietos saugykloje.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Eiti į žemėlapį</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Atsiunčiama %1. Dabar galite&#32;
+eiti į žemėlapį.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Atsiųsti %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Naujinti %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pristabdyti</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Tęsti</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1: atsiuntimas nepavyko</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Naujo sąrašo pridėjimas</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Žymių sąrašo pavadinimas</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Žymės</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Žymės ir trasos</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Pavadinimas</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresas</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Sąrašas</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Nustatymai</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Žemėlapius saugyklos vieta</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Pasirinkite aplanką atsiųstiems žemėlapiams įrašyti.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Atsiųsti žemėlapiai</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>Laisva %1 iš %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Perkelti žemėlapius?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Klaida perkeliant žemėlapių failus</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Tai gali užtrukti kelias minutes.
+Luktelėkite…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Matavimo vienetai</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Pasirinkite kilometrus arba mylias</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Nutraukti atsiuntimą</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Palikite atsiliepimą</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Taip</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Atsiųsti žemėlapį</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Žymių sąrašai</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Kur pavalgyti</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Maisto prekės</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Viešasis transportas</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Degalinė</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkavimas</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Apsipirkimas</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Naudotos prekės</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Viešbutis</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Lankytina vieta</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Pramogos</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomatas</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Naktinis gyvenimas</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Šeimos atostogos</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bankas</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Vaistinė</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Ligoninė</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Tualetas</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Paštas</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policija</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Antrinės žaliavos</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vanduo</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Kemperių aptarnavimas</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Pastabos</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Su jumis bendrinamas „Organic Maps“ žymių sąrašas</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Labas!&#32;
+&#32;
+Čia prisegtas mano žymių sąrašas iš „Organic Maps“ programėlės. Jei jos neturi, gali ją parsisiųsti iš https://omaps.app/get?kmz&#32;
+&#32;
+Smagių kelionių su „Organic Maps“!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Žymių sąrašas įkeliamas</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Žymių sąrašas įkeltas! Galite rasti jį žemėlapyje arba žymių tvarkytuvės ekrane.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Žymių sąrašo nepavyko įkelti. Gali būti, kad failas sugadintas.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Programėlė neatpažįsta failo tipo:&#32;
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nepavyko atverti failo %1&#32;
+&#32;
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Taisyti</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Jūsų vieta dar nenustatyta</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Deja, šiuo metu žemėlapio saugyklos nustatymai negalimi.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Vyksta žemėlapio atsiuntimas.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Pažiūrėk, kur dabar esu „Organic Maps“ autonominių žemėlapių programėlėje! %1 arba %2 . Neturi jos? Atsisiųsk čia: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Labas, pažvelk, ką aš pasižymėjau „Organic Maps“ žemėlapyje!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Žvilgtelk, kur dabar esu, „Organic Maps“ žemėlapyje!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Labas,&#32;
+
+Šiuo metu esu čia: %1. Spustelėk čia: %2, arba čia: %3, kad pamatytum šią vietą žemėlapyje.&#32;
+&#32;
+Ačiū.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Bendrinti</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>El. paštas</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Nukopijuota į iškarpinę: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Baigta</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>„OpenStreetMap“ duomenys: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ar tikrai norite atsijungti nuo „OpenStreetMap“ paskyros?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trasos</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Ilgis</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Bendrinti mano vietą</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Bendrieji nustatymai</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informacija</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigacija</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Mygtukai „+“ ir „-“ žemėlapyje</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Rodyti žemėlapyje</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Naktinis stilius, kai navigacija vykdoma tamsoje</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nakties veiksena</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Išjungti</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Įjungti</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatinė</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektyvos rodinys</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Trimačiai pastatai</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Trimačiai pastatai yra išjungti energijos taupymo veiksenoje</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Balso instrukcijos</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Sakyti gatvių pavadinimus</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Įjungus šią parinktį, bus įvardijamos gatvės ir išvažiavimai, į kuriuos siūloma sukti.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Balso instrukcijų kalba</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Norėdami atsisiųsti aukštesnės kokybės balsą, atidarykite programą Nustatymai ir eikite į Prieinamumas → VoiceOver → Kalba → Balsas.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Išbandyti balso instrukcijas (kalbos sintezę)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Patikrinkite sistemos kalbos sintezės garsumo nustatymus, jeigu dabar negirdite balso.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nepasiekiama</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatinis mastelis</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Atstumas</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Rodyti žemėlapyje</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Meniu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Svetainė</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Naujienos</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Atsiliepimas</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Įvertinti šią programėlę</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Žinynas</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Dažnai užduodami klausimai</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Paaukoti</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Jau paaukojau</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Priminti vėliau</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Paremti „Organic Maps“</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Paremti projektą</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autorių teisės</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Pranešti apie klaidą</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Sukalibruokite telefono kompasą ir pagerinkite navigaciją, judindami telefoną aštuoniukės judesiu.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Sukalibruokite telefono kompasą ir pagerinkite navigaciją, judindami telefoną aštuoniukės judesiu.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Bakstelėkite ir palaikykite žemėlapį vėl, kad pamatytumėte sąsają</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Naujinti viską</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Atsisakyti visko</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Atsiųsta</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Eilėje</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Netoliese</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Žemėlapiai</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Atsiųsti viską</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Atsiunčiama:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Jeigu norite pašalinti žemėlapį, sustabdykite navigaciją.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Maršrutai gali būti sukurti tik tuomet, kai jie yra vieno regiono žemėlapio ribose.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Atsiųsti žemėlapį</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Bandyti dar kartą</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Šalinti žemėlapį</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Naujinti žemėlapį</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>„Google Play“ vietos nustatymo paslaugos</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Greitai nustatyti apytikslę jūsų buvimo vietą remiantis pasiekiamais „Bluetooth“ įrenginiais, belaidžiais tinklais ir mobiliojo ryšio siųstuvais</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Atsiųsti visus žemėlapius, į kuriuos patenka jūsų maršrutas</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Kad galėtume pasiūlyti maršrutą, turime atsiųsti ir atnaujinti visus žemėlapius nuo jūsų dabartinės vietos iki paskirties taško.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nepakanka laisvos vietos</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Įjunkite vietovės tarnybas</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Įrašyti</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>kurti</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Raudonas</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Geltonas</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Mėlynas</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Žalias</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violetinis</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranžinis</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Rudas</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rožinis</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tamsiai violetinis</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Šviesiai mėlynas</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Žydras</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Turkio spalvos</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Salotinis</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tamsiai oranžinis</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Pilkas</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Mėlynai pilkas</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informacija</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>„Organic Maps“ versija: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Išvaizda</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Šviesi</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tamsi</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Šviesi nuo aušros iki sutemų</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Kita</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Padovanokite nemokamus žemėlapius be skelbimų milijonams vartotojų!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Ištaisyti arba pranešti apie neteisingus duomenis žemėlapyje</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Prisidėti</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Sekite ar susisiekite su mumis:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>El. pašto programa nenustatyta. Sukonfigūruokite ją arba susisiekite su mumis adresu %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Klaida siunčiant laišką</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompaso kalibravimas</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Prieinama</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Rasta</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Naujinti</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Nepavyko</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>pridėti žymę</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Keliaudami siūlomu maršrutu, nepamirškite, kad:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— kelių kokybė, eismo taisyklės ir kelio ženklai visuomet turi prioritetą prieš navigacijos instrukcijas;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— žemėlapis gali būti netikslus, o siūlomas maršrutas ne visada bus optimalus būdas pasiekti tikslą;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— siūlomi maršrutai turi būti suvokiami tik kaip rekomendacijos;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— būkite atsargūs su maršrutais ties šalia sienomis: maršrutai, siūlomi mūsų programėlės, kartais siūlo kirsti valstybių sienas neleistinose vietose.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Būkite budrūs ir saugūs keliuose!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Tikrinti GPS signalą</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nepavyko apskaičiuoti maršruto. Nepavyko nustatyti dabartinių GPS koordinačių.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Patikrinkite GPS signalą. Vietos nustatymo tikslumą pagerintų belaidžio tinklo įgalinimas.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Įjunkite vietovės tarnybas</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Nepavyko nustatyti dabartinių GPS koordinačių. Maršrutui apskaičiuoti, įjunkite vietovės tarnybas.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Nepavyko nustatyti maršruto</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Nepavyko apskaičiuoti maršruto.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Pakoreguokite pradžios tašką arba paskirties vietą.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Keisti pradžios tašką</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Maršruto nepavyko apskaičiuoti. Nepavyko nustatyti pradžios taško.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Pasirinkite pradžios tašką, esantį arčiau kelio.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Keisti paskirties vietą</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Maršruto nepavyko apskaičiuoti. Nepavyko nustatyti paskirties vietos.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Pasirinkite paskirties vietą, esančią arčiau kelio.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nepavyko nustatyti tarpinio taško.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Pakoreguokite tarpinį tašką.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistemos klaida</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Maršruto nepavyko apskaičiuoti dėl programinės klaidos.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Bandykite dar kartą</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ne dabar</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Ar atsiųsti žemėlapį, kad būtų apskaičiuotas geresnis maršrutas, apimantis daugiau nei vieną žemėlapį?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Atsiųskite papildomus žemėlapius, kad būtų apskaičiuotas geresnis maršrutas, išeinantis už šio žemėlapio ribų.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Atsiųsti reikalingus failus</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Prieš planuodami maršrutą, atsiųskite arba atnaujinkite visus žemėlapius, į kuriuos jis patenka.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Atsisiųskite žemėlapį, kad pradėtumėte ieškoti ir kurti maršrutus. Paskui jums nebereikės prisijungimo prie tinklo.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Pasirinkti žemėlapį</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Rodyti</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Nerodyti</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorijos</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Žurnalas</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Deja, rezultatų nerasta.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Atsisiųskite regioną, kuriame ieškote, arba pabandykite įvesti kito netoliese esančio miesto ar kaimo pavadinimą.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Paieškų žurnalas</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Rodyti paskiausias paieškas.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Valyti paieškų žurnalą</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Vikipedija</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Straipsnis iš wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Vikiteka</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Jūsų vieta</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Pradėti</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Maršrutas iš</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Maršrutas į</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigacija galima tik iš jūsų dabartinės vietos.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Ar norite, kad būtų apskaičiuotas maršrutas iš jūsų dabartinės vietos?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Toliau</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Nuo</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Iki</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Pridėti darbo laiką</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Šalinti darbo laiką</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Visą parą (24 valandas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Atsidaro</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Užsidaro</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Pridėti nedarbo laiką</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Darbo laikas</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Sudėtingesnė veiksena</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Paprastoji veiksena</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Nedarbo laikas</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Reikšmių pavyzdžiai</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Taisyti klaidą</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Pasirinkite vietą</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Išsamiai aprašykite problemą, kad „OpenStreetMap“ bendruomenę galėtų ištaisyti klaidą.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Arba atlikite tai patys svetainėje https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Siųsti</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Vieta neegzistuoja</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Uždaryta remontui</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Vieta dubliuojasi</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatiškai atsiųsti žemėlapius</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Kasdien</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24×7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Šiandien uždaryta</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Uždaryta</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Šiandien</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Atsidaro už %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Užsidaro už %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Uždaryta</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Taisyti darbo valandas</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Neturite „OpenStreetMap“ paskyros?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registruotis „OpenStreetMap“</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Prisijungti</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Neprisijungta</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Prisijungti prie „OpenStreetMap“</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Slaptažodis</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Pamiršote slaptažodį?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Atsijungti</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Taisyti vietą</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Pridėti kalbą</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Gatvė</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Namo numeris</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Išsamesnė informacija</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Socialiniai tinklai</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Pastatas</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Pridėti gatvę</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Įveskite gatvės pavadinimą</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Pasirinkite kalbą</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Pasirinkite gatvę</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Virtuvė</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Pasirinkite virtuvę</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>El. paštas arba naudotojo vardas</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Pridėti telefono numerį</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Aukštas</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Aukštas: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Visi jūsų žemėlapio pakeitimai bus pašalinti kartu su žemėlapiu.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Naujinti žemėlapius</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Maršrutui apskaičiuoti reikia atnaujinti visus žemėlapius ir suplanuoti maršrutą iš naujo.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Rasti žemėlapį</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Įsitikinkite, kad jūsų įrenginys yra prijungtas prie interneto.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nepakanka laisvos vietos</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Pašalinkite nereikalingus duomenis</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Prisijungimo klaida.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Patvirtinti pakeitimai</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Vilkite žemėlapį, kad kryžiukas atsidurtų ties vieta, kurioje yra pridedama vieta ar įmonė.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Taisoma</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Pridedama</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Vietos pavadinimas</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Kaip rašoma vietos kalba</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorija</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Išsamus problemos aprašymas</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Kita problema</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Pridėti verslą</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Čia negalima talpinti jokių objektų</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Bendruomenės surinkti „OpenStreetMap“ duomenys %1 dienai. Sužinokite, kaip redaguoti ir atnaujinti žemėlapį, apsilankydami OpenStreetMap.org svetainėje</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) – tai bendruomenės projektas, kuriuo siekiama sukurti laisvą ir atvirą žemėlapį. Tai – pagrindinis „Organic Maps“ žemėlapių duomenų šaltinis, veikiantis panašiu principu, kaip „Vikipedija“. Galite pridėti ar taisyti vietas, o jos tampa prieinamos milijonams naudotojų visame pasaulyje.&#32;
+Prisijunkite prie bendruomenės ir padėkite kurti geresnį žemėlapį visiems!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Susikurkite „OpenStreetMap“ paskyrą arba prisijunkite, kad galėtumėte skelbti savo žemėlapio pakeitimus pasauliui.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 iš %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Atsisiųsti naudojant mobilųjį ryšį?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Tai gali būti itin brangu, naudojantis kai kuriais planais ar tarptinkliniu ryšiu.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Įveskite leistiną pastato numerį</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Aukštų skaičius (daugiausia %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Aukštų skaičius negali viršyti %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Pašto kodas</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Įveskite galiojantį pašto kodą</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Pastaba „OpenStreetMap“ talkininkams (neprivaloma)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Aprašykite žemėlapyje esančias klaidas arba dalykus, kurių negalite redaguoti, naudodamiesi „Organic Maps“</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Jūsų pakeitimai įkeliami į viešą &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;„OpenStreetMap“&lt;/a&gt; duomenų bazę. Prašome nedėti asmeninės ar autorių teisėmis apsaugotos informacijos.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Plačiau apie „OpenStreetMap“</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Jūsų taisymų istorija</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Jūsų žemėlapio duomenų pastabos</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatorius</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatorius: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nerandate tinkamos kategorijos?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>„Organic Maps“ leidžia pridėti tik paprastų kategorijas taškus – jokių miestų, kelių, ežerų, pastatų kontūrų ir pan. šia programėle pridėti negalima. Šių kategorijų objektus pridėkite naudodamiesi &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; svetaine. Žvilgtelėkite į mūsų &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;vadovą&lt;/a&gt;, kuriame rasite išsamias pažingsnines instrukcijas.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Nesate atsiuntę jokių žemėlapių</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Atsiųskite žemėlapius, kad galėtumėte ieškoti vietų ir keliauti neprisijungę prie tinklo.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Dabartinė vieta nežinoma.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>myl./h</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Išsamiau</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Taisyti žymę</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Asmeninės pastabos (tekstas arba HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentaras…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Anuliuoti visus vietinius pakeitimus?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Anuliuoti</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Šalinti pridėtą vietą?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Šalinti</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Ši vieta neegzistuoja</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Nurodykite siūlymo vietą šalinti priežastį</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Įveskite galiojantį telefono numerį</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Įveskite galiojantį saityno adresą</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Įveskite galiojantį el. pašto adresą</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Įveskite galiojantį „Facebook“ saityno adresą, paskyros vardą ar puslapio pavadinimą</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Įveskite galiojantį „Instagram“ paskyros vardą ar saityno adresą</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Įveskite galiojantį „Twitter“ paskyros vardą ar saityno adresą</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Įveskite galiojantį VK paskyros vardą ar saityno adresą</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Įveskite galiojantį LINE ID ar saityno adresą</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Pridėti vietą į „OpenStreetMap“</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Arba galite palikti pastabą „OpenStreetMap“ bendruomenei, kad norimą vietą pridėtų ar patikslintų kažkas kitas.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Pastaba bus nusiųsta į „OpenStreetMap“</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Ar tikrai norite šiuos pakeitimus paviešinti?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Įsitikinkite, kad neįvedėte jokių asmeninių duomenų.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>„OpenStreetMap“ redaktoriai peržiūrės pakeitimus ir su jumis susisieks, jei kiltų klausimų.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stabdyti</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Trasa įrašoma</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Priimti</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Atmesti</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Naudoti mobilųjį internetą išsamesnei informacijai parodyti?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Visada naudoti</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Tik šiandien</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Šiandien nenaudoti</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilusis internetas</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Pranešimams apie žemėlapių naujinius ir pataisų įkėlimui reikalingas mobilusis internetas.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Niekada nenaudoti</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Visada klausti</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Jeigu norite matyti eismo duomenis, reikia atnaujinti žemėlapius.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Padidinti žemėlapio užrašų šrifto dydį</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Atnaujinkite „Organic Maps“</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Eismo duomenys neprieinami</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Įgalinti derinimo žurnalą</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Bendro pobūdžio atsiliepimas</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Balso instrukcijoms naudojame sistemos šnekos sintezatorių. Dauguma „Android“ įrenginių naudoja „Google“ šnekos sintezatorių, kurį galite atsisiųsti ar atnaujinti iš „Google Play“ parduotuvės</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Kai kurioms kalboms gali tekti įdiegti papildomą šnekos sintezatorių ar kalbos paketą iš programėlių parduotuvės („Google Play“, „Galaxy Store“, „AppGallery“, „FDroid“).&#32;
+Atverkite įrenginio nustatymus → Kalbos ir įvestis → Kalba → Teksto į kalbą išvestis.&#32;
+Čia galite tvarkyti šnekos sintezatoriaus nustatymus (pavyzdžiui, atsisiųsti kalbos paketą naudojimui neprisijungus) ar pasirinkti kitą šnekos sintezės modulį.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Jei norite išsamesnės informacijos, žvilgtelėkite į šią instrukciją.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteruoti užrašus lotyniškais rašmenimis</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Išsamesnė informacija</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Pasinaudokite paieška arba bakstelėkite žemėlapyje, kad pridėtumėte maršruto pradžios tašką</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Pasinaudokite paieška arba bakstelėkite žemėlapyje, kad pridėtumėte paskirties tašką</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Tvarkyti maršrutą</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planas</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Šalinti stotelę</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Pridėti stotelę</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Įrašyta</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Prisijunkite prie „OpenStreetMap“, kad galėtumėte automatiškai įkelti visus savo žemėlapio pakeitimus. Išsamesnė informacija – &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;čia&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Prieigos prie saugyklos problema</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Išorinė saugykla yra nepasiekiama. SD kortelė galimai yra pašalinta, pažeista, arba failų sistema joje yra nustatyta tik skaitymui. Patikrinkite SD kortelę arba susisiekite su mumis adresu support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emuliuoti blogą saugyklą</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Įveskite teisingą pavadinimą</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Sąrašai</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Nerodyti visų</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Rodyti visus</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n žymė</numerusform>
+<numerusform>%n žymės</numerusform>
+<numerusform>%n žymių</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Kurti naują sąrašą</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importuoti žymes ir trasas</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nepavyko bendrinti dėl programinės klaidos</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Klaida bendrinant</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Negalima bendrinti tuščio sąrašo</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Pavadinimas negali būti tuščias</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Įveskite sąrašo pavadinimą</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Naujas sąrašas</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Toks pavadinimas jau naudojamas</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Įveskite kitą pavadinimą</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Luktelėkite…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefono numeris</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>„OpenStreetMap“ profilis</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Aptiktas %n failas. Jį (juos) galėsite pamatyti, atlikus konvertavimą.</numerusform>
+<numerusform>Aptikti %n failai. Juos galėsite pamatyti, atlikus konvertavimą.</numerusform>
+<numerusform>Aptikta %n failų. Juos galėsite pamatyti, atlikus konvertavimą.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Atkurti</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trasa</numerusform>
+<numerusform>%n trasos</numerusform>
+<numerusform>%n trasų</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatumas</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privatumo politika</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Naudojimo sąlygos</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Eismas</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Žygiavimas</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Kelionės dviračiu</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Žemėlapio stiliai ir sluoksniai</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Sąrašas tuščias</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Jeigu norite pridėti žymę, bakstelėkite vietą žemėlapyje, o tada – žvaigždutės piktogramą</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Keisti visų žymų spalvą</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Keisti visų trasų spalvą</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…daugiau</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Eksportuoti KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Eksportuoti GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Eksportuoti GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Šalinti sąrašą</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Greičio matuokliai</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Vietos aprašymas</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Žemėlapių atsiuntimas</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Įspėti jei viršijamas greitis</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Visada įspėti</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Niekada neįspėti</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energijos taupymo veiksena</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Naudojamos elektros energijos tausojimas, aukojant dalį funkcionalumo.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Niekada</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Esant žemai įkrovai</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Visada</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Žymių pavadinimai žemėlapyje</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Jei turite per daug žymių, jų vaizdavimas žemėlapyje gali lėtinti programėlės veikimą.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Rodyti dešinėje</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Rodyti apačioje</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Įjunkite šią parinktį, jei norite kurį laiką rašyti derinimo žurnalą. Pasinaudodami mygtuku „Pranešti apie klaidą“, esančiu žinyno dialogo lange, galėsite pranešti apie problemą, pridėdami sukauptą žurnalą. Žurnaluose gali būti vietos duomenų.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Maršruto apskaičiavimo parinktys</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vengti mokamų kelių</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vengti negrįstų kelių</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vengti keltų</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vengti greitkelių</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nepavyko apskaičiuoti maršruto</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Deja, nepavyko rasti maršruto. Tikėtina, jog taip yra dėl jūsų pasirinktų parinkčių arba trūkstamų „OpenStreetMap“ duomenų. Pakeiskite parinktis ir bandykite dar kartą.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Nurodykite vengtinus kelius</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Yra įjungtų maršruto parinkčių</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Mokamas kelias</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Negrįstas kelias</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Persikėlimas keltu</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Taip</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Taip</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Talpa: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Tinklas: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Jūs pasiekėte kelionės tikslą!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Gerai</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Rikiuoti…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Rikiuoti žymes</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Numatytąja tvarka</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Pagal tipą</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Pagal atstumą</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Pagal datą</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Pagal pavadinimą</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Pastaroji savaitė</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Pastarasis mėnuo</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Virš mėnesio senumo</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Virš metų senumo</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Netoliese</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Kitkas</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Maršruto planavimas nepavyko</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Atvykimas %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Prieš planuodami maršrutą, atsiųskite ir atnaujinkite visus žemėlapius, į kuriuos jis patenka.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Pakeitėte pasaulio žemėlapį! Nelaikykite šio pokyčio tik sau – papasakokite apie jį savo draugams ir taisykite žemėlapį kartu.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Bendrinti su draugais</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Dabar uždaryta</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Atsidaro rytoj %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Atsidaro %1 %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Atsidaro %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Užsidaro %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Pridėti darbo valandas</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Slaptažodis (bent 8 simboliai)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Netinkamas naudotojo vardas arba slaptažodis.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM paskyra</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Paskutinis įkėlimas</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Ačiū</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Vietos pavadinimas</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefonas</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Atkreipkite dėmesį</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Atsiuntimo klaida</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Pasirinkite kategoriją</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populiarios</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Visos kategorijos</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Pridėkite naujų vietų į žemėlapį ir redaguokite esamas tiesiai iš programėlės.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Keisti vietą</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Žemėlapiams atsiųsti reikia daugiau laisvos vietos. Pašalinkite nereikalingus duomenis.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Aš patobulinau „Organic Maps“ žemėlapius</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Išsamus komentaras</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Jūsų pasiūlyti žemėlapio pakeitimai bus išsiųsti „OpenStreetMap“ bendruomenei. Paminėkite papildomą informaciją, kurios negalėjote pataisyti naudodamiesi „Organic Maps“.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Įvyko klaida ieškant jūsų vietos. Įsitikinkite,kad jūsų įrenginys veikia tinkamai ir bandykite iš naujo.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Vietovės tarnybos yra išjungtos</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Suteikite prieigą prie vietos nustatymo duomenų įrenginio nustatymuose</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Atverkite nustatymus</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Bakstelėkite „Vieta“</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Pasirinkite „Kol naudojama programa“</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Pasirinkite „Privatumas ir sauga“</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Pasirinkite „Vietos nustatymo paslaugos“</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Įjunkite vietos nustatymo paslaugas</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Arba toliau naudokitės „Organic Maps“ be vietos nustatymo</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Užsakyti</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Skambinti</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Žymės pavadinimas</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Naikinti žymę</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Jūsų pastaba bus nusiųsta į „OpenStreetMap“</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…daugiau</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Naujinti</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Išjungti paskiausiai keliautų trasų įrašymą?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Išjungti</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Žvilgtelk</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>„Organic Maps“ naudota jūsų vietos duomenis fone, kad įrašytų jūsų paskiausiai keliautą trasą.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Bendrieji nustatymai</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Jeigu norite matyti eismo duomenis, reikia atnaujinti programėlę.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Žurnalo failo dydis: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Vilkite čia, kad pašalintumėte</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Pakeisti Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Pradėti iš</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Prisijunkite prie „OpenStreetMap“, kad galėtumėte automatiškai įkelti visus savo žemėlapio pakeitimus. Išsamesnė informacija –</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>čia</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Slėpti ekraną</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 iš %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Atsiunčiama %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Taikoma %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Pavadinimas per ilgas</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Aptikti nauji failai</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertuoti</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Klaida</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Kai kurie failai nebuvo konvertuoti.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Įvyko klaida</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populiarūs</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Nerodyti žemėlapyje</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Įvyko klaida įkeliant gaires, bandykite iš naujo</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Dešinėje</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Apačioje</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Pirmyn</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Tikslas</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centruoti</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Paieškos rezultatai</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Tada</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Norite perskaičiuoti maršrutą?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Klaviatūra rašyti vairuojant neleidžiama</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Nepavyko apskaičiuoti maršruto iš jūsų dabartinės vietos</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nepavyko apskaičiuoti maršruto iki jūsų paskirties taško. Pasirinkite kitą tašką</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nėra GPS signalo. Pereikite į atviresnę vietą</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nepavyko apskaičiuoti maršruto. Nurodykite kitus maršruto taškus</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Maršrutui apskaičiuoti atsiųskite trūkstamus žemėlapius į šį įrenginį</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Įvyko klaida. Paleiskite programėlę iš naujo</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Maršrutas bus perskaičiuotas nuo jūsų dabartinės vietos</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Maršrutas bus konvertuotas automobilinį</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Rodomos ne visos žymės</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Perjunkite į telefono ekraną, kad pamatytumėte visas žymes</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Greičio matuokliai</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Greičio įspėjimai</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Atsiųskite žemėlapius, naudodamiesi programėle savo telefone</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 išvažiavimas</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Rikiuoti numatytąja tvarka</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Rikiuoti pagal tipą</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Rikiuoti pagal atstumą</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Rikiuoti pagal datą</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Rikiuoti pagal pavadinimą</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Maistas</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Lankytinos vietos</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muziejai</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parkai</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Plaukimas</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Kalnai</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Gyvūnai</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Viešbučiai</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Pastatai</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Pinigai</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Parduotuvės</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkingas</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Degalinės</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Ieškoti sąraše</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religinės vietos</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Pasirinkite sąrašą</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro navigacija šiame regione dar negalima</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metro maršrutas nerastas</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Pasirinkite pradžios ar pabaigos tašką, esančius arčiau metro stotelės</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Reljefas</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Atsisiųskite vietovės žemėlapį, jei norite aktyvinti ir naudoti reljefo sluoksnį</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Reljefo sluoksnis šiai vietovei dar neprieinamas</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Pakilimas</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Nusileidimas</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. aukštis</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. aukštis</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Sudėtingumas</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Atstumas:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Laikas:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Priartinkite, jei norite patyrinėti izolinijas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Atsiunčiama</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Atsisiųsti bendrą pasaulio žemėlapį</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nepavyko sukurti aplanko ir perkelti failus į įrenginio vidinę atmintį ar SD kortelę</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disko klaida</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Ryšio klaida</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Atjungti USB kabelį</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Laikyti ekraną įjungtą</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Įgalinus šią parinktį, ekranas visada liks įjungtas, kol rodomas žemėlapis.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Rodyti užrakto ekrane</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Įgalinę šią parinktį, žemėlapį matysite net tuomet, kai įrenginio ekranas užrakinamas.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Žemėlapio kalba</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Žemėlapio duomenys iš „OpenStreetMap“</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/lt/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/lt/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1 %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Dėkojame, kad naudojatės mūsų bendruomenės sukurtais žemėlapiais!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Su jūsų parama ir palaikymu mes galime sukurti geriausius žemėlapius pasaulyje!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Patinka šį programėlė? Paremkite, paaukodami jos vystymui! Dar ne? Papasakokite mums, kodėl, ir mes pasistengsime tai pataisyti!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Jeigu turite pažįstamą programuotoją, galite jo(s) paprašyti realizuoti funkciją, kurios jums reikia.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Bakstelėkite bet kurį žemėlapio tašką norimam objektui pasirinkti. Bakstelėkite ir palaikykite, kad paslėptumėte ar vėl pamatytumėte programėlės sąsają.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Ar žinote, jog galite pasirinkti savo dabartinę vietą žemėlapyje?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Galite padėti išversti šią programėlę į savo kalbą.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Šią programėlę vysto keletas entuziastų ir suburta bendruomenė.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Galite pataisyti ar papildyti žemėlapio duomenis.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Mūsų pagrindinis tikslas – sukurti spartų, privatų ir paprastą naudotis žemėlapį, kuris patiktų visiems.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Dabar naudojatės „Organic Maps“ telefono ekrane</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Dabar naudojatės „Organic Maps“ automobilio ekrane</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Prisijungėte prie „Android Auto“</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Tęsti telefone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Į automobilio ekraną</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>„Organic Maps“ programėlei reikia prieigos prie vietos . Kai bus saugu, patikrinkite pranešimą savo telefone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Šiai programėlei reikia jūsų leidimo</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Kad „Android Auto“ sistemoje „Organic Maps“ veiktų efektyviai, reikia leidimo nustatyti buvimo vietą</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Suteikti leidimą</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Laukas</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Saityno naršyklė nepasiekiama</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Garsumas</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksportuoti visas žymes ir trasas</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Šnekos sintezės sistemos nustatymai</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Šnekos sintezės nustatymų modulis nerastas, ar esate tikri, kad jūsų įrenginys ją palaiko?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Pravažiavimas</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Išvalyti paiešką</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Pritraukti vaizdą</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Atitraukti vaizdą</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Nuoroda į meniu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Peržiūrėti meniu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Atverti kitoje programėlėje</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Savitarna</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Pasirinkite</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sėdimosios vietos lauke</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Tikslesnei navigacijai pasiekti, rekomenduojame išjungti energijos taupymo veikseną telefono akumuliatoriaus nustatymuose.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Įrašyti trasą</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stabdyti trasos įrašymą</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Trasos įrašymas</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stabdyti neįrašant</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Tęsti įrašymą</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Įrašyti į žymių ir trasų sąrašą?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Trasa tuščia – nėra ką įrašyti</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nepavyko parodyti aplanko pasirinkimo dialogo, nes jūsų įrenginyje neįdiegta tinkama programa. Įdiekite failų tvarkyklės programą ir bandykite dar kartą.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Pasirinkite spalvą</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Redaguoti trasą</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Neįdiegta programėlė, galinti atverti vietą</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automatinė naviguojant</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Pagal sistemą</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Dalintis trasa</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Šalinti %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Sudėtingumo lygis</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Lengvas</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Normalus</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Sunkus</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Naujinama</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Naujinti atsisiųstus žemėlapius</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Žemėlapių atnaujinimas suteikia naujausią informaciją apie objektus</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Naujinti (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Atnaujinsiu vėliau</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Šalinti trasą</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ar tikrai norite pašalinti šią trasą?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Trasos pavadinimas</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Perkelti</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trasa</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Keisti spalvą</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Žemėlapis</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Ar norite išsiųsti pranešimą apie klaidą programos kūrėjams?
+Tokių pranešimų mes tikimės iš savo naudotojų, nes &quot;Organic Maps&quot; nerenka jokios informacijos apie klaidas automatiškai. Iš anksto dėkojame, kad prisidedate prie „Organic Maps“ tobulinimo!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>„iCloud“ sinchronizavimo įjungimas</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>„iCloud“ sinchronizavimas yra šiuo metu vystoma eksperimentinė funkcija. Nepamirškite pasidaryti atsarginę visų savo žymių ir trasų kopiją.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>„iCloud“ yra išjungta</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Jei norite naudotis šia funkcija, įjunkite „iCloud“ įrenginio nustatymuose.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Įjungti</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Padaryti atsarginę kopiją</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>„iCloud“ sinchronizavimo sutrikimas</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Klaida: Nepavyko sinchronizuoti dėl ryšio klaidos</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Klaida: Nepavyko sinchronizuoti dėl viršytos „iCloud“ kvotos</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Klaida: „iCloud“ nepasiekiama</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Neseniai pašalinti sąrašai</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Išvalyti</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Šalinti viską</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Atkurti</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Atkurti viską</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Prisidėti prie OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Pridėti vietą</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Atnaujinti žemėlapį, kad prisidėtumėte</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Prieš prisidėdami prie OpenStreetMap duomenų, turite atnaujinti %1 žemėlapį į naujausią versiją</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mano vieta</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mano vietos</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Vidinė privati saugykla</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Vidinė bendroji saugykla</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD kortelė</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Išorinė bendroji saugykla</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Belaidis ryšys</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Pašto kodas</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Žemėlapio taškas</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>myl.</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>pėd.</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Prieš parodant kelius, reikia atnaujinti žemėlapius.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Išėjimas</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Įėjimas</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metro žemėlapis neprieinamas</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Jūs</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Violetiniai atsisiųsti regionai</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Maršrutas</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Vietos aptikimas foninėje veiksenoje yra būtinas, norint, kad programėlė veiktų visapusiškai. Jis naudojamas navigacijai ir naujų trasų įrašymui.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Vietos aptikimas yra būtinas navigacijai ir naujų trasų įrašymui.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Prisijungimas su slaptažodžiu</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Prisijungimas naudojant naršyklę</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Neseniai naudotas</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Žymų spalva pakeista</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Trasų spalva pakeista</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektras</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Slankmačiai</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RAUDONA</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ŽALIA</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB šešioliktainė spalva #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Tinklelis</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/lv/omim.ts
+++ b/qt/translations/lv/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="lv">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Atpakaļ</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Atcelt</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Dzēst</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Lejupielādēt kartes</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Lejupielāde neizdevās. Uzklikšķiniet, lai mēģinātu vēlreiz.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Lejupielādē…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Jūdzes</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Vēlāk</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Meklēt</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Meklēt kartē</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Šobrīd ierīcē visi atrašanās vietas pakalpojumi vai to nodrošinošās programmas ir izslēgtas. Ieslēdziet tās iestatījumos.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ierobežota precizitāte</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Lai nodrošinātu pareizu navigāciju, ieslēdziet iestatījumos &quot;Precīzo&quot; atrašanās vietas noteikšanu.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Rādīt kartē</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Lejupielāde neizdevās</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Mēģināt vēlreiz</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Par „Organic Maps“</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Bezmaksas, pieejama visiem un veidota ar mīlestību</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Nesatur reklāmas, izsekošanu un nevāc datus</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Neizlādē bateriju, darbojas bez interneta pieslēguma</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Ātra, minimālistiska un kopienas izstrādāta</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Atvērtā pirmkoda programma, ko veidojuši entuziasti un brīvprātīgie.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Atrašanās vietas iestatījumi</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Aizvērt</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Lietotnei nepieciešams „OpenGL“ aparatūras paātrinājums, bet diemžēl Jūsu ierīce to neatbalsta.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Lejupielādēt</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Lai lietotu „Organic Maps“, atvienojiet USB kabeli vai ievietojiet atmiņas karti.</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Lietotnes izmantošanai atbrīvojiet vietu ierīces krātuvē</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Pirms sākt izmantot lietotni lejupielādējiet pasaules pārskata karti.
+Tā ierīces krātuvē aizņems %1 vietas.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Iet uz karti</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Lejupielādē „%1“. Tagad varat
+iet uz karti.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Vai lejupielādēt „%1“?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Vai atjaunināt „%1“?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Apturēt</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Turpināt</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>„%1“ lejupielāde neizdevās</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Pievienot jaunu sarakstu</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Grāmatzīmju saraksta nosaukums</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Grāmatzīmes</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Grāmatzīmes un pēdojumi</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nosaukums</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adrese</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Saraksts</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Iestatījumi</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Kartes saglabāšanas vieta</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Norādiet mapi, kurā lejupielādēt kartes.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Lejupielādētās kartes</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 brīva vieta no %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Pārvietot kartes?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Kļūda, pārvietojot kartes datnes</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Tas var aizņemt vairākas minūtes.
+Uzgaidiet…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Mērvienības</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Izvēlieties starp jūdzēm un kilometriem</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Atsaukt lejupielādi</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Atstājiet atsauksmi</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Jā</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Lejupielādēt karti</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Grāmatzīmju saraksti</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Kur paēst</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Pārtikas preces</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transports</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Degvielas uzpildes stacija</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Autostāvvieta</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Iepirkšanās</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Lietotas preces</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Viesnīca</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Apskates objekti</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Izklaide</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomāts</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Naktsdzīve</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Atpūta ģimenei</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Aptieka</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Slimnīca</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Tualete</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pasts</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policija</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Pārstrāde</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Ūdens</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Treileru laukumi</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Piezīmes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps ar jums tika dalītas grāmatzīmes</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Sveiki!
+
+Pielikumā ir grāmatzīmes. Lūdzu, atveriet tās „Organic Maps“ lietotnē. Ja Jums tā nav instalēta, instalējiet to te: https://omaps.app/get?kmz
+
+Baudiet ceļošanu ar „Oranic Maps“!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Ielādē grāmatzīmes</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Grāmatzīmes ir ielādētas! Tās varat atrast kartē un grāmatzīmju pārvaldīšanas ekrānā.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Grāmatzīmes ielādēt neizdevās. Iespējams, datne ir bojāta.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Lietotne neatpazīst datnes tipu:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Neizdevās atvērt datni %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Labot</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Jūsu atrašanās vieta vēl nav noteikta</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Atvainojamies, bet kartes saglabāšanas iestatījumi šobrīd ir izslēgti.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Notiek kartes lejupielāde.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Apskatiet manu atrašanās vietu „Organic Maps“ lietotnē! %1 vai %2 Vai Jums nav nesaistes kartes? Lejupielādējiet to: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hei, apskatiet manu grāmatzīmi Organic Maps kartē!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hei, apskati manu pašreizējo atrašanās vietu kartē „Organic Maps”!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hei,&#32;
+&#32;
+Šobrīd atrodos te: %1. Spied uz šīs %2 vai šīs %3 saites, lai kartē redzētu manu atrašanās vietu.&#32;
+&#32;
+Paldies.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Kopīgot</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-pasts</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Nokopēts starpliktuvē: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Pabeigts</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>„OpenStreetMap“ dati: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Vai tiešām vēlaties izrakstīties no „OpenStreetMap“ konta?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Pēdojumi</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Garums</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Kopīgot manu atrašanās vietu</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Vispārējie iestatījumi</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informācija</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigācija</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Pogas &quot;+&quot; un &quot;-&quot; kartē</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Rādīt kartē</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nakts stils, ja navigācija notiek tumsā</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Tumšais motīvs</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Izslēgts</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Ieslēgts</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automātisks</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektīvas skats</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D ēkas</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Energotaupības režīmā 3D ēkas ir izslēgtas</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Balss instrukcijas</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Izrunāt ielu nosaukumus</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Kad ieslēgts, ielas vai ceļa nobrauktuves nosaukumu skaļi izrunās.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Balss valoda</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Lai lejupielādētu augstākas kvalitātes balsi, atveriet lietotni Iestatījumi un dodieties uz Pieejamība → VoiceOver → Runa → Balss.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Pārbaudīt balss norādes (TTS, teksta pārvēršana runā)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Ja nedzirdat balsi, pārbaudiet skaļumu vai teksta pārvēršanas runā iestatījumus.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nav pieejama</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automātisks mērogs</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Attālums</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Rādīt kartē</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Izvēlne</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Tīmekļa vietne</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Jaunumi</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Atsauksmes</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Novērtējiet lietotni</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Palīdzība</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Biežāk uzdotie jautājumi</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Ziedot</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Jau esmu ziedojis/usi</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Atgādināt vēlāk</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Atbalstīt Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Atbalstiet projektu</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autortiesības</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Ziņot par kļūdu</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Uzlabojiet bultiņas virzienu, pārvietojot tālruni astoņniekā, kas kalibrēs kompasu.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Pārvietojot tālruni astoņniekā, lai kalibrētu kompasu un labotu bultas virzienu kartē.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Vēlreiz piespiediet un paturiet uz kartes, lai redzētu saskarni</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Atjaunināt visus</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Atcelt visus</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Lejupielādētās</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Rindota</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Man tuvumā</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kartes</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Lejupielādēt visus</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Lejupielādē:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Lai dzēstu karti, apturiet navigāciju.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Maršrutus var izveidot, ja atrodas vienas reģiona kartes robežās.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Lejupielādēt karti</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Mēģināt vēlreiz</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Dzēst karti</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Atjaunināt karti</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>„Google Play“ vietas noteikšanas pakalpojumi</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Ātri nosakiet atrašanās vietu, izmantojot „Bluetooth“, „WiFi“ vai mobilo tīklu</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Lejupielādēt visas maršruta kartes</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Lai izveidotu maršrutu, lejupielādējiet un atjauniniet visas kartes no jūsu atrašanās vietas līdz galamērķim.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Trūkst vietas</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Ieslēdziet ierīces atrašanās vietas noteikšanas pakalpojumus</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Saglabāt</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>izveidot</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Sarkana</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Dzeltena</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Zila</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zaļa</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violeta</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranža</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brūna</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rozā</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tumši violeta</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Gaiši zila</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Ciāna</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Tumši ciāna</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Dzeltenzaļa</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tumši oranža</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Pelēka</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Zilpelēka</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informācija</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>„Organic Maps“ versija: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Izskats</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Gaišs</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tumšs</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Gaišs no rītausmas līdz krēslai</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Cita</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Dāviniet bezmaksas kartes bez reklāmām miljoniem lietotāju!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Ziņojiet vai labojiet kļūdainus kartes datus</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Brīvprātīgi palīdzēt</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Sekojiet un sazinieties ar mums:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-pasta klients nav sagatavots darbam. Konfigurējiet to vai sazinieties ar mums: %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Kļūda, nosūtot vēstuli</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompasa kalibrēšana</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Pieejamas</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Atrasts</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Atjaunināt</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Neizdevās</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>grāmatzīme</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Sekojot maršrutam, ievērojiet:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Apstākļiem uz ceļa, ceļu satiksmes noteikumiem un ceļazīmēm vienmēr ir priekšroka pār navigācijas ieteikumiem;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Karte var būt kļūdaina, kā arī ieteiktais maršruts ne vienmēr būs optimālākais galamērķa sasniegšanai;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Jāsaprot, ka ieteiktie maršruti ir tikai ieteikumi;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Esiet uzmanīgi ar maršrutiem pie valsts robežām: mūsu lietotnes ģenerētie maršruti reizēm var šķērsot valsts robežas neatļautās vietās.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Uz ceļa esiet modri un uzmanīgi!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Pārbaudīt GPS signālu</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Neizdevās izveidot maršrutu. Neizdevās noteikt pašreizējās GPS koordinātes.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Pārbaudiet GPS signālu. „Wi-Fi“ ieslēgšana uzlabos atrašanās vietas precizitāti.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Ieslēgt vietas noteikšanas servisus</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Neizdodas noteikt pašreizējās GPS koordinātes. Ieslēdziet atrašanās vietas servisus, lai aprēķināt maršrutu.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Neizdevās noteikt maršrutu</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Neizdevās izveidot maršrutu.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Precizējiet savu sākuma punktu vai galamērķi.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Precizēt sākumpunktu</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Maršruts nav izveidots. Neizdodas noteikt sākuma punktu.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Atlasiet sākuma punktu tuvāk pie ceļa.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Precizēt galamērķi</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Maršruts nav izveidots. Neizdodas noteikt galamērķi.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Atlasiet galamērķa punktu pēc iespējas tuvāk ceļam.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Neizdevās noteikt starppunktu.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Labojiet starppunktu.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistēmas kļūda</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Kļūdas dēļ neizdevās izveidot maršrutu.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Mēģiniet vēlreiz</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ne tagad</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Vai vēlaties lejupielādēt karti un izveidot piemērotāku maršrutu, kas ietver vairāk par vienu karti?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Lejupielādējiet papildu kartes, lai izveidotu labāku maršrutu, kas šķērso šīs kartes robežu.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Lejupielādēt nepieciešamās datnes</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Lejupielādēt un atjaunināt visas kartes, kas varētu būt plānotajā maršrutā.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Lejupielādējiet karti, lai sāktu meklēt un veidot maršrutus. Pēc tam tīkla pieslēgumu vairs nevajadzēs.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Atlasīt karti</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Rādīt</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Slēpt</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorijas</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Vēsture</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Nekas nav atrasts.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Lejupielādējiet reģionu, kurā meklēt, vai mēģiniet pievienot tuvumā esošas apdzīvotas vietas nosaukumu.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Meklēšanas vēsture</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Apskatiet meklēšanas vēsturi.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Notīrīt vēsturi</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Vikipēdija</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Raksts no wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Vikikrātuve</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Jūsu atrašanās vieta</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Sākt</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Doties iz</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Doties turp</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigācija ir pieejama tikai no jūsu pašreizējās atrašanās vietas.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Vai vēlaties plānot maršrutu no savas pašreizējās atrašanās vietas?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Tālāk</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>No</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Līdz</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Pievienot grafiku</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Dzēst grafiku</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Visu dienu (24 stundas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Atvērts</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Slēgts</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Pievienot  laiku, kad nestrādā</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Darba laiks</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Paplašinātais režīms</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Parastais režīms</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Laiks, kad slēgts</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Piemēra vērtības</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Labot kļūdu</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Izvēlieties atrašanās vietu</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Sīkāk aprakstiet problēmu, lai „OpenStreetMap“ kopiena to varētu novērst.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Vai arī to izlabo vietnē https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Sūtīt</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problēma</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Vieta nepastāv</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Aizvērts uz remonta laiku</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Vieta dublējas</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automātiska karšu lejupielāde</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Ik dienu</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Šodien slēgts</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Slēgts</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Šodien</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Atveras pēc %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Slēgts pēc %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Slēgts</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Labot darba laiku</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Vai jums nav „OpenStreetMap“ konta?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Reģistrējieties „OpenStreetMap“</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Ierakstīties</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Neierakstījāties</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Ierakstīties OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Parole</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Vai aizmirsāt paroli?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Izrakstīties</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Labot vietu</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Pievienot valodu</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Iela</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Ēkas numurs</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Vairāk</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociālie tīkli</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Ēka</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Pievienot ielu</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Ierakstiet ielas nosaukumu</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Izvēlieties valodu</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Izvēlieties ielu</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Virtuve</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Atlasiet virtuvi</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-pasts vai lietotājvārds</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Pievienot tālruni</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Stāvs</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Stāvi virs zemes: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Kopā ar karti dzēsīsies visas jūsu veiktās kartes izmaiņas.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Atjaunināt kartes</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Lai izveidotu maršrutu, atjauniniet visas kartes un plānojiet maršrutu no jauna.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Atrast karti</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Pārliecinieties, ka ierīce ir savienota ar internetu.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Trūkst vietas</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Dzēsiet liekos datus</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Ierakstīšanās kļūda.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Apstiprinātas izmaiņas</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Velciet karti, lai novietotu krustiņu objekta vai iestādes atrašanās vietā.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Vietas labošana</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Pievienošana</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Vietas nosaukums</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Pieraksts vietējā valodā</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorija</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Plašāks problēmas apraksts</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Cita problēma</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Pievienot iestādi</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Šeit objekti nevar atrasties</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Kopienas veidotie „OpenStreetMap“ dati, %1. Uzziniet vairāk par to, kā piedalīties kartes rediģēšanā un uzlabošanā vietnē „OpenStreetMap.org“.</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) ir kopienas projekts, kura mērķis ir izveidot atvērtajos datos balstītu karti, kura ir pieejama bez maksas. Tas ir Organic Maps galvenais karšu datu avots un darbojas līdzīgi kā Vikipēdija. Jūs varat pievienot vai rediģēt vietas, un tās kļūst pieejamas miljoniem lietotāju visā pasaulē.
+Pievienojieties kopienai, lai palīdzētu izveidot labāku karti visiem!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Izveidojiet OpenStreetMap kontu vai piesakieties, lai publicētu savas kartes rediģējumus visā pasaulē.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 no %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Vai lejupielādēt arī mobilajā tīklā?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Ja lietojat ierobežotus datus vai viesabonēšanu, tas var izmaksāt dārgi.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Ierakstiet derīgu ēkas numuru</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Stāvu skaits (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Stāvu skaits nedrīkst pārsniegt %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Pasta indekss</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Ierakstiet pasta indeksu</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Piezīme OpenStreetMap brīvprātigajiem (nav obligāts)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Aprakstiet kļūdas kartē vai lietas, ko nevar rediģēt, izmantojot Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Jūsu labojumi tiek augšupielādēti sabiedriskajā &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; datubāzē. Lūdzu, nepievienojiet personisku vai ar autortiesībām aizsargātu informāciju.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Vairāk par „OpenStreetMap“</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Tava kartes izmaiņu vēsture</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Tavas kartes datu piezīmes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Saimniekotājs</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operators: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Vai neatrodat atbilstošu kategoriju?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>„Organic Maps“ ļauj pievienot tikai vienkāršu punktu kategorijas, proti, nevarat pievienot pilsētas, ceļus, ezerus, ēku aprises u.tml. Šādas kategorijas lūdzam pievienot tiešā veidā &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Lai uzzinātu, kā to izdarīt, sekojiet norādēm &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;rokasgrāmatā&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Ierīcē nav lejupielādētu karšu</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Lai darbotos nesaistes navigācija un meklēšana, lejupielādējiet kartes.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Pašreizējā vieta nav zināma.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>st.</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min.</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Vairāk</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Grāmatzīmes labošana</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personīgi pieraksti (teksts vai HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentārs…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Vai izmest visas lokāli saglabātās izmaiņas?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Noraidīt</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Vai dzēst pievienoto vietu?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Dzēst</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Vieta nepastāv</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Norādiet šīs vietas dzēšanas iemeslu</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Ierakstiet derīgu tālruņa numuru</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Ierakstiet derīgu tīmekļa vietnes adresi</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Ierakstiet e-pasta adresi</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Ierakstiet „Facebook“ lapas adresi, kontu vai mājaslapas nosaukumu</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Ierakstiet „Instagram“ vietnes adresi vai konta nosaukumu</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Ierakstiet „Twitter“ vietnes adresi vai lietotājvārdu</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Ierakstiet VK vietnes adresi vai konta nosaukumu</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Ierakstiet LINE vietnes adresi vai LINE ID</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Pievienot vietu „OpenStreetMap“</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Vai arī atstājiet piezīmi OpenStreetMap kopienai, lai kāds cits varētu pievienot vai labot vietu šeit.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Piezīme tiks nosūtīta uz OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Vai vēlaties to nosūtīt visiem lietotājiem?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Pārliecinieties, ka neievadījāt nekādus privātus vai personīgus datus.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>„OpenStreetMap“ redaktori pārskatīs veiktās izmaiņas un jautājumu gadījumā ar jums sazināsies.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Apturēt</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Pēdojums tiek ierakstīts</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Pieņemt</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Noraidīt</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Izmantot mobilos datus, lai parādītu plašāku informāciju?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Izmantot vienmēr</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Tikai šodien</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Šodien neizmantot</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilie dati</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Kartes atjauninājumu paziņojumiem un rediģējumu augšupielādēšanai ir nepieciešami mobilie dati.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nekad neizmantot</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Jautāt vienmēr</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Lai parādītu satiksmes datus, kartes ir jāatjaunina.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Palielināt fonta lielumu kartē</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Atjauniniet „Organic Maps“</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Satiksmes dati nav pieejami</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Ieslēgt žurnalēšanu</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Vispārīgas atsauksmes</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Balss norādēm lietotne izmanto teksta pārveides runā sistēmu (TTS). Daudzas „Android“ ierīces izmanto „Google TTS“, ko varat lejupielādēt un atjaunināt „Google Play“ veikalā</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Dažām valodām nepieciešams instalēt runas sintezatoru vai papildu valodas paku, kas parasti atrodama lietotņu veikalā („Google Play“, „Galaxy Store“, „App Gallery“, „FDroid“).
+Atveriet ierīces iestatījumus → Valoda un ievade → Runa → Teksta pārveide runā.
+Te varat pārvaldīt runas sintēzes iestatījumus (piemēram, lejupielādēt valodas paku lietošanai nesaistē, kā arī varat nomainīt dzini teksta pārvēršanai runā.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Vairāk informācijas atradīsiet šajā pamācībā</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterācija uz latīņu alfabētu</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Uzzināt vairāk</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Lietojiet meklēšanu vai pieskarieties kartei, lai pievienotu galamērķi</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Lietojiet meklēšanu vai pieskarieties kartei, lai pievienotu sākuma punktu</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Pārvaldīt maršrutu</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plānot</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Noņemt starppunktu</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Pievienot starppunktu</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saglabāts</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Ierakstieties „OpenStreetMap“, lai automātiski augšupielādētu visus kartes rediģējumus. Uzziniet vairāk &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;te&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Krātuves pieejas problēma</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ārējā krātuve nav pieejama. Iespējams, ir izņemta vai bojāta SD karte, vai arī datņu sistēma ir tikai lasāma. Pārbaudiet savu SD karti vai sazinieties ar mums, rakstot uz support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Simulēt bojātu krātuvi</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Ierakstiet pareizu nosaukumu</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Saraksti</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Slēpt visus</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Rādīt visus</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n grāmatzīme</numerusform>
+<numerusform>%n grāmatzīmes</numerusform>
+<numerusform>%n grāmatzīmju</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Izveidot jaunu sarakstu</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importēt grāmatzīmes un pēdojumus</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Programmas kļūdas dēļ kopīgošana neizdevās</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Kopīgošanas kļūda</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Nav iespējams kopīgot tukšu sarakstu</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Nosaukums nevar būt tukšs</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Ierakstiet saraksta nosaukumu</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Jauns saraksts</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Šāds nosaukums jau ir aizņemts</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Izvēlieties citu nosaukumu</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Uzgaidiet…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Tālruņa numurs</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>„OpenStreetMap“ profils</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Lietotne atrada %n jaunu datni. Varat to apskatīt pēc konvertācijas.</numerusform>
+<numerusform>Lietotne atrada %n jaunas datnes. Varat tās apskatīt pēc konvertācijas.</numerusform>
+<numerusform>Lietotne atrada %n jaunu datņu. Varat tās apskatīt pēc konvertācijas.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Atjaunot</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n pēdojums</numerusform>
+<numerusform>%n pēdojumi</numerusform>
+<numerusform>%n pēdojumu</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privātums</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privātuma politika</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Lietošanas noteikumi</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Satiksme</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Pārgājieni</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Riteņbraukšana</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kartes stili un slāņi</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Saraksts ir tukšs</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Lai pievienotu grāmatzīmi, sākumā spiediet uz vietas kartē, bet tad uz zvaigznītes ikonas</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Mainīt visu grāmatzīmju krāsu</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Mainīt visu maršrutu krāsu</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…vairāk</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Izgūt KMZ formātā</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Izgūt GPX formātā</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Izgūt GeoJSON formātā</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Dzēst sarakstu</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Fotoradari</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Vietas apraksts</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Karšu lejupielādētājs</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Brīdināt par ātruma pārsniegšanu</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Brīdināt vienmēr</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nekad nebrīdināt</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energotaupības režīms</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Mēģināt samazināt enerģijas patēriņu, izslēdzot atsevišķas funkcijas.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nekad</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Kad ir zems uzlādes līmenis</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Vienmēr</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Grāmatzīmju nosaukumi kartē</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ja ir pārāk daudz grāmatzīmju, to nosaukumu attēlošana kartē var palēnināt programmas darbību.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Rādīt pa labi</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Rādīt apakšā</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Uz laiku ieslēdziet šo opciju, lai reģistrētu un manuāli nosūtītu sīkākus žurnālus problēmu diagnostikai, izmantojot „Ziņot par kļūdu“ funkciju palīdzības lodziņā. Žurnāli var saturēt informāciju par atrašanās vietu.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Maršruta opcijas</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Izvairīties no maksas ceļiem</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Izvairīties no zemes ceļiem</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Izvairīties no prāmjiem</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Izvairīties no automaģistrālēm</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Neizdevās aprēķināt maršrutu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Maršrutu neatrada. Iespējams, maršruta iestatījumi ir pārāk ierobežojoši vai trūkst „OpenStreetMap“ datu. Mēģiniet mainīt iestatījumus un atkārtot.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Noteikt nevēlamos ceļus</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Maršruta izvēles ir ieslēgtas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Maksas ceļš</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Neasfaltēts ceļš</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Prāmja pārceltuve</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Jā</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nē</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Pieejams</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nav pieejams</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Ietilpība: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Tīkls: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Ieradāties galamērķī!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Labi</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Kārtot…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Kārtot grāmatzīmes</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Pēc noklusējuma</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Pēc tipa</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Pēc attāluma</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Pēc datuma</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Pēc nosaukuma</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Pirms nedēļas</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Pirms mēneša</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Vairāk nekā pirms mēneša</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Vairāk nekā pirms gada</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Man tuvumā</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Cits</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Maršruta plānošana neizdevās</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ierašanās: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Lejupielādēt un atjaunināt visas kartes gar iespējamo maršrutu, lai to aprēķinātu.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Jūs nomainījāt pasaules karti! Neturiet izmaiņas pie sevis, bet pastāstiet par tām saviem draugiem un rediģējiet kopā!</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Kopīgot ar draugiem</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Šobrīd slēgts</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Atveras rīt %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Atveras %1 plkst. %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Atveras plkst. %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Slēgts no plkst. %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Pievienot darba laiku</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Parole (vismaz 8 simboli)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nederīgs lietotājvārds vai parole.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM konts</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Pēdējo reizi augšupielādēja</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Paldies</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Vietas nosaukums</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Tālrunis</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Ievērojiet</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Lejupielādes kļūda</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Atlasiet kategoriju</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populāras</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Visas kategorijas</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Pievienojiet kartei jaunas vietas un rediģējiet jau esošās uzreiz lietotnē.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Mainīt atrašanās vietu</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Lejupielādei nepieciešams vairāk vietas. Izdzēsiet liekos datus.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Es uzlaboju „Organic Maps“ kartes</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Sīkāks komentārs</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Jūsu izmaiņu priekšlikumu nosūtīsim „OpenStreetMap“ kopienai. Lūdzu, sniedziet jebkādu papildu informāciju, ko nevarat norādīt „Organic Maps“ lietotnē.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Nosakot jūsu atrašanās vietu, radās kļūda. Pārleicinieties, ka ierīce darbojas korekti un mēģiniet vēlreiz.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Vietas noteikšanas servisi ir izslēgti</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Ierīces iestatījumos ieslēdziet pieeju ģeolokācijai.</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Atveriet iestatījumus</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Pieskarieties „Vietai&quot;</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Atlasiet „Izmantojot lietotni“</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Atlasiet „Privātums“</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Atlasiet atrašanās vietas pakalpojumus</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ieslēdziet atrašanāš vietas noteikšanas pakalpojumus</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Vai turpiniet izmantot „Organic Maps“ bez vietas</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervēt</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Zvanīt</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Grāmatzīmes nosaukums</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Dzēst grāmatzīmi</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Jūsu piezīmi nosūtīsim uz „OpenStreetMap“</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…vairāk</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Atjaunināt</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Vai izslēgt pēdējā noietā vai nobrauktā maršuta ierakstīšanu?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Izslēgt</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Paskaties</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>„Organic Maps“ fonā izmantos ierīces atrašanās vietas datus, lai reģistrētu pēdējo noieto vai nobraukto maršrutu.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Pamata iestatījumi</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Lai parādītu satiksmes datus, lietotne ir jāatjaunina.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Žurnāla datnes lielums: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Velciet te, lai noņemtu</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Aizstāt Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Sākt no</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Ierakstieties „OpenStreetMap“, lai automātiski augšupielādētu visus kartes rediģējumus. Uzziniet vairāk</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>te</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Slēpt ekrānu</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 no %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Lejupielādē %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Pielieto %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Nosaukums ir par garu</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Atrastas jaunas datnes</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertēt</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Kļūda</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Atsevišķas datnes nav konvertētas.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Notika kļūda</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populāras</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Slēpt kartē</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Kļūda, ielādējot birkas. Mēģiniet vēlreiz.</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Tiesības</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Apakšējā daļa</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Uz priekšu</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Galamērķis</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrēt</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Meklēšanas rezultāti</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Pēc tam</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vai vēlaties maršrutu izveidot no jauna?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Braukšanas laikā tastatūra nav pieejama</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>No pašreizējās vietas maršrutu izveidot nevar</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Neizdodas atrast maršrutu līdz galamērķim. Izvēlieties citu galamērķa punktu</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nav GPS signāla. Aizejiet līdz atklātai vietai</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Neizdevās izveidot maršrutu. Norādiet citus maršruta punktus</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Lejupielādējiet trūkstošās kartes, lai izveidotu maršrutu</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Notika kļūda. Palaidiet programmu no jauna</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Maršrutu izveidos no jūsu pašreizējās vietas</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Maršrutu konvertēs par piemērotu automobilim</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nav parādītas visas grāmatzīmes</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Lai redzētu visas grāmatzīmes, pārslēdzieties uz tālruni</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Fotoradari</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Ātruma brīdinājumi</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Lejupielādējiet lietotnes kartes savā mobilajā ierīcē</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 izeja</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Kārtot pēc noklusējuma</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Kārtot pēc tipa</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Kārtot pēc attāluma</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Kārtot pēc datuma</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Kārtot pēc nosaukuma</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Ēdiens</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Apskates objekti</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzeji</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parki</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Peldvietas</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Kalni</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Dzīvnieki</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Viesnīcas</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Ēkas</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Nauda</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Veikali</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Autostāvvietas</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Degvielas uzpildes stacija</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicīna</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Meklēt sarakstā</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Reliģiskas vietas</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Izvēlēties sarakstu</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro navigācija šajā reģionā nav pieejama</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metro maršruts nav atrasts</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Izvēlieties sākuma un beigu punktu tuvāk metro stacijai</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Reljefa līnijas</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Reljefa līniju parādīšanai nepieciešamas lejupielādēt šī reģiona karti</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Topogrāfiskais slānis šim reģionam nav pieejams</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Kāpums</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Kritums</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Zemākais punkts</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Augstākais punkts</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Sarežģītība</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Attālums:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Ceļā:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Pietuviniet, lai izpētītu izolīnijas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Lejupielādē</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Lejupielādēt pasaules pārskata karti</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Neizdevās izveidot mapi un pārvietot datnes iekšējā atmiņā vai SD kartē</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Diska kļūda</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Savienojuma kļūda</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Atvienojiet USB kabeli</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Paturēt ekrānu ieslēgtu</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Kad ieslēgts, rādot karti, ekrāns vienmēr būs ieslēgts.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Rādīt bloķēšanas ekrānā</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Ja ieslēgts, lietotne darbosies pat tad, ja ierīce būs nobloķēta.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kartes valoda</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kartes datu avots ir „OpenStreetMap“</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Paldies, ka izmantojat mūsu kopienas veidotās kartes!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Ar jūsu ziedojumiem un atbalstu varam izveidot pasaulē labākās kartes!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Vai jums patīk mūsu lietotne? Lūdzam ziedot tās attīstībai! Varbūt tā nepatīk? Tādā gadījumā lūdzam mums pastāstīt, kas tajā nepatīk, lai varam „Organic Maps“ uzlabot!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ja pazīstat kādu programmatūras izstrādātāju, varat viņam vai viņai palūgt ieviest funkciju, kas jums pietrūkst.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Pieskarieties jebkurai vietai kartē, lai atlasītu jebkuru objektu. Garš pieskāriens tiek izmantots, lai paslēptu un parādītu saskarni.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Vai zinājāt, ka ir iespējams atlasīt jūsu pašreizējo atrašanās vietu kartē?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Varat palīdzēt tulkot lietotni savā valodā.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Šo lietotni veido daži entuziasti un mūsu kopiena.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Kartes datus varat viegli labot un papildināt.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Mūsu mērķis ir izveidot viegli lietojamas kartes, kas respektē jūsu privātumu un kuras jums patiks.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Tagad „Organic Maps“ izmantojat tālruņa ekrānā</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Tagad „Organic Maps“ izmantojat automobiļa ekrānā</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Savienots ar Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Turpināt tālrunī</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Uz auto ekrānu</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps lietotnes darbībai ir nepieciešama piekļuve jūsu atrašanās vietai. Kad tas ir droši, pārbaudiet paziņojumu savā tālrunī.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Šai lietotnei ir nepieciešama jūsu atļauja</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps lietotnei ir nepieciešama atrašanās vietas atļauja sekmīgai Android Auto darbībai</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Atļaut piekļuvi</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Aktīvā atpūta</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Tīmekļa pārlūkprogramma nav pieejama</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Skaļums</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksportēt visas trases un grāmatzīmes</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Runas sintēzes sistēmas iestatījumi</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Lietotnes neatrada runas sintēzes iestatījumus. Vai ierīce tos atbalsta?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Caurbrauktuve</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Notīrīt meklēšanu</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Tuvināt</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Tālināt</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Saite uz ēdienkarti</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Apskatīt ēdienkarti</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Atvērt citā lietotnē</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Pašapkalpošanās</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Atlasīt opciju</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Ārtelpu sēdvietas</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Lai navigācija būtu pēc iespējas precīzāka, iesakām tālruņa baterijas iesatatījumos izslēgt energotaupības režīmu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Ierakstīt pēdojumu</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Apstādināt pēdojuma ierakstīšanu</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Trases ierakstīšana</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Pārtraukt ierakstīšanu</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Turpināt ierakstīt</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Saglabāt pēdojumu grāmatzīmju sadaļā?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Pēdojums ir tukšs – nav nekā saglabājama</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nevar parādīt mapes atlases dialoglodziņu, jo jūsu ierīcē nav instalēta piemērota lietotne. Lūdzu, uzstādiet failu pārvaldnieka lietotni un mēģiniet vēlreiz.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Izvēlieties krāsu</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Pēdojuma labošana</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nav uzstādīta neviena lietotne, kas varētu atvērt atrašanās vietu</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automātisks navigācijas laikā</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Sekot sistēmai</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Kopīgot pēdojumu</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Dzēst %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Sarežģītības līmenis</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Viegls</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Normāls</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Sarežģīts</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Atjaunina</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Atjaunināt lejupielādētās kartes</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Karšu atjaunināšana nodrošina, ka karšu informācija ir svaiga</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Atjaunināt (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Atjaunināšu vēlāk</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Dzēst ceļu</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Tiešām vēlies dzēst šo ceļu?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Ceļa nosaukums</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Pārvietot</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Ceļš</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Mainīt krāsu</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Karte</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Vai vēlaties izstrādātājiem nosūtīt ziņojumu par kļūdu?
+Mēs paļaujamies uz šiem ziņojumiem, jo „Organic Maps“ automātiski nevāc nekādus datus par kļūdām. Jau iepriekš pateicamies par „Organic Maps“ atbalstīšanu!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Ieslēgta „iCloud“ sinhronizācija</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>„iCloud“ sinhronizācija šobrīd ir eksperimentāla iespēja, ko joprojām veidojam. Pirms tās izmantošanas izveidojiet grāmatzīmju un ceļu dublējumkopijas.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>„iCloud“ ir izslēgts</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ja vēlaties izmantot šo funkciju, ierīces iestatījumos ieslēdziet „iCloud“.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Ieslēgt</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Dublējumkopija</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>„iCloud“ sinhronizācijas kļūda</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Kļūda: sinhronizācija neizdevās savienojuma kļūdas dēļ</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Kļūda: sinhronizācija neizdevās pārsniegtas „iCloud“ kvotas dēļ</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Kļūda: „iCloud“ nav pieejams</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nesen dzēstie saraksti</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Notīrīt</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Dzēst visu</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Atjaunot</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Atjaunot visu</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Piedalīties OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Pievienot vietu</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Atjauniniet karti, lai piedalītos</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Jums ir jāatjaunina %1 karte uz jaunāko versiju, pirms varat piedalīties OpenStreetMap datos</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mana atrašanās vieta</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Manas vietas</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Iekšējā privātā krātuve</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Iekšējā kopīgā krātuve</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Atmiņas karte</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ārējā kopīgā krātuve</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Pasta indekss</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punkts kartē</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Lai parādītu maršrutus, ir jāatjaunina kartes.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Izeja</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ieeja</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metro karte nav pieejama</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Jūs</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Violeti lejupielādētie reģioni</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Maršruts</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Lai pilnībā izmantotu lietotnes funkcionalitāti, ir nepieciešams noteikt atrašanās vietu fonā. Tā tiek izmantota navigācijai un nesen veikto ceļojumu saglabāšanai.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Atrašanās vietas noteikšana ir nepieciešama navigācijai un nesen veiktā maršruta saglabāšanai.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Pieteikšanās ar paroli</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Pieteikšanās, izmantojot pārlūkprogrammu</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nesen izmantots</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Grāmatzīmju krāsa mainīta</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Maršrutu krāsa mainīta</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrs</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Slīdņi</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>SARKANS</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZAĻŠ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Režģis</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ml/omim.ts
+++ b/qt/translations/ml/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ml">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>പുലർകാലം മുതൽ സന്ധ്യ വരെ ലൈറ്റ്</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org-ൽ നിന്നുള്ള ലേഖനം</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/ml/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>അടുത്തിടെ ഉപയോഗിച്ചത്</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>സ്പെക്ട്രം</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>സ്ലൈഡറുകൾ</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ചുവപ്പ്</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>പച്ച</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>നീല</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB ഹെക്സ് നിറം #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>ഗ്രിഡ്</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/mr/omim.ts
+++ b/qt/translations/mr/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="mr">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>मागे</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>रद्द करा</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>हटवा</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>नकाशे डाउनलोड करा</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>डाउनलोड अयशस्वी झाले. पुन्हा प्रयत्न करण्यासाठी स्पर्श करा.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>डाउनलोड करत आहे…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>किलोमीटर</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>मैल</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>नंतर</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>शोधा</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>नकाश्यात शोधा</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>आपल्या उपकरणात किंवा ऍप मध्ये स्थानसेवा सध्या बंद आहेत. कृपया सेटिंग मधून त्यांना चालू करा.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>मर्यादित अचूकता</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>अचूक नेव्हिगेशन सुनिश्चित करण्यासाठी सेटिंग्जमध्ये अचूक स्थान सक्षम करा.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>नकाशावर दाखवा</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>डाउनलोड अयशस्वी</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>पुन्हा प्रयत्न करा</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps बद्दल</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>सर्वांसाठी विनामूल्य, आवडीने तयार केलेले</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• जाहिराती नाही, माहितीचा मागोवा नाही, डेटा संग्रहण नाही</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• बॅटरी संपत नाही, ऑफलाइन कार्य करते</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• जलद, मिनिमलिस्ट, समुदायाद्वारे विकसित</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>उत्साही आणि स्वयंसेवकांनी तयार केलेले मुक्त-स्रोत अनुप्रयोग.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>स्थान सेटिंग्ज</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>बंद</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>ह्या ऍपला हार्डवेअर प्रवेगक OpenGL आवश्यक आहे. दुर्दैवाने, तुमच्या उपकरणाला ह्याचा आधार नाही.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>डाउनलोड करा</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps वापरण्यासाठी कृपया USB केबल काढून टाका किंवा मेमरी कार्ड घाला</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>कृपया ऍप वापरण्यासाठी प्रथम SD कार्ड/USB स्टोरेजवरील काही जागा मोकळी करा</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>ऍपचा वापर सुरू करण्यापूर्वी, आम्हाला तुमच्या उपकरणावर जगाचा सामान्य नकाशा डाउनलोड करण्याची परवानगी द्या.
+ते %1 जागा वापरेल.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>नकाशावर जा</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 डाउनलोड करत आहे.
+तुम्ही आता नकाशावर जाऊ शकता.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 डाउनलोड करायचे?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 अद्ययावत करायचे?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>विराम द्या</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>चालू ठेवा</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 डाउनलोड अयशस्वी</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>नवीन यादी जोडा</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>खूणपत्र यादीचे नाव</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>खूणपत्रे</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>खूणपत्रे आणि ट्रॅक</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>नाव</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>पत्ता</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>यादी</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>सेटिंग</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>नकाशे येथे साठवा</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>नकाशे डाउनलोड करायचे ठिकाण निवडा</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>डाउनलोड केलेले नकाशे</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 %2 पैकी मोकळे</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>नकाशे हलवायचे?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>नकाशा फाइल्स हलवताना त्रुटी</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>यास काही मिनिटे लागू शकतात.
+कृपया प्रतीक्षा करा…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>मापन एकके</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>मैल की किलोमीटर ह्यामध्ये निवडा</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>डाउनलोड रद्द करा</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>अभिप्राय द्या</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>होय</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>नकाशा डाउनलोड करा</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>खूणपत्र याद्या</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>जेवायचे ठिकाण</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>किराणा</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>वाहतूक</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>इंधन</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>वाहनतळ</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>खरेदी</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>वापरलेले</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>मुक्कामगृह</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>पर्यटन</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>मनोरंजन</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>रात्रीजीवन</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>कौटुंबिक सुट्टी</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>बँक</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>औषधालय</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>रुग्णालय</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>शौचालय</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>टपाल</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>पोलीस</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>भंगारवाला</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>पाणी</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>कँपिंग वाहन सोयी</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>चिठ्ठया</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps द्वारे तुम्हाला खूणपत्रे सामायिक केले</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>नमस्कार!
+
+Organic Maps ऍप मधील माझे खूणपत्रे संलग्न केले आहेत. तुम्ही Organic Maps इन्स्टॉल केले असल्यास हे खूणपत्रे उघडा. इन्स्टॉल केले नसल्यास, पुढील दुव्यावर जाऊन तुमच्या iOS किंवा अँड्रॉइड उपकरणावर हे डाउनलोड करा: https://omaps.app/get?kmz
+
+Organic Maps सह प्रवासाचा आनंद घ्या!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>खूणपत्रे वाचत आहे</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>खूणपत्रे वाचून झाले! ते तुम्ही नकाशावर किंवा खूणपत्र व्यवस्थापक पटलावर पाहू शकता.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>खूणपत्रे वाचण्यात अपयश. फाइल दूषित किंवा बिघडलेली असू शकते.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>फाइल प्रकार ॲपद्वारे ओळखला जात नाही:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>फाइल उघडण्यात अयशस्वी%1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>संपादन</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>तुमचे स्थान अद्याप निश्चित केलेले नाही</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>क्षमस्व, नकाशा साठवायचे सेटिंग सध्या बंद आहेत.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>नकाशा डाउनलोड होत आहे</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>मी आता इथे आहे %1 किंवा %2 Organic Maps डाउनलोड करा: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Organic Maps द्वारे एक खूणपत्र पाठवत आहे!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Organic Maps द्वारे माझे वर्तमान स्थान पाठवत आहे!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>नमस्कार,
+
+मी आता इथे आहे: %1. नकाशावर ठिकाण पाहण्यासाठी या %2 किंवा या %3 वर क्लिक करा.
+
+आभारी.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>सामायिक</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>ई-मेल</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>क्लिपबोर्डावर कॉपी केले: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>झाले</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap डेटा: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>तुमची खात्री आहे की तुम्ही तुमच्या OpenStreetMap खात्यातून लॉग आउट करू इच्छिता?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>ट्रॅक</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>लांबी</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>माझे स्थान सामायिक करा</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>सर्वसामान्य सेटिंग</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>माहिती</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>मार्गनिर्देशन</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>नकाशावर + आणि - बटणे</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>नकाशावर दाखवा</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>अंधारात नेव्हिगेट करताना रात्रीची शैली</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>रात्र मोड</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>बंद</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>चालू</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>स्वयं</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>यथार्थ दृश्य</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>त्रिमिती (3D) इमारती</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D इमारती वीज बचत मोडमध्ये बंद केल्या आहेत</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>ध्वनी सूचना</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>मार्गांची नावे घोषित करा</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>चालू केल्यास, वळण घेण्यापूर्वी रस्त्याचे किंवा वळणाचे नाव बोलून सांगितले जाईल.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>ध्वनी भाषा</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>उच्च-गुणवत्तेचा आवाज डाउनलोड करण्यासाठी, सेटिंग्ज अॅप उघडा आणि प्रवेशयोग्यता → VoiceOver → स्पीच → व्हॉइस येथे जा.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>चाचणी आवाज दिशानिर्देश (TTS, टेक्स्ट-टू-स्पीच)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>तुम्हाला आता आवाज ऐकू येत नसल्यास व्हॉल्यूम किंवा सिस्टम टेक्स्ट-टू-स्पीच सेटिंग्ज तपासा.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>उपलब्ध नाही</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>स्वयं झूम</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>अंतर</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>नकाशावर पहा</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>मेनू</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>संकेतस्थळ</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>बातम्या</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>अभिप्राय</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>ऍप मानांकित करा</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>मदत</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>वारंवार विचारलेले प्रश्न</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>दान करा</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>आधीच दान केले</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>नंतर आठवण करून द्या</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps ला समर्थन द्या</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>प्रकल्पाला पाठठिंबा द्या</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>प्रकाशन अधिकार (कॉपीराईट)</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>त्रुटी कळवा</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>कंपास कॅलिब्रेट करण्यासाठी फोनला आकृती-आठ मोशनमध्ये हलवून बाणाची दिशा सुधारा.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>होकायंत्र कॅलिब्रेट करण्यासाठी आणि नकाशावर बाणाची दिशा निश्चित करण्यासाठी फोनला आकृती-आठ मोशनमध्ये हलवा.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>इंटरफेस पाहण्यासाठी पुन्हा नकाशावर दीर्घ टॅप करा</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>सर्व अद्ययावत</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>सर्व रद्द</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>डाउनलोड केले</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>रांगेत</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>माझ्या जवळ</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>नकाशे</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>सर्व डाउनलोड</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>डाउनलोड करत आहे:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>नकाशा पुसून टाकण्यासाठी, मार्गनिर्देशन थांबवा.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>केवळ एका प्रदेशाच्या नकाशामध्ये पूर्णपणे समाविष्ट असलेले मार्ग तयार केले जाऊ शकतात.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>नकाशा डाउनलोड करा</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>पुनर्प्रयत्न</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>नकाशा काढून टाका</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>नकाशा अद्ययावत करा</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play स्थान सेवा</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>ब्लूटूथ, वायफाय किंवा मोबाइल नेटवर्क वापरून तुमचे अंदाजे स्थान द्रुतपणे निर्धारित करा</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>तुमच्या मार्गावरील सर्व नकाशे डाउनलोड करा</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>मार्ग तयार करण्यासाठी आम्हाला तुमच्या स्थानापासून तुमच्या गंतव्यस्थानापर्यंताचे सर्व नकाशे डाउनलोड करून अद्ययावत करावे लागतील.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>पुरेशी जागा नाही</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>कृपया स्थान सेवा सक्रिय करा</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>साठवा</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>तयार करा</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>लाल</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>पिवळा</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>निळा</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>हिरवा</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>जांभळा</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>भगवा</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>तपकिरी</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>गुलाबी</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>गडद जांभळा</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>फिकट निळा</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>हिरवट निळा (फिकट)</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>हिरवट निळा (गडद)</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>पोपटी</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>नारंगी</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>राखाडी</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>निळा राखाडी</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>माहिती</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps आवृत्ती: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>दर्शनी रूप</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>प्रकाश</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>अंधार</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>फिकट पहाटेपासून संध्याकाळपर्यंत</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>इतर</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>लाखो वापरकर्त्यांना जाहिरातीशिवाय विनामूल्य नकाशे भेट द्या!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>चुकीच्या नकाशा डेटाचा अहवाल द्या किंवा त्याचे निराकरण करा</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>स्वयंसेवक करण्यासाठी</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>अनुसरण करा आणि आमच्याशी संपर्क साधा:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>ईमेल वाहक सेट केलेले नाही. कृपया ते सेट करा किंवा वेगळ्या पद्धतीने आमच्याशी %1 वर संपर्क करा</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>मेल पाठवताना त्रुटी</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>होकायंत्र अंशशोधन</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>उपलब्ध</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>आढळले</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>अद्ययावत करा</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>अयशस्वी</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>खूणपत्र</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>प्रवास करताना, कृपात लक्षात ठेवा:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— मार्गनिर्देशक संकेतांपेक्षा रस्त्याची परिस्थिती, वाहतुकीचे नियम व वाहतुकीचे चिन्ह ह्यांना जास्त प्राधान्य द्या;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— नकाशा चुकीचा असू शकतो, आणि सुचवलेला मार्ग हा गंतव्यस्थानापर्यंत पोहोचण्यासाठी नेहमी सर्वोत्तम मार्ग असेलच असे नाही;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— सुचवलेले मार्ग ह्यांना केवळ शिफारसी म्हणून समजावे;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— सीमेजवळच्या मार्गांबाबतीत सावधानी बाळगा: इथे प्रकाशित मार्ग कधीकधी अनधिकृतरित्या देशाची सीमा ओलांडू शकतात.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>कृपया वाटेवर सतर्क आणि सुरक्षित रहा!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS सिग्नल तपासा</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>मार्ग तयार करण्यात अक्षम. वर्तमान GPS सहनिर्देशक ओळखता आले नाहीत.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>कृपया तुमचा GPS सिग्नल तपासा. WiFi चालू केल्याने तुमच्या स्थानाची अचूकता सुधारेल.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>स्थान सेवा चालू करा</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>वर्तमान GPS सहनिर्देशक शोधण्यात अक्षम. मार्गाची गणना करण्यासाठी स्थान सेवा चालू करा.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>मार्ग शोधण्यात अक्षम</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>मार्ग तयार करण्यात अक्षम.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>कृपया तुमचा प्रारंभस्थान किंवा गंतव्यस्थानाचा बिंदू समायोजित करा.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>प्रारंभ बिंदू समायोजित करा</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>मार्ग तयार केला नाही. प्रारंभ बिंदू शोधण्यात अक्षम.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>कृपया रस्त्याच्या जवळचा प्रारंभ बिंदू निवडा.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>गंतव्यस्थान समायोजित करा</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>मार्ग तयार केला नाही. गंतव्यस्थान शोधण्यात अक्षम.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>कृपया रस्त्याच्या जवळ असलेले गंतव्यस्थान निवडा.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>मध्यबिंदू शोधण्यात अक्षम.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>कृपया तुमचा मध्यबिंदू समायोजित करा.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>सिस्टम त्रुटी</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>ऍप त्रुटीमुळे मार्ग तयार करण्यात अक्षम.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>कृपया पुर्नरप्रयत्न करा</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>आता नाही</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>एकापेक्षा जास्त नकाशात पसरलेला अधिक चांगला मार्ग तयार करण्यासाठी, नकाशा डाउनलोड केलेला चालेल का?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>या नकाशाच्या सीमा ओलांडणारा एक चांगला मार्ग तयार करण्यासाठी अधिक नकाशे डाउनलोड करा.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>आवश्यक फाईली डाउनलोड करा</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>मार्ग शोधण्यासाठी प्रक्षेपित वाटेभोवतीचे सर्व नकाशे व मार्गनिर्देशक माहिती डाउनलोड करा.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>ठिकाण व मार्ग शोध सुरु करण्यासाठी, कृपया नकाशा डाउनलोड करा. त्यानंतर तुम्हाला इंटरनेटची आवश्यकता भासणार नाही.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>नकाशा निवडा</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>दाखवा</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>लपवा</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>प्रवर्ग</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>इतिहास</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>अरेच्चा, काहीच सापडले नाही.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>तुम्ही जिथे शोधत आहात तो प्रदेश डाउनलोड करा किंवा जवळच्या शहर/गावाचे नाव जोडण्याचा प्रयत्न करा.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>शोध इतिहास</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>अलीकडील शोध पहा.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>शोध इतिहास पुसून टाका</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>विकिपीडिया</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org वरून लेख</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>विकिमीडिया कॉमन्स</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>तुमचे स्थान</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>सुरू करा</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>पासून मार्ग</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>पर्यंतचा मार्ग</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>मार्गनिर्देशन फक्त तुमच्या वर्तमान स्थानावरून उपलब्ध आहे.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>तुमच्या वर्तमान स्थानापासून मार्ग नियोजन करायचे का?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>पुढे</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>ते</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>पर्यंत</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>वेळापत्रक जोडा</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>वेळापत्रक मिटवा</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>दिवसभर (२४ तास)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>उघडे</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>गैर-व्यवसायाची वेळ जोडा</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>व्यवसायाची वेळ</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>प्रगत मोड</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>साधा मोड</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>गैर-व्यवसाय वेळ</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>उदाहरण मूल्ये</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>चूक सुधारा</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>स्थान निवडा</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>OpenStreetMap समुदायाने ही त्रुटी सुधारण्यासाठी कृपया समस्येचे तपशिलात वर्णन करा.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>किंवा https://www.openstreetmap.org/ वर ते स्वतः करा</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>पाठवा</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>समस्या</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>जागा अस्तित्वात नाही</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>देखभालीसाठी बंद</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>प्रतिलिपीत (डुप्लिकेट) ठिकाण</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>स्वयं डाउनलोड</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>दैनिक</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>२४/७</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>आज बंद</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>आज</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>आणखी %1 मध्ये उघडेल</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>आणखी %1 मध्ये बंद होईल</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>बंद</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>व्यवसायाची वेळ संपादित करा</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>OpenStreetMap खाते नाही?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>OpenStreetMap वर नोंदणी करा</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>लॉग इन</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>साइन इन केलेले नाही</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMap मध्ये लॉगिन करा</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>पासवर्ड</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>पासवर्ड विसरलात?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>लॉग आऊट</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>ठिकाण संपादित करा</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>भाषा जोडा</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>रस्ता</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>बिल्डिंग क्रमांक</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>तपशील</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>सोशल मीडिया</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>इमारत</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>रस्ता जोडा</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>कृपया रस्त्याचे नाव जोडा</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>भाषा निवडा</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>रस्ता निवडा</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>पाककृती</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>पाककृती निवडा</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>ईमेल किंवा वापरकर्तानाव</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>फोन जोडा</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>मजला</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>स्तर: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>तुमचे सर्व नकाशा संपादने नकाशासह पुसले जातील.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>नकाशे अद्ययावत करा</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>मार्ग तयार करण्यासाठी तुम्हाला सर्व नकाशे अद्ययावत करावे लागतील आणि मग मार्ग नियोजन करता येईल.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>नकाशा शोधा</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>कृपया तुमचे सेटिंग तपासा आणि तुमचे उपकरण इंटरनेटशी जोडले असल्याची खात्री करा.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>पुरेशी जागा नाही</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>कृपया अनावश्यक डेटा पुसून टाका</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>लॉग इन त्रुटी.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>सत्यापित बदल</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>ठिकाण किंवा व्यवसायाच्या ठिकाणी क्रॉस ठेवण्यासाठी नकाशा ड्रॅग करा.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>संपादन</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>जोडणे</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>ठिकाणाचे नाव</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>स्थानिक भाषेत लिहिल्याप्रमाणे</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>प्रवर्ग</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>समस्येचे तपशिलात वर्णन</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>वेगळी समस्या</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>व्यवसाय जोडा</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>इथे कोणतीही वस्तू ठेवू शकत नाही</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>समुदाय-निर्मित OpenStreetMap डेटा %1 नुसार. OpenStreetMap.org वर नकाशा संपादित आणि अपडेट कसा करायचा याबद्दल अधिक जाणून घ्या</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) हा मोफत आणि मुक्त नकाशा तयार करण्याचा समुदाय प्रकल्प आहे. हा Organic Maps मधील नकाशा डेटाचा मुख्य स्रोत आहे आणि विकिपीडियाप्रमाणे कार्य करतो. तुम्ही ठिकाणे जोडू किंवा संपादित करू शकता आणि ती जगभरातील लाखो वापरकर्त्यांसाठी उपलब्ध होतात.
+समुदायात सामील व्हा आणि सर्वांसाठी अधिक चांगला नकाशा तयार करण्यात मदत करा!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>एक OpenStreetMap खाते तयार करा किंवा तुमची नकाशा संपादने जगासमोर प्रकाशित करण्यासाठी लॉग इन करा.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%2 पैकी %1</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>मोबाईल डेटा वापरून डाउनलोड करायचे?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>रोमिंग वर असल्यास हे बरेच महाग पडू शकते.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>एक वैध बिल्डिंग क्रमांक प्रविष्ट करा</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>मजल्यांची संख्या (कमाल %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>मजल्यांची संख्या %1 पेक्षा जास्त नसावी</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>पिनकोड</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>वैध पिनकोड प्रविष्ट करा</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap स्वयंसेवकांसाठी टीप (पर्यायी)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>नकाशावरील त्रुटी किंवा संपादन करता येणार नाहीत अशा गोष्टी Organic Maps वापरून वर्णन करा</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>तुमची संपादने सार्वजनिक &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; डेटाबेसवर अपलोड केली जातात. कृपया वैयक्तिक किंवा कॉपीराइट केलेली माहिती जोडू नका.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap बद्दल अधिक</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>तुमचा संपादन इतिहास</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>तुमचा नकाशा डेटा नोट्स</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>ऑपरेटर</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>ऑपरेटर: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>योग्य श्रेणी शोधू शकत नाही?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps फक्त साध्या बिंदू श्रेण्या जोडण्याची परवानगी देते, म्हणजे शहरं, रस्ते, तलाव, इमारतींच्या रूपरेषा इत्यादी नाहीत. कृपया अशा श्रेण्या थेट &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; वर जोडा. सविस्तर टप्प्याटप्प्याच्या सूचनांसाठी आमचे &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;मार्गदर्शक&lt;/a&gt; तपासा.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>तुम्ही कोणतेही नकाशे डाउनलोड केलेले नाहीत</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>स्थान शोधण्यासाठी नकाशे डाउनलोड करा आणि ऑफलाइन मार्गनिर्देशन वापरा.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>वर्तमान स्थान अज्ञात आहे.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>तास</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>मिनिट</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>दि</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>सेकंद</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>अधिक</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>खूणपत्र संपादित करा</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>वैयक्तिक चिठ्ठ्या (मजकूर किंवा html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>टिप्पणी…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>सर्व स्थानिक बदल टाकून द्यायचे?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>टाकून द्या</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>जोडलेले ठिकाण पुसून टाकायचे?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>पुसा</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>ठिकाण अस्तित्वात नाही</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>कृपया ठिकाण हटवण्याचे कारण सूचित करा</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>वैध संपर्क क्रमांक प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>वैध वेब पत्ता प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>वैध ईमेल प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>वैध Facebook वेब पत्ता, खाते किंवा पृष्ठ नाव प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>वैध Instagram वेब पत्ता किंवा खाते नाव प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>वैध Twitter वेब पत्ता किंवा वापरकर्तानाव प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>वैध VK वापरकर्तानाव किंवा वेब पत्ता प्रविष्ट करा</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>वैध LINE आयडी किंवा वेब पत्ता प्रविष्ट करा</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>OpenStreetMap मध्ये ठिकाण जोडा</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>किंवा, पर्यायीरित्या, OpenStreetMap समुदायासाठी एक टीप सोडा, ज्यामुळे इतर कोणीही येथे एखादे ठिकाण जोडू किंवा दुरुस्त करू शकेल.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>नोंद OpenStreetMap कडे पाठवली जाईल</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>तुम्ही ते सर्व वापरकर्त्यांना पाठवू इच्छिता?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>आपण कोणतीही वैयक्तिक माहिती प्रविष्ट केला नाही याची खात्री करा.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap संपादक बदल तपासतील व काही प्रश्न असल्यास तुमच्याशी संपर्क साधतील.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>थांबा</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>ट्रॅक रेकॉर्ड करत आहे</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>स्वीकारा</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>नाकारा</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>तपशीलवार माहिती दाखवण्यासाठी मोबाईल इंटरनेट वापरायचे?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>नेहमी वापरा</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>फक्त आज</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>आज वापरू नका</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>मोबाइल इंटरनेट</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>नकाशा अद्यतन सूचना तसेच ठिकाणे व खूणपत्रांबद्दल तपशीलवार माहिती प्रदर्शित करण्यासाठी मोबाइल इंटरनेट आवश्यक आहे.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>कधीही वापरू नका</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>नेहमी विचारा</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>वाहतूक माहिती दाखवण्यासाठी नकाशे अद्ययावत करणे आवश्यक आहे.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>नकाशावर अक्षरांचा आकार वाढवा</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>कृपया Organic Maps अद्ययावत करा</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>वाहतूक माहिती उपलब्ध नाही</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>लॉग चालू करा</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>सामान्य अभिप्राय</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>आम्ही ध्वनी निर्देशांसाठी &quot;सिस्टम TTS&quot; वापरतो. अनेक Android उपकरणे &quot;Google TTS&quot; वापरतात, जे तुम्ही Google Play वरून डाउनलोड किंवा अद्ययावत करू शकता</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>काही भाषांसाठी, तुम्हाला अँप स्टोअर (Google Play, Galaxy Store, App Gallery, FDroid) वरून स्पीच मिश्रक किंवा अतिरिक्त भाषा संच इन्स्टॉल करावे लागतील.
+तुमच्या उपकरणाची सेटिंग → भाषा आणि इनपुट → स्पीच → &quot;टेक्स्ट टू स्पीच आउटपुट&quot; उघडा.
+येथे तुम्ही स्पीच मिश्रणासाठी सेटिंग व्यवस्थापित करू शकता (उदाहरणार्थ, ऑफलाइन वापरासाठी भाषा संच डाउनलोड करा) आणि दुसरे टेक्स्ट-टू-स्पीच इंजिन निवडा.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>अधिक माहितीसाठी कृपया ही मार्गदर्शिका पहा.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>रोमन लिपीत लिप्यंतरण</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>अधिक जाणून घ्या</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>मार्ग प्रारंभ बिंदू जोडण्यासाठी नकाशावर शोध वापरा किंवा टॅप करा</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>गंतव्य बिंदू जोडण्यासाठी नकाशावर शोधा किंवा टॅप करा</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>मार्ग व्यवस्थापन</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>नियोजन</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>थांबा काढा</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>स्टॉप जोडा</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>जतन केले</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>तुमची सर्व नकाशा संपादने स्वयंचलितपणे अपलोड करण्यासाठी कृपया OpenStreetMap वर लॉग इन करा. &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;येथे&lt;/a&gt; अधिक जाणून घ्या.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>स्टोरेज प्रवेश समस्या</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>बाह्य साठ्याचा प्रवेश अपयशी. SD कार्ड कदाचित काढले गेले असेल, खराब झाले असेल किंवा फाइल सिस्टम ही केवळ-वाचनीय असावी. कृपया, तुमचे SD कार्ड तपासा किंवा support@organicmaps.app वर आमच्याशी संपर्क साधा</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>खराब साठ्याचे अनुकरण करा</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>कृपया योग्य नाव प्रविष्ट करा</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>याद्या</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>सर्व लपवा</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>सर्व दाखवा</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n खूणपत्र</numerusform>
+<numerusform>%n खूणपत्रे</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>नवीन यादी जोडा</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>बुकमार्क आणि ट्रॅक आयात करा</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>ऍप त्रुटीमुळे सामायिक करण्यात अक्षम</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>सामायिकरण त्रुटी</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>रिकामी यादी सामायिक करू शकत नाही</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>नाव रिक्त असू शकत नाही</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>कृपया यादीचे नाव प्रविष्ट करा</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>नवीन यादी</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>हे नाव आधीच वापरात आहे</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>कृपया दुसरे नाव निवडा</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>कृपया थांबा…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>फोन क्रमांक</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap प्रोफाइल</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n फाईल सापडली. रूपांतरानंतर तुम्ही ती पाहू शकता.</numerusform>
+<numerusform>%n फाईली सापडल्या. रूपांतरानंतर तुम्ही त्या पाहू शकता.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>पूर्ववत् करा</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ट्रॅक</numerusform>
+<numerusform>%n ट्रॅक</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>गोपनीयता</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>गोपनीयता धोरण</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>वापरण्याच्या अटी</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>ट्रॅफिक</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>हायकिंग</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>सायकलिंग</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>मेट्रो/भुयारी मार्ग</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>नकाशा शैली आणि स्तर</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>ही यादी रिकामी आहे</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>खूणपत्र जोडण्यासाठी, नकाशातील ठिकाणाला स्पर्श करा आणि नंतर तारा चिन्हाला स्पर्श करा</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>सर्व बुकमार्कचा रंग बदला</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>सर्व ट्रॅकांचा रंग बदला</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…अधिक</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZ निर्यात करा</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPX निर्यात करा</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSON निर्यात करा</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>यादी मिटवा</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>वेग कॅमेरे</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>ठिकाणाचे वर्णन</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>नकाशा डाउनलोडक</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>वेगाबद्दल चेतावणी द्या</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>नेहमी चेतावणी द्या</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>कधीही चेतावणी देऊ नका</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>ऊर्जा बचत मोड</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>काही कार्यप्रणालींचा त्याग करून बॅटरीतील ऊर्जा वाचवण्याचा प्रयत्न करा.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>कधीच नाही</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>स्वयंचलित</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>कमाल वीज बचत</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>नकाशावरील बुकमार्क नावे</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>जर खूप सारे बुकमार्क असतील, तर नकाशावर त्यांची नावे दाखवल्याने अॅप मंदावू शकते.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>उजवीकडे दाखवा</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>तळाशी दाखवा</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>निदान करण्याकरिता हा पर्याय लॉगिंग चालू करतो. ह्याने ऍपच्या समस्यांचे निवारण करणे आम्हाला उपयुक्त ठरू शकते. तुमच्या समस्येबद्दल तपशीलवार नोंदी रेकॉर्ड करण्यासाठी आणि आम्हाला पाठवण्यासाठी हा पर्याय तात्पुरता चालू करा.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>मार्गशोधी पर्याय</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>टोल रस्ते टाळा</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>कच्चे मार्ग टाळा</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>जल मार्ग टाळा</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>मोटरवे टाळा</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>मार्गाची गणना करण्यात अक्षम</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>दुर्दैवाने, आम्ही मार्ग शोधू शकलो नाही. ह्याचे कारण कदाचित तुम्ही निवडलेले पर्याय असावे. कृपया सेटिंग बदला आणि पुन्हा प्रयत्न करा.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>टाळण्याचे मार्ग निवडा</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>मार्गशोधी पर्याय चालू केले</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>टोल मार्ग</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>कच्चे मार्ग</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>जल मार्ग</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>होय</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>नाही</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>होय</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>नाही</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>क्षमता: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>नेटवर्क: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>तुम्ही पोचलात!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>ठीक आहे</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>क्रमाने लावा…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>खूणपत्रे क्रमाने लावा</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>डिफॉल्ट</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>प्रकारानुसार</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>अंतरानुसार</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>दिनांकानुसार</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>नावाने</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>गेल्या आठवड्यात</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>गेल्या महिन्यात</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>एक महिन्यापूर्वी</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>एक वर्षांपूर्वी</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>माझ्या जवळ</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>इतर</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>मार्ग नियोजन अयशस्वी</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>%1 वाजता आगमन</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>मार्गाची गणना करण्यासाठी प्रक्षेपित वाटेवरील सर्व नकाशा डाउनलोड आणि अद्ययावत करा.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>तुम्ही जगाचा नकाशा बदलला आहे. हे स्वतःपुरते ठेऊ नका! मित्रांना पण सांगा आणि एकत्र संपादित करा.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>मित्रांना वाटा</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>आता बंद</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>उद्या %1 ला उघडेल</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 ला %2 वाजता उघडेल</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1 ला उघडेल</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1 ला बंद होईल</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>उघडण्याची वेळ जोड</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>पासवर्ड (किमान ८ अक्षरे)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>अवैध वापरकर्तानाव किंवा पासवर्ड.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM खाते</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>शेवटचे अपलोड</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>आभारी</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>ठिकाणाचे नाव</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>फोन</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>कृपया नोंद घ्या</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>डाउनलोड त्रुटी</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>प्रवर्ग निवडा</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>लोकप्रिय</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>सर्व प्रवर्ग</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>नकाशावर नवीन ठिकाणे जोडा आणि विद्यमान ठिकाणे थेट ऍप मधून संपादित करा.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>स्थान बदला</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>डाउनलोड करण्यासाठी तुम्हाला अधिक जागा आवश्यक आहे. कृपया अनावश्यक डेटा पुसून टाका.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>मी Organic Maps नकाशे सुधारित केले</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>तपशीलवार टिप्पणी</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>तुम्ही सुचवलेले नकाशातील बदल OpenStreetMap समुदायाला पाठवले जातील. Organic Maps मध्ये संपादित न करता येणाऱ्या अधिक तपशीलांचे वर्णन करा.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>तुमचे स्थान शोधत असताना एक त्रुटी आढळली. तुमचे उपकरण योग्यरितीने काम करत असल्याचे तपासा आणि नंतर पुन्हा प्रयत्न करा.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>स्थान सेवा बंद आहे</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>उपकरणाच्या सेटिंगमध्ये भूस्थानाची उपलब्धता चालू करा</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>१. सेटिंग उघडा</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>२. स्थान टॅप करा</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>३. &quot;ऍप वापरत असताना&quot; निवडा</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. गोपनीयता निवडा</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. स्थान सेवा निवडा</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. स्थान सेवा चालू करा</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>किंवा स्थानशिवाय Organic Maps वापरणे सुरू ठेवा</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>पुस्तक</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>फोन करा</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>खूणपत्राचे नाव</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>खूणपत्र पुसा</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>तुमची टीप OpenStreetMap वर पाठवली जाईल</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…अधिक</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>अद्ययावत करा</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>तुम्ही अलीकडे प्रवास केलेल्या मार्गाचे रेकॉर्डिंग बंद करायचे?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>बंद करा</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>तपासा</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>तुम्ही अलीकडे प्रवास केलेला मार्ग रेकॉर्ड करण्यासाठी Organic Maps पार्श्वभूमीत तुमचे स्थान वापरते.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>सामान्य सेटिंग</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>वाहतूक माहिती दाखवण्यासाठी ऍप अद्ययावत करणे आवश्यक आहे.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>लॉग फाइल आकारमान: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>काढण्यासाठी इथे सरकवा</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>स्टॉप बदला</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>पासून प्रारंभ</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>तुमची सर्व नकाशा संपादने स्वयंचलितपणे अपलोड करण्यासाठी कृपया OpenStreetMap वर लॉग इन करा. अधिक जाणून घ्या</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>येथे</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>पटल (स्क्रीन) लपवा</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 पैकी %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 डाउनलोड करत आहे…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 लागू करत आहे…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>हे नाव अति लांब आहे</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>नवीन फाइल आढळल्या</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>रूपांतरित करा</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>त्रुटी</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>काही फायली रूपांतरित झाल्या नाहीत.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>त्रुटी आढळली</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>लोकप्रिय</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>नकाशावरून लपवा</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>टॅग लोड करताना त्रुटी आढळली, कृपया पुन्हा प्रयत्न करा</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>उजवे</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>तळ</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>चल जाऊया</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>गंतव्यस्थाना</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>पुनरकेंद्रित करा</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>शोध परिणाम</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>मग</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>तुम्हाला मार्ग पुन्हा तयार करायचा आहे का?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>गाडी चालवताना कीबोर्ड उपलब्ध नसतो</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>तुमच्या वर्तमान स्थानावरून मार्ग तयार करण्यात अक्षम</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>तुमच्या गंतव्यस्थानापर्यंत मार्ग तयार करण्यात अक्षम. कृपया दुसरे ठिकाण निवडा</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS सिग्नल नाही. कृपया उघड्या परिसरात जा</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>मार्ग तयार करण्यात अक्षम. कृपया इतर मार्ग बिंदू निर्दिष्ट करा</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>मार्ग तयार करण्यासाठी, तुमच्या उपकरणावर गहाळ नकाशे डाउनलोड करा</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>त्रुटी आढळली. कृपया ऍप पुनःचालू करा</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>तुमच्या वर्तमान स्थानावरून मार्ग पुन्हा तयार केला जाईल</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>मार्गाचे रुपांतर वाहनासाठी केले जाईल</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>सर्व बुकमार्क दर्शविले जात नाहीत</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>सर्व बुकमार्क पाहण्यासाठी फोनवर स्विच करा</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>वेगकॅमेरा</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>गती चेतावणी</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>कृपया तुमच्या उपकरणावर Organic Maps ऍप मध्ये नकाशे डाउनलोड करा</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 बाहेर पडा</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>डिफॉल्ट क्रमाने लावा</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>प्रकारानुसार क्रमाने लावा</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>अंतरानुसार क्रमाने लावा</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>दिनांकानुसार क्रमाने लावा</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>नावानुसार क्रमवारी लावा</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>अन्न</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>पर्यटन स्थळ</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>संग्रहालय</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>उद्यान</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>जलतरण</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>पर्वत</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>प्राणी</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>मुक्कामगृह</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>इमारती</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>पैसे</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>दुकान</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>वाहनतळ</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>पेट्रोल पंप</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>औषध</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>यादीत शोधा</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>धार्मिक स्थळ</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>यादी निवडा</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>या प्रदेशात मेट्रोचे मार्गनिर्देशन अद्याप उपलब्ध नाही</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>मेट्रो मार्ग सापडला नाही</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>कृपया मेट्रो स्थानकाजवळचा प्रारंभ किंवा शेवटचा बिंदू निवडा</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>भूप्रदेश</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>भूस्वरूप स्तर वापरण्यासाठी कृपया नकाशा डाउनलोड किंवा अद्ययावत करा</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>या भागात भूस्वरूप स्तर अद्याप उपलब्ध नाही</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>चढण</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>उतरण</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>किमान उंची</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>कमाल उंची</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>काठिण्य</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>अंतर.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>वेळ:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>समोच्च रेषा पाहायला नकाशा विशाल (झूम) करा</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>डाउनलोड करत आहे</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>जगाचा नकाशा डाउनलोड करा</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>उपकरणाच्या अंतर्गत मेमरी किंवा SD-card वर फोल्डर तयार करण्यात आणि फायली हलविण्यात अक्षम</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>डिस्क त्रुटी</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>जोडणी अयशस्वी</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB केबल काढा</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>स्क्रीन चालू ठेवा</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>सक्षम असतानानकाशाशप्रदर्शितिकरतानानस्क्रीनीनेहमीमचालूाअसेलसेल.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>लॉक पटलावर (स्क्रीनवर) दाखवा</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>चालू असल्यास, ऍप चालू असताना प्रत्येक वेळी तुम्हाला तुमचे उपकरण अनलॉक करण्याची आवश्यकता नाही.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>नकाशाची भाषा</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>OpenStreetMap कडून नकाशा डेटा</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/mr/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>आमचे समुदाय-निर्मित नकाशे वापरल्याबद्दल धन्यवाद!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>तुमच्या देणग्या आणि समर्थनासह, आम्ही जगातील सर्वोत्तम नकाशे तयार करू शकतो!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>तुम्हाला आमचे अॅप आवडते का? कृपया विकासाला पाठिंबा देण्यासाठी देणगी द्या! अजून आवडत नाही? कृपया आम्हाला कळवा आणि आम्ही त्याचे निराकरण करू!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>तुम्हाला सॉफ्टवेअर डेव्हलपर माहीत असल्यास, तुम्ही त्याला किंवा तिला तुम्हाला आवश्यक असलेले वैशिष्ट्य लागू करण्यास सांगू शकता.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>काहीही निवडण्यासाठी नकाशावर कुठेही टॅप करा. इंटरफेस लपवण्यासाठी आणि परत दर्शविण्यासाठी दीर्घ-टॅप करा.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>तुम्हाला माहीत आहे का की तुम्ही नकाशावर तुमचे वर्तमान स्थान निवडू शकता?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>तुम्ही आमच्या अॅपचे तुमच्या भाषेत भाषांतर करण्यात मदत करू शकता.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>आमचे अॅप काही उत्साही आणि समुदायाने विकसित केले आहे.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>तुम्ही नकाशा डेटा सहजपणे दुरुस्त करू शकता आणि सुधारू शकता.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>आमचे मुख्य ध्येय जलद, गोपनीयता-केंद्रित, वापरण्यास-सुलभ नकाशे तयार करणे आहे जे तुम्हाला आवडतील.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>आपण आता फोन स्क्रीनवर Organic Maps वापरत आहात</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>तुम्ही आता कार स्क्रीनवर Organic Maps वापरत आहात</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>तुम्ही Android Auto शी कनेक्ट आहात</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>फोनवर सुरू ठेवा</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>कारच्या स्क्रीनकडे</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps स्थान प्रवेश आवश्यक आहे. जेव्हा सुरक्षित असेल, तेव्हा आपल्या फोनवरील सूचना तपासा.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>या अॅपला तुमची परवानगी आवश्यक आहे</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps Android Auto मध्ये प्रभावीपणे कार्य करण्यासाठी स्थान परवानग्या आवश्यक आहेत</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>परवानग्या द्या</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>भटकंती</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>वेब ब्राउझर उपलब्ध नाही</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>व्हॉल्यूम</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>सर्व बुकमार्क आणि ट्रॅक निर्यात करा</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>सिस्टम स्पीच सिंथेसिस सेटिंग्ज</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>स्पीच सिंथेसिस सेटिंग्ज आढळल्या नाहीत, तुमची खात्री आहे की तुमचे डिव्हाइस त्यास समर्थन देते?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>मार्गे चला</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>शोध साफ करा</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>प्रतिमेचे दृष्य रूप मोठे करा</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>झूम कमी करा</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>मेनू लिंक</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>मेनू पहा</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>दुसऱ्या ॲपमध्ये उघडा</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>स्व: सेवा</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>पर्याय निवडा</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>बाहेरची आसनव्यवस्था</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>सर्वात अचूक नेव्हिगेशनसाठी, आम्ही फोनच्या बॅटरी सेटिंग्जमध्ये पॉवर सेव्हिंग मोड अक्षम करण्याची शिफारस करतो.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>ट्रॅक रेकॉर्ड करा</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>ट्रॅक रेकॉर्डिंग थांबवा</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>ट्रॅक रेकॉर्डिंग</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>जतन न करता थांबवा</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>रेकॉर्डिंग चालू ठेवा</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>मार्ग रेकॉर्डिंग खूणपत्रे आणि ट्रॅकमध्ये साठवायचे?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>मार्ग रिकामा आहे - साठवण्यासाठी काहीही नाही</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>फोल्डर निवड संवाद प्रदर्शित करण्यात अक्षम कारण आपल्या डिव्हाइसवर कोणतेही योग्य ॲप स्थापित केलेले नाही. कृपया फाइल व्यवस्थापक ॲप स्थापित करा आणि पुन्हा प्रयत्न करा</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>रंग निवडा</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>मार्ग संपादित करा</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>स्थान उघडू शकणारे कोणतेही ॲप स्थापित केलेले नाही</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>नेव्हिगेशनमध्ये ऑटो</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>प्रणालीचे अनुसरण करा</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>ट्रॅक शेअर करा</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>%1 हटवा?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>काठिण्य पातळी</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>सोपे</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>मध्यम</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>कठिण</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>अद्ययावत करत आहे</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>तुमचे डाउनलोड केलेले नकाशे अद्ययावत करा</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>नकाशे अद्ययावत केल्याने वस्तूंची माहिती अद्यतनित राहते</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>अद्ययावत करा (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>नंतर स्वतः अद्ययावत करा</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>ट्रॅक पुसून टाका</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>तुमची खात्री आहे की तुम्ही हा ट्रॅक हटवू इच्छिता?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>ट्रॅकचे नाव</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>हलवा</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>ट्रॅक</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>रंग बदला</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>नकाशा</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>तुम्हाला विकासकांना बग रिपोर्ट पाठवायचा आहे का?
+आम्ही आमच्या वापरकर्त्यांवर अवलंबून आहोत कारण Organic Maps आपोआप कोणतीही त्रुटीची माहिती गोळा करत नाही. Organic Maps ला पाठिंबा दिल्याबद्दल आगाऊ धन्यवाद!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud सिंक्रोनाइझेशन सक्षम करा</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud सिंक्रोनाइझेशन हे विकासाधीन प्रायोगिक वैशिष्ट्य आहे. तुम्ही तुमच्या सर्व बुकमार्क्स आणि ट्रॅकचा बॅकअप घेतला असल्याची खात्री करा.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud अक्षम आहे</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>कृपया हे वैशिष्ट्य वापरण्यासाठी तुमच्या डिव्हाइसच्या सेटिंग्जमध्ये iCloud सक्षम करा.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>सक्षम करा</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>बॅकअप</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud सिंक्रोनाइझेशन अयशस्वी</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>त्रुटी: कनेक्शन त्रुटीमुळे सिंक्रोनाइझ करण्यात अयशस्वी</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>त्रुटी: iCloud कोटा ओलांडल्यामुळे सिंक्रोनाइझ करण्यात अयशस्वी</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>त्रुटी: iCloud उपलब्ध नाही</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>अलीकडे हटवलेल्या याद्या</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>साफ करा</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>सर्व हटवा</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>पुनर्प्राप्त करा</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>सर्व पुनर्प्राप्त करा</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap मध्ये योगदान द्या</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>ठिकाण जोडा</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>योगदान देण्यासाठी नकाशा अद्यतनित करा</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>OpenStreetMap डेटामध्ये योगदान देण्यापूर्वी तुम्हाला %1 नकाशा नवीनतम आवृत्तीत अद्यतनित करणे आवश्यक आहे</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>एमबी</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>माझे स्थान</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>माझी ठिकाणे</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>आंतरिक खाजगी संग्रहण</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>आंतरिक सामायिक संग्रहण</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>एसडी कार्ड</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>बाह्य सामायिक संग्रहण</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>वायफाय इंटरनेट</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>पिनकोड</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>नकाशा बिंदू</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>किमी</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>फूट</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>मार्ग दाखवण्यासाठी नकाशे अद्ययावत केले पाहिजेत.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>बाहेर पडा</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>प्रवेशद्वार</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>मेट्रो नकाशा अनुपलब्ध आहे</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>तुम्ही</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>जांभळे डाउनलोड केलेले प्रदेश</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>मार्ग</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>ऍपच्या कार्यक्षमतेचा पूर्णपणे आनंद घेण्यासाठी पार्श्वभूमीतील स्थान जाणणे आवश्यक आहे. मार्गनिर्देशनासाठी व अलीकडे प्रवास केलेला मार्ग जतन करण्यासाठी ह्याचा उपयोग होतो.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>मार्गनिर्देशनासाठी व अलीकडे प्रवास केलेला मार्ग जतन करण्यासाठी तुमचे स्थान जाणणे आवश्यक आहे.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>पासवर्डने लॉगिन करा</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ब्राउझर वापरून लॉगिन करा</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>अलीकडे वापरलेले</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>बुकमार्कचा रंग बदलला</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>ट्रॅकांचा रंग बदलला</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>स्पेक्ट्रम</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>स्लायडर्स</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>लाल</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>हिरवा</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>निळा</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB हेक्स रंग #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>ग्रिड</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/mt/omim.ts
+++ b/qt/translations/mt/omim.ts
@@ -1,0 +1,3939 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="mt">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Lura</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Ikkanċella</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Ħassar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Niżżel il-mappa</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>It-tniżżil falla. Għaffas biex terġa tipprova.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Tniżżil…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mili</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Aktar tard</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Fittex</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Fittex fuq il-mappa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Bħalissa għandek kull Servizzi tal-Lokażżjoni fuq dan l-apparat jew l-applikazzjoni mitfijin. Jekk jogħġbok erġa ixgħelhom ġos-Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Preċiżjoni Limitata</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Biex tassigura navigazzjoni preċisa ixgħel Precise Location ġewwa is-Settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Uri fuq il-mappa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>It-tniżżil falla</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Erġa prova</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Dwar Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>B&#x27; xejn għal kulħadd, magħmul bl-imħabba</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Bla reklami, bla traċċar, bla kollezjoni ta&#x27; data</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Bla ħela ta&#x27; batterija, jaħdem offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Malajr, minimalista, żvillupat mill-komunità</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Apliażżjoni tas-sors miftuħ magħmula min dilettanti u il-voluntiera</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Settings tal-lokażżjoni</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Ġħalaq</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>L-applikazzjoni għanda bżonn &#x27;hardware accelerated OpenGL&#x27;. Sfortunatament, l-apparat tiegħek ma jappoġġjax dan.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Niżżel</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Jekk jogħġbok neħħi il-USB kejbil jew daħħal karta tal-memorja biex tuża Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Jekk jogħġbok żid ftit spazju fuq il-karta tal-memorja jew il-ħażna tal-USB biex tkun tista tuża l-applikazzjoni</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Qabel ma tibda tuża l-applikazzjoni, niżżel il-mappa ġenerali tad-dinja fuq l-apparat.&#32;
+Dan ser juża %1 ta&#x27; storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Mur għal Mappa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Tniżżil %1. Issa tista
+tkompli għal mappa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Tniżżel %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Aġġorna %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pawsa</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Kompli</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 tniżżil falla</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Żid lista ġdida</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Isem tal-lista tal-Bookmark</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Werrejja</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Werrejja u Korsiji</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Isem</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Indirizz</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Issalvagwardja il-mapep ġo</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Għażel il-post fejn tixtieq tniżżel il-mapep.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapep imniżżla</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 b&#x27; xejn min %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Iċċaqlaq il-mapep?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Errur waqt it-tmexxija tal-fajls tal-mapep</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Din tista tieħu diversi minuti.
+Jekk jogħġbok stenna…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unitajiet tal-kejl</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Għażel bejn mili u kilometri</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Ikkanċella it-Tniżżil</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Ħalli reviżjoni</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Iva</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Niżżel il-mappa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Listi tal-Bookmark</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Għażel fejn tiekol</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Tal-Merċa</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Trasport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gass</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkeġġ</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Xiri</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Użati</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Lukanda</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Siti</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Divertiment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Ħajja tal-lejl</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Vaganza tal-Familja</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Spiżerija</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Sptar</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Loki</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Uffiċċju postali</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Puliżija</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Riċiklaġġ</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Ilma</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Faċilitajiet tal-RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Noti</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks maqsuma miegħek</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Helow!
+
+Mehmuża huma il-bookmarks; iftaħhom ġo Organic Maps. Jekk mhuwiex installat tista tniżżlu min hawn: https://omaps.app/get?kmz
+
+Ħu pjaċir ivvjaġġa ġo Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Tgħobijja tal-bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks mgħobbija b&#x27;suċċess!Tista issibhom ġol-mappa jew fuq l-iskrin tal-Maniġer tal-Bookmarks.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>It-tgħobbija tal-bookmarks falliet. Il-fajl jista jkun korrott jew difettuż.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>It-tip tal-fajl mhuwiex rikonoxxut mill-applikazzjoni:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Il-fajl falla biex jiftaħ %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editja</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Il-lokażżjoni tiegħek mhuwiex determinat s&#x27;issa</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Jiddispjaċini, is-settings tal-Ħażna tal-Mappa huma mitfija bħalissa.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>It-tniżżil tal-mappa għaddej bħalissa.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Ara il-lokażżjoni kurrenti tiegħi ġo Organic Maps! %1 or %2 M&#x27;għandekx mapep offlajn? Niżżel hawn: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Merħba, ara il-pin tiegħi fuq Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Merħba, ara il-lokażżjoni kurrenti tiegħi fuq il-mappa ta&#x27;Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Merħba,&#32;
+
+Jien qiegħed hawn: %1. Għaffas din il-link %2 jew fuq din %3 biex tara il-post fuq il-mappa.
+
+Grazzi.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Aqsam</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mejl</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Ikkupjat fil-klibbord: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Lest</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dejta tal-OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ċert li trid toħroġ mill-akkount tal-OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Korsa</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Tul</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Ixxerja l-post tiegħi</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Settings ġenerali</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informazzjoni</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigazzjoni</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Il-buttuni + u - fuq il-mappa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Uri fuq il-mappa</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Stil bil-lejl meta tkun qed tinnaviga fid-dlam</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Il-mod ta’ bil-lejl</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Itfi</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Ixgħel</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Dehra tal-perspettiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Bini 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Il-binjiet 3D huma mitfigħin fil-mod tal-iffrankar tal-enerġija</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Istruzzjonijiet tal-vuċi</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Ħabbar l-ismijiet tat-toroq</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Meta jkun attivat, l-isem tat-triq jew tal-ħruġ biex iddur fuqu se jiġi mitkellem b’ leħen għoli.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Lingwa tal-vuċi</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Biex tniżżel vuċi ta&#x27; kwalità ogħla, iftaħ l-app Settings u mur Aċċessibbiltà → VoiceOver → Diskors → Vuċi.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Ittestja id-Direzzjonijiet tal-vuċi (TTS, Test għad-diskors)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Iċċekkja l-volum jew is-settings tal-Vuċi għad-diskors tas-sistema jekk ma tismax il-vuċi issa.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Mhux disponibbli</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Iżżumja awtomatikament</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distanza</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Uri fuq il-mappa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Websajt</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Aħbarijiet</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Għati rata lill-app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Għajnuna</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Mistoqsijiet Frekwenti</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donazzjoni</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Ġa mogħtija id-donazzjoni</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Fakkar aktar tard</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Appoġġja lill-Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Appoġġja lill-proġett</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Drittijiet tal-awtur</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Irrapporta problemi bl-app</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Tejjeb id-direzzjoni tal-vleġġa billi tmexxi l-mowbajl f’ moviment figure-eight biex tikkalibra l-boxxla.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mexxi l-mowbajl f&#x27; moviment figura-tmienja biex tikkalibra l-boxxla u tiffissa d-direzzjoni vleġġa fuq il-mappa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Taptap fit-tul fuq il-mappa għal darb’ oħra biex tara l-interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aġġorna kollox</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Ikkanċella kollox</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Imniżżla</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Fil-kju</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Ħdejja</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mappep</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Niżżel kollox</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Tniżżil:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Biex tħassar il-mappa, waqqaf in-navigazzjoni.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Jistgħu jinħolqu rotot biss li jinsabu kompletament f’ mappa ta’ reġjun wieħed.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Niżżel il-mappa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Erġa ’pprova</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Ħassar il-Mappa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aġġorna l-Mappa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servizzi ta&#x27; Lokalizzazzjoni ta&#x27; Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Iddetermina malajr il-post approssimattiv tiegħek billi tuża Bluetooth, WiFi, jew netwerk mobbli</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Niżżel il-mapep kollha tul ir-rotta tiegħek</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Niżżel il-mapep kollha tul ir-rotta tiegħek.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Mhux biżżejjed spazju</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Attiva s-servizzi tal-post</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Issejvja</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>Oħloq</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Aħmar</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Isfar</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Aħdar</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Vjola</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranġjo</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Kannella</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Roża</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Vjola Fond</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Blu Ċar</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Blu jagħti fl-aħdar</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Oranġjo Fond</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Griż</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blu Griż</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informazzjoni</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Verżjoni ta&#x27; Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Dehra</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Ċar</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Skur</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Ċar mill-għodwa sal-għaxija</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Oħrajn</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Agħti mapep b&#x27;xejn u bla reklami lil miljuni ta&#x27; utenti!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Irrapporta jew sewwi informazzjoni żbaljata tal-mappa</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Voluntier</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Segwi u kkuntattjana:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Il-klijent tal-posta elettronika ma ġiex ikkonfigurat. Jekk jogħġbok ikkonfiguraha jew ikkuntattjana fuq %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Żball meta bgħatt e-mejl</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrazzjoni tal-boxxla</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponibbli</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Misjuba</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aġġorna</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Falla</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Meta ssegwi r-rotta, jekk jogħġbok żomm f’ moħħok:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Il-kundizzjonijiet tat-toroq, il-liġijiet tat-traffiku, u s-sinjali tat-toroq dejjem jieħdu preċedenza fuq il-ħjiel tan-navigazzjoni;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Il-mappa tista ’ma tkunx preċiża, u r-rotta ssuġġerita mhux dejjem tista’ tkun l-aħjar mod biex tasal fid-destinazzjoni;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Ir-rotot issuġġeriti għandhom jinftiehmu biss bħala rakkomandazzjonijiet;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Oqgħod attent bir-rotot fiż-żoni tal-fruntiera: ir-rotot maħluqa mill-app tagħna xi kultant jistgħu jaqsmu l-fruntieri tal-pajjiż f ’postijiet mhux awtorizzati.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Jekk jogħġbok ibqa ’attent u sikur fit-toroq!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Iċċekkja s-sinjal tal-GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Ma jistax joħloq rotta. Il-koordinati attwali tal-GPS ma setgħux jiġu identifikati.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Jekk jogħġbok iċċekkja s-sinjal tal-GPS tiegħek. L-attivazzjoni tal-Wi-Fi ttejjeb il-preċiżjoni tal-post tiegħek.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Attiva s-servizzi tal-post</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Ma jistax isib il-koordinati GPS attwali. Attiva s-servizzi tal-post biex tikkalkula r-rotta.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Ir-rotta ma&#x27; tistax tinsab</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Ir-rotta ma&#x27; tistax tinħoloq.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Irranġa l-punt tal-bidu jew id-destinazzjoni tiegħek.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Irranġa l-punt tat-tluq</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Ir-rotta ma&#x27; nħolqitx. Il-punt tal-bidu ma&#x27; jistax jinsab.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Jekk jogħġbok agħżel punt tat-tluq eqreb lejn triq.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Irranġa d-destinazzjoni</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Ir-rotta ma nħolqitx. Id-destinazzjoni ma&#x27; tistax tinsab.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Agħżel punt ta’ destinazzjoni li jinsab eqreb ta’ triq.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Il-punt intermedju ma&#x27; jistax jinsab.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Jekk jogħġbok irranġa l-punt intermedju tiegħek.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Żball fis-sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Ir-rotta ma&#x27; tistax tinħoloq minħabba żball fl-applikazzjoni.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Jekk jogħġbok erġa ’pprova</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Mhux issa</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Tixtieq tniżżel il-mappa u toħloq rotta aktar ottimali li tkopri aktar minn mappa waħda?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Niżżel mapep addizzjonali biex toħloq rotta aħjar li taqsam il-konfini ta ’din il-mappa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Niżżel il-fajls meħtieġa</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Niżżel jew aġġorna l-mapep kollha tul il-mogħdija projettata biex tikkalkula rotta.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Biex tibda tfittex u toħloq rotot, jekk jogħġbok niżżel il-mappa. Wara dan ma jkollokx bżonn aktar konnessjoni mal-Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Agħżel il-Mappa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Uri</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Aħbi</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategoriji</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Kronoloġija</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, ma nstab l-ebda riżultat.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Niżżel ir-reġjun fejn qed tfittex jew ipprova żid isem ta’ belt/raħal fil-qrib.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Kronoloġija tat-tiftix</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ara t-tfittxijiet riċenti tiegħek.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Neħħi l-kronoloġija tat-tiftix</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artiklu minn wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Il-Lokazzjoni Tiegħek</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Ibda</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Rotta minn</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rotta lejn</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>In-navigazzjoni hija disponibbli biss mill-post attwali tiegħek.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Tixtieq tippjana rotta mill-post attwali tiegħek?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Li jmiss</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Minn</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Sa</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Żid Skeda</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Ħassar l-Iskeda</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Il-Ġurnata Kollha (24 siegħa)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Miftuħ</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Magħluq</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Żid Ħinijiet Mhux tan-Negozju</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Sigħat tan-Negozju</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mod Avvanzat</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mod Sempliċi</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Ħinijiet Mhux tan-Negozju</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valuri tal-Eżempju</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Irranġa żball</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Agħżel il-Post</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Jekk jogħġbok iddeskrivi l-problema fid-dettall sabiex il-komunita OpenStreetMap tkun tista ’tirranġaha.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Jew agħmilha int stess f’ https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Ibgħat</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Kwistjoni</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Dan il-post ma jeżistix</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Magħluq għall-manutenzjoni</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Post Duplikat</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Mapep Jitniżżlu Awtomatikament</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Kuljum</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Magħluq illum</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Magħluq</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Illum</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Jiftaħ f’ %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Jagħlaq f’ %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Magħluq</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editja s-sigħat tan-negozju</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>M’ għandekx kont ta’ OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Irreġistra f’ OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Illoggja</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Mhux imdaħħal</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Illoggja f’ OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Insejt il-password tiegħek?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Oħroġ</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editja l-Post</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Żid lingwa</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Triq</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numru tal-bini</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Dettalji</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Midja Soċjali</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bini</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Żid triq</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Daħħal isem tat-triq</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Agħżel lingwa</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Agħżel triq</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kċina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Agħżel il-kċina</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mejl jew isem l-utent</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Żid in-Numru tat-Telefown</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Livell</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Livell: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>L-editti kollha tal-mappa tiegħek se jitħassru mal-mappa.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Aġġorna l-Mapep</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Biex toħloq rotta, trid taġġorna l-mapep kollha u mbagħad terġa ’tippjana r-rotta.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Sib mappa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Żgura li t-tagħmir tiegħek huwa mqabbad mal-Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Mhux biżżejjed spazju</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Ħassar kwalunkwe dejta mhux neċessarja</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Żball tal-illoggjar.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Bidliet Ivverifikati</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Mexxi l-mappa biex tqiegħed is-salib fil-post tal-post jew tan-negozju.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editjar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Żiddiet</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Isem tal-post</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Kif inhi miktuba bil-lingwa lokali</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorija</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Deskrizzjoni dettaljata tal-kwistjoni</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Problema differenti</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Żid in-negozju</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ebda oġġett ma jista&#x27; jinstab hawn</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dejta tal-OpenStreetMap maħluqa mill-komunita’ fl-%1. Sir af aktar dwar kif teditja u taġġorna l-mappa f’ OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) huwa proġett komunitarju biex jinbena mappa ħielsa u miftuħa. Huwa s-sors ewlieni tad-dejta tal-mappa fl-Organic Maps, u jaħdem b&#x27;mod simili għal Wikipedia. Tista&#x27; żżid jew teditja postijiet u dawn isiru disponibbli għal miljuni ta&#x27; utenti madwar id-dinja. Ingħaqad mal-komunità u għin biex toħloq mappa aħjar għal kulħadd!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Oħloq kont OpenStreetMap jew idħol biex tippubblika l-editjar tal-mapep tiegħek fid-dinja.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 ta&#x27; %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Niżżel fuq konnessjoni tan-netwerk ċellulari?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Dan jista’ jkun konsiderevolment għali b’ xi pjanijiet tal-mowbajl jew jekk qed tuża&#x27; r-roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Daħħal numru tal-bini validu</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Numru ta’ sulari (massimu ta’ %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>In-numru ta’ sulari m’ għandux jaqbeż il-%1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Kodiċi ZIP</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Daħħal kodiċi ZIP validu</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota lill-voluntiera ta’ OpenStreetMap (fakultattiva)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Iddeskrivi l-iżbalji fuq il-mappa jew l-affarijiet li ma jistgħux jiġu editjati ġewwa Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>L-editjar tiegħek jittella’ fid-database pubblika &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;ta’ OpenStreetMap&lt;/a&gt;. Jekk jogħġbok iżżidx informazzjoni personali jew bid-drittijiet tal-awtur.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Aktar dwar OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Il-kronoloġija tal-editjar tiegħek</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>In-noti tad-dejta tal-mappa tiegħek</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatur</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatur: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Ma tistax isib kategorija adattata?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps jippermetti li jiżdiedu kategoriji punti sempliċi biss, li jfisser l-ebda bliet, toroq, lagi, linji ġenerali tal-bini, eċċ. Jekk jogħġbok żid dawn il-kategoriji direttament mal-&lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Iċċekkja l-&lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;gwida&lt;/a&gt; tagħna għal struzzjonijiet dettaljati.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Ma niżżilt l-ebda mapep</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Niżżel mapep biex tfittex u tinnaviga mingħajr l-użu tal-Internet.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Il-post attwali mhux magħruf.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Aktar</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editja l-Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Noti personali (kitba jew html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kumment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Armi l-bidliet lokali kollha?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Armi</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Ħassar il-post miżjud?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Ħassar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Il-post ma&#x27; jeżistix</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Jekk jogħġbok indika r-raġuni għat-tħassir tal-post</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Daħħal numru tat-telefown validu</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Daħħal indirizz validu tal-web</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Daħħal l&#x27; e-mejl</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Daħħal indirizz tal-web, kont, jew isem tal-paġna validu ta ’Facebook</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Daħħal isem l-utent jew indirizz tal-web validu ta’ Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Daħħal isem l-utent jew indirizz tal-web validu ta’ Twitter</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Daħħal isem l-utent jew indirizz tal-web validu ta&#x27; VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Daħħal ID tal-LINJA jew indirizz tal-web validu</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Żid post f’ OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Jew, bħala alternattiva, ħalli nota lill-komunità ta&#x27; OpenStreetMap sabiex xi ħadd ieħor ikun jista&#x27; iżid jew jissistema post hawn.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Nota se tintbagħat lil OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Tixtieq tibgħatha lill-utenti kollha?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Kun ċert li ma daħħalt l-ebda informazzjoni privata jew personali.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>L-edituri ta’ OpenStreetMap ser jiċċekkjaw il-bidliet u jikkuntattjawk jekk ikollhom xi mistoqsijiet.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Waqqaf</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Reġistrazzjoni tal-korsija</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aċċetta</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Irrifjuta</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Uża l-internet mobbli biex turi informazzjoni dettaljata?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Uża Dejjem</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Illum Biss</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Tużax Illum</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet Mobbli</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>L-internet mobbli huwa meħtieġ għan-notifiki tal-aġġornament tal-mapep u għat-tlugħ tal-editjar.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Tuża Qatt</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Staqsi Dejjem</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Biex tintwera d-dejta dwar it-traffiku, il-mapep iridu jiġu aġġornati.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Żid id-daqs għat-tikketti tal-mapep</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Aġġorna Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>L-Informazzjoni dwar it-traffiku mhijiex disponibbli</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Attiva l-illoggjar</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Feedback Ġenerali</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Aħna nużaw is-sistema TTS għall-istruzzjonijiet bil-vuċi. Ħafna apparati Android jużaw Google TTS, tista&#x27; tniżżlu jew taġġornah minn Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Għal xi lingwi, se jkollok bżonn tinstalla sintetizzatur tad-diskors jew pakkett tal-lingwa addizzjonali mill-App Store (Google Play, Galaxy Store, App Gallery, FDroid).
+Iftaħ is-settings tat-tagħmir → Language and input → Speech → Text to speech output.
+Hawnhekk tista’ timmaniġġja s-settings għas-sinteżi tad-diskors (pereżempju, niżżel il-pakkett tal-lingwa għall-użu offline) u agħżel magna oħra minn kitba għal diskors.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Għal aktar informazzjoni jekk jogħġbok iċċekkja din il-gwida.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Jittraduċi ruħu fl-alfabett Latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Tgħallem iktar</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Uża t-tiftix jew għafas fuq il-mappa biex iżżid punt tal-bidu tar-rotta</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Uża t-tiftixa jew għafas fuq il-mappa biex iżżid punt tad-destinazzjoni</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Immaniġġja r-Rotta</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Pjan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Neħħi l-Waqfa</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Żid Waqfa</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Salvat</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Illoggja f’ OpenStreetMap biex awtomatikament ittella’ l-editjar kollu tal-mappa tiegħek. Tgħallem aktar &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hawn&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema tal-aċċess għall-ħażna</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Il-ħżin estern mhuwiex aċċessibbli. Il-kard tal-SD setgħet tneħħiet, saritilha l-ħsara, jew is-sistema tal-fajl tinqara biss. Jekk jogħġbok, iċċekkja l-karta tal-SD tiegħek jew ikkuntattjana fuq support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Imita ħażna ħażina</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Daħħal isem korrett</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listi</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Aħbi kollox</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Uri kollox</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>bookmark ta&#x27; %n</numerusform>
+<numerusform>bookmarks ta&#x27; %n</numerusform>
+<numerusform>bookmarks ta&#x27; %n</numerusform>
+<numerusform>bookmarks ta&#x27; %n</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Oħloq lista ġdida</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importa l-Bookmarks u l-Korsiji</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Ma jistax jixxerja minħabba żball fl-applikazzjoni</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Żball fl-ixxerjar</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Ma tistax tixxerja lista vojta</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>L-isem ma jistax ikun vojt</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Daħħal l-isem tal-lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Lista ġdida</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Dan l-isem diġa meħud</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Agħżel isem ieħor</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Stenna ftit…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numru tat-telefown</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil ta’ OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Instab fajl %n. Tista’ tarah wara l-konverżjoni.</numerusform>
+<numerusform>Instabu %n fajls. Tista ’tarahom wara l-konverżjoni.</numerusform>
+<numerusform>Instabu %n fajls. Tista ’tarahom wara l-konverżjoni.</numerusform>
+<numerusform>Instabu %n fajls. Tista ’tarahom wara l-konverżjoni.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Irrestawra</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>Trekk %n</numerusform>
+<numerusform>%n Trekks</numerusform>
+<numerusform>%n Trekks</numerusform>
+<numerusform>%n Trekks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatezza</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politika dwar il-privatezza</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Termini tal-użu</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffiku</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Mixi</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ċikliżmu</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stili u Saffi tal-Mapep</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Din il-lista hija vojta</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Biex iżżid bookmark, għafas post fuq il-mappa u mbagħad għafas is-simbolu tal-istilla</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Ibdel il-kulur tal-bookmarks kollha</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Ibdel il-kulur tat-tracks kollha</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…aktar</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Esporta KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Esporta GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Esporta GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Ħassar il-lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Kameras tal-veloċita</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Deskrizzjoni tal-Post</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Tniżżil ta’ mapep</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Wissi jekk għaddej b&#x27; veloċita qawwija</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Dejjem wissi</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Qatt twissi</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mod ta’ ffrankar tal-enerġija</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Ipprova naqqas l-użu tal-enerġija għad-detriment ta’ xi funzjonalitajiet.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Qatt</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Meta l-batterija tkun baxxa</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Dejjem</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Ismijiet tal-bookmark fuq il-mappa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Jekk hemm wisq bookmarkijiet, l-esibizzjoni tal-ismijiet tagħhom fuq il-mappa tista&#x27; tnaqqas il-veloċità tal-app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Uri fuq il-lemin</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Uri fil-qiegħ</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Attiva din l-għażla biex tirrekordja u tibgħat manwalment dijanjostiċi dettaljati dwar il-kwistjoni tiegħek lilna billi tuża “Irrapporta problemi” fid-djalogu għajnuna. Ir-reġistri jistgħu jinkludu informazzjoni dwar il-post.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Għażliet tar-rotta</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evita ħlasijiet għall-użu tat-triq</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evita toroq mhux pavimentati</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evita l-laneċ</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evita l-passaġġi ħielsa</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Ir-rotta ma&#x27; tistax tiġi kalkulata</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Ma setgħetx tinstab rotta. Dan jista’ jkun ikkawżat mill-għażliet tar-rotta tiegħek jew mil-informazzjoni mhux kompluta ta’ OpenStreetMap. Ibdel l-għażliet tar-rotta tiegħek u erġa ’pprova.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Iddefinixxi t-toroq li tixtieq tevita</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Għażliet tar-rotta attivati</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Triq għall-pedaġġ</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Triq mhux pavimentata</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Qsim bil-lanċa</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Iva</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Le</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Iva</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Le</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapaċita: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netwerk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Wasalt!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Issortja…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Issortja l-bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>B’ mod awtomatiku</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Skont it-tip</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Skont id-distanza</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Skont id-data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Skont l-isem</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Ġimgħa ilu</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Xahar ilu</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Aktar minn xahar ilu</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Aktar minn sena ilu</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Ħdejja</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Oħrajn</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>L-Ippjanar tar-rotta ma rnexxiex</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Wasla fil-%1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Niżżel u aġġorna l-mappa kollha tul il-mogħdija proġettata biex tikkalkula r-rotta.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Biddilt il-mappa tad-dinja! Iżżommhiex għalik innifsek; għid lil sħabek u editjawha flimkien.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Ixxerja mal-ħbieb</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Magħluq issa</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Jiftaħ għada fil-%1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Jiftaħ %1 fl-%2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Jiftaħ f &#x27; %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Jagħlaq f ’ %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Żid il-ħinijiet tal-ftuħ</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (minimu ta&#x27; 8 karattri)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Isem tal-utent jew password mhux valida.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Kont ta&#x27; OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>L-aħħar tella&#x27;</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Grazzi</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Isem tal-post</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Jekk jogħġbok innota</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Żball fit-tniżżil</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Agħżel kategorija</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popolari</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kategoriji kollha</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Żid postijiet ġodda mal-mappa, u editja dawk eżistenti direttament mill-app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Biddel il-post</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Biex tniżżel, għandek bżonn aktar spazju. Jekk jogħġbok ħassar kwalunkwe data mhux meħtieġa.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ittejjibt il-mappijiet tal-Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Kumment dettaljat</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Il-bidliet fil-mappa li ssuġġerejt se jintbagħtu lill-komunità ta&#x27; OpenStreetMap. Jekk jogħġbok, iddeskrivi kwalunkwe dettalji addizzjonali li ma jistgħux jiġu editjati f&#x27;Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Seħħ żball waqt id-determinazzjoni tal-post tiegħek. Iċċekkja li t-tagħmir tiegħek qed jaħdem kif suppost u ipprova mill-ġdid aktar tard.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Is-servizzi tal-lokazzjoni huma diżattivati</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Ippermetti l-aċċess għall-ġeolokazzjoni fl-issettjarijiet tal-apparat</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Iftaħ l-issettjarijiet</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Agħfas fuq Postazzjoni</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Agħżel Waqt l-Użu tal-App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Agħżel Privatità</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Agħżel Servizzi tal-Post</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ixgħel is-Servizzi tal-Post</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Jew kompli tuża Organic Maps mingħajr il-pożizzjoni</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Ktieb</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Sejħa</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Isem tal-marka tal-paġna</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Ħassar il-marka tal-paġna</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>In-nota tiegħek se tintbagħat lil OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…aktar</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aġġornament</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Tiddiżattiva r-reġistrazzjoni tar-rotta li għadek kemm għaddejtha?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Diżattiva</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Ħares</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps tuża l-lokazzjoni tiegħek fil-isfond biex tirreġistra r-rotta li għadek kemm għaddejt minnha.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Is-settings ġenerali</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Biex turi d-dejta tat-traffiku, l-applikazzjoni trid tiġi aġġornata.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Daqs tal-fajl tal-log: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Iġbed hawn biex tneħħi</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Biddel Waqaf</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Ibda minn</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Jekk jogħġbok idħol f&#x27;OpenStreetMap biex ittella&#x27; awtomatikament il-bidliet kollha tal-mappa tiegħek. Tgħallem aktar</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hawn</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Aħbi l-iskrin</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 ta&#x27; %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Niżżel %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applikazzjoni ta&#x27; %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Dan l-isem hu twil wisq</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Fajls ġodda skoperti</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Ikkonverti</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Żball</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Xi fajls ma ġewx ikkonvertiti.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Seħħ żball</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popolari</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Aħbi mill-mappa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Seħħ żball waqt it-tagħbija tat-tikketti, jekk jogħġbok ipprova mill-ġdid</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Lemin</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Qiegħ</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Ejja mmorru</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinazzjoni</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Irriċentra</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Riżultati tat-tfittxija</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Imbagħad</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Trid terġa&#x27; tibni r-rotta?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Il-tastiera mhix disponibbli waqt is-sewqan</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Ma jistax jinbena rotta mill-post attwali tiegħek</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Ma nistax insib rotta lejn id-destinazzjoni tiegħek. Jekk jogħġbok agħżel punt finali ieħor</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>M&#x27;hemmx sinjal GPS. Jekk jogħġbok mur f&#x27;żona miftuħa</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Ma jistax jinbena rotta. Jekk jogħġbok speċifika punti oħra tar-rotta</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Biex toħloq rotta, niżżel il-mappijiet nieqsa fuq it-tagħmir tiegħek</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Seħħ żball. Jekk jogħġbok erġa&#x27; ibda l-applikazzjoni</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Il-rotta se terġa&#x27; tinbena mill-post attwali tiegħek</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Ir-rotta se tiġi kkonvertita f&#x27;rotta għall-karozza</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Mhux il-bookmarks kollha huma murija</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Ibdel għall-mowbajl biex tara l-marki kollha</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kameras tal-veloċità</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Twissijiet dwar il-veloċità</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Jekk jogħġbok niżżel il-mappijiet fl-app fuq it-tagħmir mobbli tiegħek</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 ħruġ</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordna skont id-default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordna skont it-tip</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordna skont id-distanza</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordna skont id-data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordna skont l-isem</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Ikel</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Siti</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Mużewijiet</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parkijiet</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Għawm</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Muntanji</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Annimali</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Lukandi</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Bini</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Flus</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Ħwienet</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkeġġi</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Stazzjonijiet tal-Gass</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Mediċina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Fittex fil-lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Postijiet reliġjużi</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Agħżel il-lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>In-navigazzjoni tas-subway f’ dan ir-reġjun għadha mhix disponibbli</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Ma nstabet l-ebda rotta tas-subway</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Agħżel punt tal-bidu jew tat-tmiem eqreb lejn stazzjon tas-subway</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Linji tal-Contour</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>L-attivazzjoni tal-linji tal-contour teħtieġ it-tniżżil tad-dejta tal-mappa għal din iż-żona</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Il-linji tal-Contour għadhom mhumiex disponibbli f ’din iż-żona</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Tlugħ</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Inżul</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevazzjoni minima</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevazzjoni massima</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Diffikulta’</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distanza:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Ħin:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Iżżumja ’l ġewwa biex tesplora l-isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Tniżżil</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Niżżel il-mappa ġenerali tad-dinja</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Ma jistax joħloq fowlder u jmexxi fajls fuq il-memorja tat-tagħmir intern jew l-SD card</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Żball fid-diska</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Falliment tal-konnessjoni</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Aqla&#x27; l-kejbil tal-USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Żomm l-iskrin mixgħul</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Meta attivat, l-iskrin dejjem se jkun mixgħul meta juri l-mappa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Uri fuq l-iskrin imsakkar</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Meta tkun attivata, l-applikazzjoni taħdem fuq il-lockscreen anki meta t-tagħmir ikun imsakkar.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Lingwa tal-mappa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Informazzjoni tal-mappa minn OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Grazzi talli użajtu l-mapep tagħna mibnija mill-komunita’!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Bid-donazzjonijiet u l-appoġġ tiegħek, nistgħu noħolqu l-aqwa mapep fid-dinja!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Togħġbok l-app tagħna? Jekk jogħġbok agħti donazzjoni biex tappoġġja l-iżvilupp! Għadha ma togħġbokx? Jekk jogħġbok għidilna għaliex, u nirranġawha!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Jekk taf żviluppatur tas-softwer, tista’ titolbu jimplimenta il-karatteristika li għandek bżonn.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Għafas kullimkien fuq il-mappa biex tagħżel xi ħaġa. Tgħafisa twila tista&#x27; tintuża biex taħbi u turi l-interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Kont taf li l-post attwali tiegħek fuq il-mappa jista’ jintgħażel?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Tista’ tgħin sabiex tittraduċi l-applikazzjoni tagħna fil-lingwa tiegħek.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>L-app tagħna hija żviluppata minn ftit dilettanti u l-komunita’.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Tista’ faċilment tirranġa u ttejjeb l-informazzjoni tal-mappa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>L-għan ewlieni tagħna huwa li nibnu mapep veloċi, iffukati fuq il-privatezza, u faċli biex jintużaw li se jinħabbu.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Issa qed tuża Organic Maps fuq l-iskrin tat-telefown</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Issa qed tuża Organic Maps fuq l-iskrin tal-karozza</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Int imqabbad ma’ Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Kompli fuq il-mowbajl</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Lejn l-iskrin tal-karozza</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps teħtieġ aċċess għall-post. Meta jkun sigur, iċċekkja n-notifika fuq il-mowbajl tiegħek.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Din l-applikazzjoni teħtieġ il-permess tiegħek</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps ġo’ Android Auto jeħtieġ permessi tal-post biex jaħdem b ‘mod effettiv</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Għati Permess</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Fil-beraħ</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Brawżer tal-web mhux disponibbli</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volum</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Esporta l-bookmarks u l-korsiji kollha</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Settings tas-sistema tas-sinteżi tad-diskors</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Is-settings tas-Sinteżi tad-diskors ma nstabux, żgur li t-tagħmir tiegħek jappoġġjah?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Neħħi t-tiftixa</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Iżżumja ’l ġewwa</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Iżżumja ’l barra</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link tal-menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ara l-Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Iftaħ f’ Applikazzjoni Oħra</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Agħżel l-għażla</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sedili barra</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Għan-navigazzjoni l-aktar preċiża, nirrakkomandaw li titfi l-mod tal-iffrankar tal-enerġija fl-issettjar tal-batterija tal-mowbajl.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Rekord Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Waqqaf ir-reġistrazzjoni tal-korsa</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Irrekordjar tat-Traċċa</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Waqqaf Mingħajr ma&#x27; Tissejvja</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Kompli rrekordja</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Issejvja fil-Bookmarks u l-Korsiji?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Il-Korsija hija vojta - xejn x’ tissejvja</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Ma jistax juri d-djalogu tal-għażla tal-fowlder għax l-ebda applikazzjoni xierqa mhi installata fuq it-tagħmir tiegħek. Installa applikazzjoni tal-maniġer tal-fajl u erġa ’pprova.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Agħżel Kulur</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editja l-Korsija</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ebda applikazzjoni installata li tista’ tiftaħ il-post</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto fin-navigazzjoni</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Segwi s-sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Iqassam il-Traċċa</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Ħassar %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Livell ta&#x27; diffikultà</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Faċli</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderata</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Ċast</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Qed taġġorna</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Aġġorna l-mapep mniżżla</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>L-aġġornament tal-mapep iżomm l-informazzjoni dwar l-oġġetti aġġornata</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Aġġorna (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Aġġorna manwalment aktar tard</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Ħassar il-Traċċa</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Inti ċert li trid tħassar din il-mogħdija?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Isem tal-korsa</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Ħawwad</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Traċċa</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Biddel il-kulur</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mappa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Tixtieq tibgħat rapport ta&#x27; żball lill-iżviluppaturi?
+Aħna niddependu fuq l-utenti tagħna għax Organic Maps ma jiġborx awtomatikament l-ebda informazzjoni dwar żbalji. Grazzi minn qabel talli tappoġġja Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Iattiva s-sinkronizzazzjoni tal-iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Is-sinkronizzazzjoni tal-iCloud hija karatteristika sperimentali għadha fl-iżvilupp. Kun żgur li għamilt kopja ta&#x27; backup ta&#x27; kull bookmark u traċċa tiegħek.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud huwa diżattivat</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Jekk jogħġbok,attiva l-iCloud fl-issettjar tal-apparat tiegħek biex tuża din il-karatteristika.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Attiva</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Rizerva</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Falliment fis-sinkronizzazzjoni tal-iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Żball: Ma rnexxiex is-sinkronizzazzjoni minħabba żball fil-konnessjoni</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Żball: Ma rnexxiex is-sinkronizzazzjoni minħabba li l-kwota tal-iCloud ġiet eċċeduta</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Żball: iCloud mhix disponibbli</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listi ta&#x27; dawk imħassra riċentement</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Ħassar</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Ħassar Kollha</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Irkupru</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Irkuprar Kollu</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Ikontribwixxi għal OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Żid Post</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Aġġorna l-mappa biex tikkontribwixxi</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Trid taġġorna l-mappa %1 għall-aħħar verżjoni qabel ma tkun tista&#x27; tikkontribwixxi għad-data ta&#x27; OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Il-Pożizzjoni Kurrenti</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Il-Postijiet Tiegħi</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Ħażna internali privata</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Ħażna internali maqsuma</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Karta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ħażna esterna maqsuma</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Kodiċi Postali</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Il-Punt tal-Mappa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Biex turi r-rotot, il-mappijiet iridu jiġu aġġornati.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Oħroġ</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Daħla</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Il-mappa tas-subway mhix disponibbli</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Int</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Reġjuni mniżżla vjola</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rotta</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Id-determinazzjoni tal-post fl-isfond hija meħtieġa biex tgawdi bis-sħiħ il-funzjonalità tal-app. Tintuża għan-navigazzjoni u biex tissejvja t-traċċa tiegħek li vvjaġġajt reċentement.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Id-determinazzjoni tal-post tiegħek hija meħtieġa għan-navigazzjoni u biex tissejvja t-traċċa tiegħek li vvjaġġajt reċentement.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login bil-password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login billi tuża l-browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Użat riċentement</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Il-kulur tal-bookmarks inbidel</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Il-kulur tat-tracks inbidel</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spettru</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sliders</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>AĦMAR</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>AĦDAR</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ĦAMRANI</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Kulur Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grilja</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/nb/omim.ts
+++ b/qt/translations/nb/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="nb">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Tilbake</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Slett</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Last ned kart</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Nedlastingen mislyktes – trykk på nytt for å prøve en gang til</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Laster ned …</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Senere</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Søk</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Søk kart</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Du har for øyeblikket deaktivert alle posisjonstjenester for denne enheten eller applikasjonen. Slå dem på i «Innstillinger».</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Begrenset nøyaktighet</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>For å sikre nøyaktig navigering aktiverer du Precise Location i innstillingene.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Vis på kartet</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Laster ned mislyktes</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Prøv på nytt</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Om Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis for alle, laget med kjærlighet</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Ingen annonser, ingen sporing, ingen datainnsamling</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Ingen batterislitasje, fungerer offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rask, minimalistisk, utviklet av fellesskapet</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open source-applikasjon opprettet av entusiaster og frivillige.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Innstillinger for plassering</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Lukk</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>En maskinvareakselerert OpenGL kreves. Dessverre støttes ikke enheten din.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Last ned</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Koble fra USB-kabelen eller sett inn minnekortet for å bruke Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Frigjør plass på SD-kortet/USB-enheten først for å bruke appen</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Før du begynner, la oss laste ned det generelle verdenskartet til enheten. Det trengs %1 med data.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Gå til kart</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Laster ned %1. Du kan nå
+fortsette til kartet.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Vil du laste ned %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Vil du oppdatere %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Fortsett</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Nedlasting av %1 mislyktes</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Legg til nytt sett</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bokmerk settnavn</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bokmerker</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bokmerker og ruter</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Navn</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresse</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Innstillinger</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Lagre kart på</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Velg hvor du vil at kartene skal lastes ned til</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Kart</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 ledig av %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Flytt kart?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Kunne ikke flytte kart</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Dette kan ta flere minutter.
+Vent et øyeblikk …</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Måleenheter</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Velg mellom miles og kilometer</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Avbryt nedlasting</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Legg inn en vurdering</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Last ned kart</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bokmerk sett</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Spisesteder</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Dagligvarer</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Drivstoff</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkering</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Brukt</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotell</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Severdigheter</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Underholdning</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Minibank</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nattliv</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Familieferie</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Sykehus</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toalett</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Politi</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Resirkulering</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vann</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Bobilanlegg</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Merknader</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Delte Organic Maps-bokmerker</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hei!
+
+Vedlagt er mine bokmerker fra Organic Maps-appen. Åpne de dersom du har Organic Maps installert. Har du ikke har det, last ned appen til iOS eller Android ved å trykke på denne linken: https://omaps.app/get?kmz
+
+Nyt reisen med Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Laster inn bokmerker</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bokmerkene ble lastet inn! Du finner dem på kartet eller på skjermen «Bokmerkeadministrasjon».</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Opplasting av bokmerker mislyktes. Filen kan være skadet eller defekt.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Filtypen gjenkjennes ikke av appen:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Kunne ikke åpne filen %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Rediger</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Posisjonen din har ikke blitt fastslått enda</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Beklager, innstillingene for kartlagring er for øyeblikket deaktivert.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Kartnedlasting pågår nå.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hei, se posisjonen min på Organic Maps! %1 eller %2 Har du ikke offline-kart? Last dem ned her: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hei, se merket mitt på Organic Maps-kartet</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hei, se posisjonen min på Organic Maps-kartet!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hei,Jeg er her nå: %1. Klikk på denne koblingen %2 eller denne %3 for å se stedet på kartet.
+
+Takk.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Del</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-post</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopiert til utklippstavlen: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Ferdig</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Er du sikker på at du vil logge ut av OpenStreetMap-kontoen din?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Ruter</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lengde</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Del posisjonen min</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Generelle instillinger</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informasjon</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigasjon</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Knappene + og - på kartet</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Vis på skjermen</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nattstil når du navigerer i mørket</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nattmodus</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Av</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>På</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivvisning</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Bygninger i 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-bygninger er slått av i strømsparingsmodus</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Taleinstrukser</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Kunngjør gatenavn</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Når aktivert, vil navnet på gaten eller avkjørselen du skal svinge inn på, bli lest opp.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Talespråk</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>For å laste ned en stemme med høyere kvalitet, åpne Innstillinger-appen og gå til Tilgjengelighet → VoiceOver → Tale → Stemme.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test taleanvisninger (TTS, tekst-til-tale)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kontroller volumet eller systeminnstillingene for tekst-til-tale hvis du ikke hører stemmen nå.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ikke tilgjengelig</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatisk zooming</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Avstand</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Vis på kartet</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Meny</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Nettside</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nyheter</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Tilbakemelding</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Ranger appen</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hjelp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Spørsmål og svar</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donere</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Allerede donert</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Påminn senere</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Støtt Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Støtt prosjektet</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Opphavsrett</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Rapporter en feil</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Forbedre pilretningen ved å bevege telefonen i en åttetallsbevegelse for å kalibrere kompasset.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Beveg telefonen i en åttetallsbevegelse for å kalibrere kompasset og fikse pilretningen på kartet.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Trykk lenge på kartet igjen for å se grensesnittet</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Oppdater alle</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Avbryt alle</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Lastet ned</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Lagt i kø</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>I nærheten</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kart</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Last ned alle</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Laster ned:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Stans navigeringen for å slette kartet.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Det kan bare opprettes ruter som passer fullstendig innenfor ett enkelt kart.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Last ned kartet</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Gjenta</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Slett kart</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Oppdater kart</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Stedstjenester</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Finn raskt ut din omtrentlige posisjon via Bluetooth, WiFi eller mobilnettverk</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Last ned kart langs ruten</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Når du skal opprette en rute må du ha oppdatert alle kartene fra ditt ståsted til din destinasjon.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ikke nok ledig minne</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Aktiver posisjonstjenester</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Lagre</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>opprett</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rød</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Gul</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blå</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Grønn</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Lilla</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oransje</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brun</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Mørkepurpur</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Lyseblå</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Blågrønn</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smaragdgrønn</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limegrønn</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Mørkeoransje</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grå</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gråblå</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informasjon</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps versjon: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Utseende</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Lys</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Mørke</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Lys fra daggry til skumring</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Andre</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gi gratis kart uten reklame til millioner av brukere!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Rapportere eller korrigere feil kartdata</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Frivillig arbeid</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Følg og kontakt oss:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-postklienten har ikke blitt konfigurert. Konfigurer den eller bruk en annen måte å kontakte oss på %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Feil ved sending av e-post</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompasskalibrering</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Tilgjengelig</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Funnet</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Oppdatering</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Mislyktes</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bokmerk</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Husk følgende når du følger ruten:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>– Veiforhold, trafikkregler og skilt skal alltid prioriteres fremfor navigasjonsråd;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>– Kartet kan inneholde unøyaktigheter, og den foreslåtte ruten er ikke nødvendigvis alltid den mest optimale veien;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>– Foreslåtte ruter bør bare anses som anbefalinger;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Vær forsiktig når det gjelder ruter i grenseområder: rutene som appen vår oppretter kan komme til å krysse landegrenser i uatoriserte områder;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Kjør trygt!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Sjekk GPS-signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Ingen rute ble opprettet. Nåværende GPS-koordinater ble ikke funnet.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Sjekk GPS-signalet. Resultatet blir mer nøyaktig når du bruker wi-fi.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktiver stedstjenester</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Nåværende GPS-koordinater ble ikke funnet. Aktiver stedstjenester for å beregne en rute.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Kunne ikke finne rute</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Kunne ikke finne rute.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Endre startpunkt eller bestemmelsessted.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Endre startpunkt</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Ingen rute ble opprettet. Startpunktet ble ikke funnet.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Velg et startpunkt som er i nærheten av en vei.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Endre bestemmelsessted</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Ingen rute ble opprettet. Bestemmelsesstedet ble ikke funnet.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Velg et bestemmelsessted som er i nærheten av en vei.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Kunne ikke finne mellomstopp.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Kontroller og juster mellomstopp.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systemfeil</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>En applikasjonsfeil førte til at ruten ikke kunne opprettes.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Vennligst prøv igjen</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ikke nå</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Vil du laste ned kartet og lage en mer optimal rute som går over flere kart?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Last ned kartet for å opprette en mer optimal rute som går utenfor dette kartet.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Last ned nødvendige filer</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Last ned og oppdater all kart- og ruteinformasjon langs den foreslåtte veien for å beregne ruten.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Last vennligst ned kartet for å begynne å søke og opprette ruter - så slipper du i fremtiden å være avhengig av å ha internettforbindelse.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Velg kartet</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Vis</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Skjul</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorier</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historikk</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Beklager, jeg fant ingenting.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Last ned regionen du søker i, eller prøv å legge til et bynavn i nærheten.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Søkehistorikk</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Vis de siste søkene raskt.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Tøm søkehistorikk</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikkel fra wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Din beliggenhet</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Fra</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rute til</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigering er kun tilgjengelig fra din nåværende beliggenhet.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Vil du vi skal planlegge en rute fra din nåværende posisjon?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Neste</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Fra</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Til</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Legg til tidsrom</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Slett tidsrom</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Hele dagen (24 timer)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Åpen</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Stengt</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Legg til stengt tid</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Åpningstider</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Avansert modus</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Enkel modus</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Stengt</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Eksempelverdier</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Rett feil</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Velg sted</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Beskriv problemet detaljert slik at OpenStreetMap-samfunnet kan fikse feilen.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Eller gjør det selv på https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Stedet finnes ikke</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Stengt pga. vedlikehold</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplisert sted</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatisk nedlasting</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daglig</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Dag og natt</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Fridag i dag</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Fridag</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>I dag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Åpner om %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Stenger om %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Stengt</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Rediger åpningstider</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Har du ingen konto hos OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrer deg</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Logg inn</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Ikke logget inn</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Logg på OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Passord</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Glemt passordet?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Logg ut</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Rediger stedet</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Legg til et språk</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Gate</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Et husnummer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detaljer</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sosiale medier</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bygning</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Legg til en gate</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Legg til en gateadresse</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Velg et språk</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Velg en gate</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Matrett</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Velg matrett</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-postadresse eller brukernavn</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Legg til telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Gulv</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivå: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alle endringer i kartet vil slettes sammen med kartet.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Oppdater kart</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>For å opprette en reiserute må du oppdatere alle kartene og deretter planlegge reiseruten på nytt.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Finn kartet</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Kontroller innstillingene dine og sørg for at enheten din er koblet til Internett.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ikke nok plass</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Fjern unødvendig data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Innloggingsfeil.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Bekreftede endringer</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Dra kartet for å plassere korset der stedet eller virksomheten befinner seg.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Redigerer</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Legger til</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Navn på stedet</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Som det står skrevet på det lokale språket</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategori</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detaljert beskrivelse av problemet</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Et annet problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Legg til organisasjon</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Et objekt kan ikke plasseres her</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Fellesskapsopprettede OpenStreetMap-data fra %1. Les mer om hvordan du redigerer og oppdaterer kartet på OpenStreetMap.org.</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) er et fellesskapsprosjekt for å bygge et gratis og åpent kart. Det er hovedkilden til kartdata i Organic Maps og fungerer på samme måte som Wikipedia. Du kan legge til eller redigere steder, og de blir tilgjengelige for millioner av brukere over hele verden.&#32;
+Bli med i fellesskapet og bidra til å lage et bedre kart for alle!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Opprett en OpenStreetMap-konto eller logg inn for å publisere kartredigeringene dine til hele verden.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 av %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Last ned med mobildata?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Dette kan medføre store kostnader med enkelte dataplaner eller om du roamer.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Skriv riktig husnummer</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Antall etasjer (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Rediger bygningen med maks. %1 etasjer</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postnummer</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Angi riktig postnummer</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Merknad til OpenStreetMap-frivillige (valgfritt)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beskriv feil på kartet eller ting som ikke kan redigeres med Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Dine endringer lastes opp til den offentlige &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-databasen. Vennligst ikke legg til personlig eller opphavsrettsbeskyttet informasjon.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mer om OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Din redigeringshistorikk</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Notater om kartdataene dine</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatør</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatør: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Finner du ikke en passende kategori?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps tillater kun å legge til enkle punktkategorier, det vil si ingen byer, veier, innsjøer, bygningsomriss osv. Vennligst legg til slike kategorier direkte til &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Sjekk vår &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detaljerte trinnvise instruksjoner.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Du har ikke lastet ned noen kart</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Last ned kart for å finne plasseringen og navigere frakoblet.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Gjeldende plassering er ukjent.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/t</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>t</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mer</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Rediger bokmerke</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personlige notater (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Nullstille alle lokale endringer?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Nullstill</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Fjerne et tilføyd sted?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Fjern</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Sted finnes ikke</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Forklar hvorfor stedet skal slettes</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Skriv riktig telefonnummer</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Oppgi en gyldig nettadresse</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Oppgi en gyldig epostadresse</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Skriv inn en gyldig Facebook-adresse, -konto eller -side.</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Skriv inn en gyldig Instagram-adresse eller -kontonavn</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Skriv inn en gyldig Twitter-adresse eller -brukernavn.</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Skriv inn en gyldig VB-adresse eller -kontonavn</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Skriv inn en gyldig LINE-adresse eller -ID.</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Legg til sted i OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Alternativt kan du legge igjen et notat til OpenStreetMap-fellesskapet, slik at noen andre kan legge til eller fikse et sted her.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Notat vil bli sendt til OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Vil du sende det til alle brukere?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Sørg for at du ikke har skrevet noe personlig informasjon.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-redaktører vil sjekke endringene og ta kontakt med deg hvis de har spørsmål.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stopp</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Registrere sporet</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Godta</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Avvis</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Bruke mobilt Internett til å vise detaljert informasjon?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Bruk alltid</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Bare i dag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Ikke bruk i dag</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilt Internett</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobilt Internett er nødvendig for å vise detaljert informasjon om steder, for eksempel fotografier, priser og anmeldelser.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Aldri bruk</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Alltid spør</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>For å vise trafikkdata må kartene i appen være oppdaterte.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Forstørr skriften på kartet</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Vennligst oppdater Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Trafikkdata er ikke tilgjengelig</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Aktiver loggføring</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Generell tilbakemelding</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Vi bruker system TTS for stemmeveiledning. Mange Android-enheter bruker Google TTS, Du kan laste ned eller oppdatere via Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For enkelte språk er det nødvendig å installere en annen talesyntese eller en ekstra språkpakke fra appbutikken (Google Play, Galaxy Store, App Gallery, FDroid).
+Gå til enhetens innstillinger → Språk og input → Tale → Tekst til tale output.
+Her kan du administrere innstillingene for talesyntese (for eksempel laste ned språkpakke for offline bruk) og velge en annen tekst-til-tale-motor.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Les denne veiledningen for mer informasjon.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Omskrivning til latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Finn ut mer</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Bruk søk eller trykk på kartet for å legge til et startpunkt for ruten</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Bruk søk eller trykk på kartet for å legge til et destinasjonspunkt</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Administrere rute</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planlegge</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Fjern stopp</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Angi stopp</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Reddet</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Logg inn på OpenStreetMap for automatisk å laste opp alle kartredigeringene dine. Finn ut mer &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;her&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problemer med tilgang til lagring</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ekstern lagring er ikke tilgjengelig. Sannsynligvis er SD-kortet fjernet eller skadet eller så er filsystemet skrivebeskyttet. Undersøk og kontakt oss på support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulere skadet lagring</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Skriv inn korrekt navn</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lister</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Skjul alle</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Vis alle</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bokmerke</numerusform>
+<numerusform>%n bokmerker</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Opprett ny liste</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importer bokmerker og spor</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Kan ikke dele på grunn av en programfeil</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Delingsfeil</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Kan ikke dele en tom liste</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Navnet kan ikke være tomt</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Vennligst skriv inn listenavnet</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Ny liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Dette navnet er allerede tatt</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Vennligst velg et annet navn</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Vennligst vent…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonnummer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fil funnet. Du vil se den etter konverteringen.</numerusform>
+<numerusform>%n filer funnet. Du vil se dem etter konverteringen.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurere</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n spor</numerusform>
+<numerusform>%n spor</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Personvern</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Personvernpolitikk</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Bruksbetingelser</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafikk</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Vandring</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Sykling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>T-bane</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kartstiler og -lag</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Denne listen er tom</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>For å legge til et bokmerke, trykk et sted på kartet og trykk så stjerneikonet</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Endre farge på alle bokmerker</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Endre farge på alle spor</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mer</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Eksporter KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Eksporter GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Eksporter GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Slett liste</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Fartskamera</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Plasser beskrivelse</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Nedlast kart</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>For å advare deg mot fartsovertredelser</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Advar alltid</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Advar aldri</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Strømsparemodus</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Når automatisk modus er valgt, begynner programmet å deaktivere batteridriftfunksjonene avhengig av det nåværende batterinivået</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Aldri</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automatisk</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Maksimum strømsparing</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bokmerke navn på kartet</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Hvis det er for mange bokmerker, kan det gjøre appen tregere å vise navnene på dem på kartet.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Vis til høyre</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Vis nederst</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Alternativet slår på logging for diagnostiske formål. Det kan være nyttig for våre supportpersonale som feilsøker problemer med appen. Aktiver dette alternativet bare på forespørsel fra Organic Maps-brukerstøtte.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Kjørealternativer</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Unngå bompenger</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Unngå uasfalterte veier</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Unngå fergeoverganger</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Unngå motorveien</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Kan ikke beregne rute</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Dessverre kunne vi ikke finne en rute sannsynligvis på grunn av dine definerte alternativer. Vennligst endre innstillingene og prøv igjen</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definer veier som skal unngås</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Kjørealternativer aktivert</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Bompengevei</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Uasfaltert vei</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Fergeovergang</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nei</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nei</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapasitet: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Nettverk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Du har ankommet!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sortere…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sortere merker</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Som standard</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Etter type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Etter avstand</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Etter dato</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Etter navn</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>For en uke siden</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>For en måned siden</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Mer enn en måned siden</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Mer enn ett år siden</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Nær meg</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Andre</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Mislykket ruteplanlegging</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ankomme: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Du har endret verdenskartet. Ikke skjul denne! Fortell vennene dine, og rediger det sammen.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Del med venner</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Lukket nå</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Åpner i morgen klokka %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Åpner %1 klokka %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Åpner klokka %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Stenger %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Legg til åpningstider</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Passord (minimum 8 tegn)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Ugyldig brukernavn eller passord.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-konto</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Siste opplasting</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Takk skal du ha</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Stedsnavn</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Vær oppmerksom på at</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Nedlastningsfeil</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Velg kategori</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populære</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Alle kategorier</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Legg til nye steder i kartet og rediger eksisterende steder direkte fra appen.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Endre plassering</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Du må frigjøre mer lagringsplass for å laste ned. Slett unødvendig data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Jeg har forbedret Organic Maps kartene</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detaljert kommentar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>De foreslåtte endringene vil sendes til OpenStreetMap-gruppen. Beskriv detaljene som ikke kan redigeres i Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Det oppstod en feil under søking etter plasseringen din. Kontroller at plasseringen din virker som den skal, og prøv på nytt senere.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Lokalisering er deaktivert</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Tillat bruk av av geografisk lokalisering i enhetens innstillinger</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Åpne Innstillinger</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Trykk Lokalisering</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3.Velg når appen er i bruk</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Velg Personvern</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Velg Stedstjenester</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Slå på Stedstjenester</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Eller fortsett å bruke Organic Maps uten plassering</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Bestill</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Ring</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bokmerkenavn</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Slett bokmerke</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Notatet ditt vil bli sendt til OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mer</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Oppdatere</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Deaktivere opptak av nylig reiste rute?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Deaktiver</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Sjekk ut</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps bruker geografiske funksjoner i bakgrunnen for å registrere din nylig reiste rute.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Generelle innstillinger</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Du må oppdatere applikasjonen for å kunne se trafikkdata.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Loggfilstørrelse: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Dra hit for å fjerne</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Erstatt stopp</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start fra</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Logg inn på OpenStreetMap for automatisk å laste opp alle kartredigeringene dine. Finn ut mer</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>her</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Skjul skjerm</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 av %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Laster ned %1 …</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Bruker %1 …</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Dette navnet er for langt</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nye filer oppdaget</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertere</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Feil</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Noen filer ble ikke konvertert.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Det oppsto en feil</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populær</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Skjul fra kart</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Det oppsto en feil under lasting av emneknagger, prøv igjen</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Høyre</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bunn</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>La oss begynne</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinasjon</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Sentrer</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Søkeresultater</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Deretter</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vil du planlegge en rute på nytt?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tastatur er ikke tilgjengelig mens en kjører</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Kan ikke planlegge rute fra din nåværende posisjon</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Kan ikke planlegge rute til din nåværende posisjon. Vennligst velg en annen posisjon</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ingen GPS-signal. Vennligst gå til et åpent område</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Kan ikke planlegge rute. Vennligst spesifiser en annen posisjon for rute</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>For å beregne rute last ned manglende kart på enheten din</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Feil oppstod. Vennligst restart appen</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Rute vil planlegges fra din nåværende posisjon</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Rute vil oppdateres til kjørerute</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Ikke alle bokmerker vises</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Bytt til telefonen for å se alle bokmerker</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kamera-info</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Kamera-advarsel</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Vennligst last ned kart i Organic Maps appen på enheten din</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 avkjøring</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortere som standard</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sortere etter type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sortere etter avstand</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sortere etter dato</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sorter etter navn</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Mat</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Severdigheter</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museer</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parker</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Svømming</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Fjell</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Dyr</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteller</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Bygninger</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Penger</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Butikker</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkeringer</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Bensinstasjoner</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medisin</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Søk på lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Hellige steder</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Velge liste</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>T-bane navigasjon er ikke tilgjengelig i denne regionen ennå</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>T-bane rute ikke funnet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Velg utgangspunkt eller destinasjon som befinner seg nærmere en T-bane stasjon</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Høyder</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>For å bruke høydekurver oppdater eller last opp kartet til nødvendig område</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Høydekurver er ikke tilgjengelige i dette området ennå</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stigning</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Nedstigning</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. høyde</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. høyde</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Vanskelighet</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Avstand:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>I rute</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Forstørr kartet for å se høydekurver</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Nedlasting</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Last ned verdenskart</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Klarte ikke opprette mappe og flytte filer i enhetens minne eller SD-kort</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Diskfeil</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Tilkoblingsfeil</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Fjern USB-kabelen</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Behold skjermen på</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Når dette er aktivert, vil skjermen alltid være på når kartet vises.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Vis på låseskjerm</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Når dette er aktivert trenger du ikke låse opp enheten hver gang når appen kjører.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kart-språk</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kartdata fra OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Takk for at du bruker kartene vi har laget i fellesskap!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Med dine donasjoner og støtte kan vi lage de beste kartene i verden!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Liker du appen vår? Vennligst doner for å støtte utviklingen! Liker du det ikke ennå? Gi oss beskjed, så fikser vi det!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Hvis du kjenner en programvareutvikler, kan du be ham eller henne implementere en funksjon du trenger.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Trykk hvor som helst på kartet for å velge noe. Trykk lenge for å skjule og vise grensesnittet igjen.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Vet du at du kan velge din nåværende posisjon på kartet?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Du kan hjelpe til med å oversette appen vår til ditt språk.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Appen vår er utviklet av noen få entusiaster og samfunnet.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Du kan enkelt fikse og forbedre kartdataene.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Vårt hovedmål er å bygge raske, personvernfokuserte, brukervennlige kart som du vil elske.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Du bruker nå Organic Maps på telefonskjermen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Du bruker nå Organic Maps på bilskjermen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Du er koblet til Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Fortsett i telefonen</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Til bilens skjerm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps trenger posisjonstilgang. Når det er trygt, kan du sjekke varslingen på telefonen.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Denne appen trenger din tillatelse</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps i Android Auto trenger en posisjonstillatelse for å fungere effektivt</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Gi tillatelser</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Fotturer</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Nettleser er ikke tilgjengelig</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volum</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksporter alle bokmerker og spor</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Systeminnstillinger for talesyntese</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Innstillinger for talesyntese ble ikke funnet, er du sikker på at enheten din støtter dette?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Gjennomkjøring</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Fjern søket</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom inn</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom ut</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Lenke til menyen</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Vis meny</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Åpne i en annen app</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Selvbetjening</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Velg alternativ</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Uteservering</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For å få mest mulig nøyaktig navigering anbefaler vi at du deaktiverer strømsparingsmodus i telefonens batteriinnstillinger.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Ta opp rute</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stopp opptak av rute</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Opptak av rute</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stopp uten å lagre</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Fortsett opptak</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Lagre i bokmerker og ruter?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Ruten er tom - ingenting å lagre</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kan ikke vise dialogboksen for mappevalg fordi ingen passende app er installert på enheten din. Installer en filbehandler-app og prøv på nytt</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Velg farge</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Rediger ruten</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ingen app installert som kan åpne stedet</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto i navigasjon</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Følg systemet</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Del spor</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Slett %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Vanskelighetsgrad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Lett</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Middels</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Vanskelig</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Oppdatering</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Oppdater dine nedlastede kart</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Ved å oppdatere kart holder du også informasjonen om ulike elementer oppdatert</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Oppdater (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Oppdater manuelt senere</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Slett rute</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Er du sikker på at du vil slette dette sporet?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Rutenavn</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Flytt</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Rute</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Endre farge</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kart</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Vil du sende en feilrapport til utviklerne?
+Vi er avhengige av brukerne våre, da Organic Maps ikke samler inn noen feilinformasjon automatisk. Takk på forhånd for at du støtter Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktiver iCloud-synkronisering</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-synkronisering er en eksperimentell funksjon under utvikling. Sørg for at du har tatt en sikkerhetskopi av alle bokmerkene og sporene dine.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud er deaktivert</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aktiver iCloud i enhetens innstillinger for å bruke denne funksjonen.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktiver</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Sikkerhetskopiering</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud-synkroniseringsfeil</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Feil: Kunne ikke synkronisere på grunn av tilkoblingsfeil</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Feil: Kunne ikke synkronisere på grunn av overskredet iCloud-kvote</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Feil: iCloud er ikke tilgjengelig</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nylig slettede lister</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Fjern</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Slett alle</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Gjenopprette</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Gjenopprett alt</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Bidra til OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Legg til sted</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Oppdater kartet for å bidra</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Du må oppdatere %1-kartet til den nyeste versjonen før du kan bidra til OpenStreetMap-dataene</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Min posisjon</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mine steder</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Intern privat lagring</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Intern delt lagring</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kort</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ekstern delt lagring</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postnummer</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kartpunkt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>fot</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>For å vise ruter må kartene være oppdaterte.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Avslutt</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Inngang</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>T-banekart er utilgjengelig</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Du</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Lilla nedlastede regioner</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rute</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Det er nødvendig å fastslå den gjeldende posisjonen i bakgrunnen for å utnytte appens funksjonalitet til fulle. Dette brukes når en rute skal følges og når den siste reiseruten din skal lagres.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Definerer nåværende plassering brukes i alternativene hvor man følger ruten og lagrer din nylige reiseretning.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Logg inn med passord</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Logg inn med nettleser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nylig brukt</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bokmerkefarge endret</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Sporfarge endret</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Glidebrytere</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RØD</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GRØNN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLÅ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rutenett</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/nl/omim.ts
+++ b/qt/translations/nl/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="nl">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Terug</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Annuleer</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Verwijder</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download kaarten</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Downloaden is mislukt. Tik om het opnieuw te proberen.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloaden…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mijlen</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Zoek</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Zoek op de kaart</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>U heeft momenteel alle locatieservices voor dit apparaat of deze app uitgeschakeld. Schakel ze in bij Instellingen.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Beperkte nauwkeurigheid</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Voor nauwkeurige navigatie schakelt u Precise Location in bij instellingen.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Toon op de kaart</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Downloaden is mislukt</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Probeer opnieuw</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Over Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis voor iedereen, met liefde gemaakt</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Geen advertenties, geen tracking, geen gegevensverzameling</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Geen batterijverlies, werkt offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Snel, minimalistisch, ontwikkeld door de gemeenschap</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source applicatie gemaakt door enthousiastelingen en vrijwilligers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Locatie-instellingen</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Sluit</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Een hardware geaccellereerde OpenGL is nodig. Jammer genoeg wordt uw apparaat niet ondersteund.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Downloaden</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Verwijder de USB-kabel of plaats een geheugenkaart om Organic Maps te gebruiken</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Maak eerst ruimte vrij op de SD-kaart/USB-opslag om de app te gebruiken</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Voordat u start, laten we de algemene wereldkaart naar uw apparaat downloaden.
+Deze neemt %1 in beslag.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ga naar de kaart</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 aan het downloaden. U kunt nu
+doorgaan naar de kaart.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 downloaden?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 updaten?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pauzeer</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Ga verder</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download is mislukt</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Voeg nieuwe groep toe</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Naam van bladwijzergroep</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bladwijzers</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bladwijzers en tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Naam</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adres</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lijst</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Instellingen</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Kaarten opslaan in</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Selecteer de map waar kaarten naar gedownload worden.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Kaarten</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 beschikbaar van %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Kaarten verplaatsen?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Fout bij het verplaatsen van kaartbestanden</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Dit kan enkele minuten duren.
+Even geduld…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Afstandseenheid</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Kies tussen mijlen en kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Annuleer downloaden</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Laat een review achter</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download kaart</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bladwijzergroepen</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Waar iets gaan eten</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Boodschappen</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzine</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkeerplaats</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Winkelen</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Tweedehands</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Bezienswaardigheden</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Amusement</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Geldautomaat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nachtleven</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Gezinsvakantie</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotheek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Ziekenhuis</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Politie</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Caravan Faciliteiten</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notities</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Bladwijzers van Organic Maps zijn met u gedeeld</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hallo!
+
+Bijgesloten zijn mijn bladwijzers uit de Organic Maps app. Open ze als je Organic Maps geïnstalleerd hebt. Of, als je dat niet hebt, download de app hier: https://omaps.app/get?kmz
+
+Geniet van het reizen met Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Bladwijzers worden geladen</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bladwijzers succesvol geüpload! U vindt ze op de kaart of op het scherm van de Bladwijzerbeheerder.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Bladwijzers uploaden is mislukt. Het bestand is mogelijk beschadigd of defect.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Het bestandstype wordt niet herkend door de app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Bestand openen mislukt %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Wijzig</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Je locatie is nog niet vastgesteld</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, instellingen voor kaartopslag zijn momenteel uitgeschakeld.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>De kaart wordt nu gedownload.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hey, kijk naar mijn huidige locatie op Organic Maps! %1 of %2 Heeft u geen offline-kaarten? Download ze hier: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, bekijk mijn pin op Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, bekijk mijn huidige locatie op Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hoi,
+
+Momenteel ben ik hier: %1. Klik op deze %2 link of deze %3 link om de plaats op de kaart te zien.
+
+Bedankt.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Deel</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Naar het klembord gekopieerd: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Klaar</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-gegevens: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Weet u zeker dat u wilt uitloggen uit uw OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lengte</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Deel mijn locatie</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Algemene instellingen</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informatie</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigatie</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Zoomknoppen op de kaart</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Toon op de kaart</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nachtstijl bij navigeren in het donker</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nachtmodus</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Uit</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Aan</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatisch</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspectiefbeeld</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-gebouwen</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-gebouwen worden uitgeschakeld in de energiebesparende modus</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Gesproken instructies</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Straatnamen aankondigen</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Indien ingeschakeld, wordt de naam van de straat of afrit waar u afslaat hardop uitgesproken.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Gesproken taal</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Open de app Instellingen en ga naar Toegankelijkheid → VoiceOver → Spraak → Stem om een stem van hogere kwaliteit te downloaden.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test gesproken aanwijzingen (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Controleer het volume of de tekst-naar-spraak instellingen van het systeem als je de stem nu niet hoort.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Niet beschikbaar</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatisch zoomen</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Afstand</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Bekijk op de kaart</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nieuws</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Beoordeel de app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hulp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Vragen en antwoorden</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doneer</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Reeds gedoneerd</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Herinner later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Ondersteun Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Steun het project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Auteursrechten</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Meld een fout</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Verbeter de richting van de pijl door de telefoon in een achtvormige beweging te bewegen om het kompas te kalibreren.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Beweeg de telefoon in een achtvormige beweging om het kompas te kalibreren en de pijl op de kaart in de juiste richting te doen wijzen.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Tik nogmaals lang op de kaart om de interface te zien</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update alles</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Annuleer alles</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Gedownload</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>In de wachtrij</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Bij mij in de buurt</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kaarten</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download alles</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Aan het downloaden:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Stop de navigatie om de kaart te verwijderen.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Enkel routes die volledig in één kaart passen, kunnen gecreëerd worden.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download de kaart</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Probeer opnieuw</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Verwijder kaart</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update kaart</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play-locatieservices</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bepaal snel je locatie bij benadering via Bluetooth, WiFi of een mobiel netwerk</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download kaarten op de route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Voor het creëren van een route is het nodig dat alle kaarten van uw locatie naar uw bestemming gedownload en bijgewerkt zijn.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Niet genoeg ruimte</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Schakel locatiediensten in</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Bewaar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>aanmaken</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rood</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Geel</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blauw</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Groen</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Paars</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranje</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Bruin</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Roze</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Donkerpaars</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Lichtblauw</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Blauwgroen</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smaragdgroen</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limoen</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Donkeroranje</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grijs</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Grijsblauw</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps versie: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Weergave</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Licht</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Donker</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Licht van zonsopgang tot zonsondergang</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Andere</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Geef gratis kaarten zonder advertenties aan miljoenen gebruikers!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Rapporteer of repareer onjuiste kaartgegevens</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Vrijwilligerswerk</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Volg ons en neem contact met ons op:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Het e-mailprogramma is niet ingesteld. Stel het programma in of neem contact met ons op via %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>E-mail verzendfout</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompaskalibratie</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Beschikbaar</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Gevonden</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Updaten</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Mislukt</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>markeer</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Belangrijk bij het volgen van een route:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— De toestand van het wegdek, de verkeersregels en -borden hebben altijd voorrang op het advies van het navigatiesysteem;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— De kaart kan onnauwkeurig zijn en de voorgestelde route is niet altijd de meest optimale manier om uw bestemming te bereiken;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Beschouw de voorgestelde routes enkel als aanbevelingen;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Wees voorzichtig met de routes in de grenszones: de routes die door onze app gecreëerd zijn, gaan wellicht door landgrenzen in ongeautoriseerde plaatsen.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Blijf alert en rij veilig!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Controleer gps-signaal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Route samenstellen mislukt. De huidige gps-coördinaten kunnen niet worden geïdentificeerd.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Controleer uw gps-signaal. Schakel wifi in voor een betere locatiebepaling.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Schakel locatiediensten in</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>De huidige gps-coördinaten kunnen niet worden gevonden. Schakel locatiediensten in om de route te berekenen.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Route vinden mislukt</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Route samenstellen mislukt.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Kies een ander startpunt of een andere bestemming.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Kies ander startpunt</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route samenstellen mislukt. Startpunt kan niet worden gevonden.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Kies een startpunt dat dichter bij een weg ligt.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Kies andere bestemming</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route samenstellen mislukt. Bestemming kan niet worden gevonden.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Kies een bestemming die dichter bij een weg ligt.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Kan de tussenstop niet vinden.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Gelieve uw tussenstop aan te passen.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systeemfout</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Route samenstellen mislukt door een applicatiefout.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Probeer het opnieuw</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Niet nu</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Wilt u de kaart downloaden en een betere route samenstellen die meer dan één kaart beslaat?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download de kaart om een betere route samen te stellen die de grenzen van deze kaart overschrijdt.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download de vereiste bestanden</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download de kaart en route-informatie voor het ingestelde traject en werk deze bij om de route te berekenen.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Om te beginnen met zoeken en om routebeschrijvingen te kunnen maken, moet u de kaart downloaden. U heeft vervolgens geen internetverbinding meer nodig.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Selecteer de kaart</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Toon</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Verberg</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorieën</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Geschiedenis</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Sorry, geen resultaten gevonden.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download de regio waar u zoekt of probeer een nabijgelegen stad/dorpnaam toe te voegen.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Zoekgeschiedenis</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Snel toegang tot recente zoekopdrachten.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Wis zoekgeschiedenis</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel van wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Uw locatie</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route van</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route naar</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigatie is uitsluitend beschikbaar vanuit uw huidige locatie.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Wilt u een route plannen vanaf uw huidige locatie?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Volgende</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Van</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Naar</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Voeg schema toe</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Verwijder schema</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Elke dag (24 uur)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Gesloten</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Niet-kantooruren toevoegen</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Openingstijden</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Geavanceerde modus</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Eenvoudige modus</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Sluitingstijden</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Voorbeeldwaarden</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corrigeer fout</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Locatie selecteren</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Beschrijf het probleem gedetailleerd, zodat de OpenStreetMap-community de fout kan oplossen.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Of doe het zelf op https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Verzend</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Probleem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Deze plaats bestaat niet</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Gesloten voor onderhoud</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Dubbele plaats</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Download kaarten automatisch</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Dagelijks</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Vandaag gesloten</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Gesloten</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Vandaag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opent over %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Sluit over %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Gesloten</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Bewerk openingstijden</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Geen account bij OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registreer bij OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Log in</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Niet ingelogd</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Log in bij OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Wachtwoord</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Wachtwoord vergeten?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log uit</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Bewerk de locatie</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Voeg een taal toe</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Straat</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Huisnummer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociale media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Gebouw</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Voeg een straat toe</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Voer een straatnaam in alstublieft</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Kies een taal</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Kies een straat</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Keuken</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Selecteer keuken</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mailadres of gebruikersnaam</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Voeg telefoonnummer toe</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Verdieping</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Niveau: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alle wijzigingen aan de kaart zullen samen met de kaart worden verwijderd.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update kaarten</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Om een route te creëren, moet je alle kaarten updaten en dan de route opnieuw plannen.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Vind een kaart</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>A.u.b zorg ervoor dat het apparaat verbonden is met het internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Niet genoeg ruimte</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Verwijder overbodige gegevens</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Inlogfout.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Gecontroleerde wijzigingen</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Sleep de kaart om het kruis op de locatie van de plaats of het bedrijf te plaatsen.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Bewerken</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Toevoegen</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Naam van de plaats</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Zoals het in de plaatselijke taal geschreven staat</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Gedetailleerde probleemomschrijving</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Een ander probleem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Voeg een organisatie toe</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Hier kan geen object worden geplaatst</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Door de gemeenschap gemaakte OpenStreetMap-gegevens tot %1. Lees meer over hoe je de kaart kunt bewerken en bijwerken op OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is een gemeenschapsproject om een vrije en open kaart te bouwen. Het is de belangrijkste bron van kaartgegevens in Organic Maps en werkt ongeveer hetzelfde als Wikipedia. U kunt plaatsen toevoegen of bewerken en deze worden dan beschikbaar voor miljoenen gebruikers over de hele wereld.
+Sluit u aan bij de gemeenschap en help mee om een betere kaart voor iedereen te maken!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Maak een OpenStreetMap account aan of log in om uw kaartbewerkingen voor de wereld te publiceren.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 van %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Downloaden via een mobiele gegevensverbinding?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Met sommige abonnementen of bij roaming kan dit behoorlijk duur zijn.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Voer een geldig huisnummer in</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Aantal verdiepingen (max. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Het gebouw mag niet meer dan %1 verdiepingen hebben</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postcode</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Voer een geldige postcode in</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Opmerking voor OpenStreetMap vrijwilligers (optioneel)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beschrijf fouten op de kaart of dingen die niet bewerkt kunnen worden met Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Uw bewerkingen worden geüpload naar de openbare &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/NL:About&quot;&gt;OpenStreetMap&lt;/a&gt; database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Meer over OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Uw bewerkingsgeschiedenis</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Opmerkingen over uw kaartgegevens</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Exploitant</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Exploitant: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Kun je geen geschikte categorie vinden?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Met Organic Maps kun je alleen eenvoudige puntcategorieën toevoegen, dus geen steden, wegen, meren, contouren van gebouwen, enzovoort. Voeg zulke categorieën direct toe aan &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Bekijk onze &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;gids&lt;/a&gt; voor gedetailleerde stap voor stap instructies.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>U hebt geen kaarten gedownload</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download kaarten om een locatie te zoeken en offline te navigeren.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Huidige locatie is onbekend.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>u</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Meer</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Bewerk bladwijzer</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Persoonlijke aantekeningen (tekst of html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Reactie…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Alle lokale wijzigingen negeren?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Negeer</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Toegevoegde locatie verwijderen?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Verwijder</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Locatie bestaat niet</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Graag de reden voor verwijdering aangeven</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Voer een geldig telefoonnummer in</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Voer een geldig webadres in</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Voer een geldig emailadres in</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Voer een geldig Facebook-webadres, een accountnaam of een paginanaam in</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Voer een geldig Instagram-webadres of accountnaam in</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Voer een geldig Twitter-gebruikersnaam of web adres in</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Voer een geldig VK-webadres of accountnaam in</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Voer een geldig LINE-webadres of LINE ID in</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Voeg een plaats toe aan OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Of, als alternatief, laat een opmerking achter voor de OpenStreetMap gemeenschap zodat iemand anders een plaats kan toevoegen of verbeteren.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Opmerking wordt verzonden naar OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Wil je het naar alle gebruikers sturen?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Controleer dat je geen persoonlijke gegevens hebt ingevoerd.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-editors zullen de wijzigingen controleren en contact met u opnemen als ze vragen hebben.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Het spoor opnemen</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accepteer</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Weiger</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Mobiel internet gebruiken om gedetailleerde informatie weer te geven?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Gebruik altijd</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Alleen vandaag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Gebruik vandaag niet</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobiel internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobiel internet is vereist voor het weergeven van gedetailleerde informatie over plaatsen, zoals foto&#x27;s, prijzen en beoordelingen.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Gebruik nooit</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Vraag altijd</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Om verkeersgegevens weer te geven, moeten de kaarten bijgewerkt worden.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Vergroot lettergrootte op de kaart</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Gelieve Organic Maps bij te werken</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Verkeersgegevens zijn niet beschikbaar</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Logboekregistratie inschakelen</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Algemene feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We gebruiken het TTS-systeem voor gesproken instructies. Vele Android toestellen gebruiken Google TTS, u kunt het downloaden of bijwerken in Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Voor sommige talen dient u een andere spraaksynthesesoftware of een aanvullende taalpakket te installeren van de app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open de instellingen van uw toestel → Taal en invoer → Spraak → Uitvoer voor tekst-naar-spraak.
+Hier kunt u instellingen voor spraaksynthese beheren (bijvoorbeeld taalpakket downloaden voor offline gebruik) en een andere tekst-naar-spraak engine selecteren.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Gelieve deze handleiding te lezen voor meer informatie.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteratie in het Latijnse alfabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Meer informatie</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Gebruik zoeken of tik op de kaart om een startpunt voor de route toe te voegen</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Gebruik zoeken of tik op de kaart om een bestemmingspunt toe te voegen</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Beheer route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Verwijder tussenstop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Voeg tussenstop toe</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Opgeslagen</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Log in op OpenStreetMap om al je kaartbewerkingen automatisch te uploaden. Meer informatie &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hier&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Probleem met opslagtoegang</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Externe opslag is niet beschikbaar, wellicht is de SD-kaart verwijderd, beschadigd of is het bestandssysteem alleen-lezen. Gelieve dit te controleren en ons te contacteren via support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Slechte opslag emuleren</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Voer een geldige naam in</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lijsten</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Verberg alles</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Toon alles</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bladwijzer</numerusform>
+<numerusform>%n bladwijzers</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Maak een nieuwe lijst</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importeer bladwijzers en tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Delen is onmogelijk wegens een toepassingsfout</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Deelfout</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Een lege lijst kan niet gedeeld worden</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>De naam kan niet leeg zijn</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Voer de lijstnaam in</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nieuwe lijst</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Deze naam is al in gebruik</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Kies alstublieft een andere naam</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Even geduld aub…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefoonnummer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap-profiel</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n bestand gevonden. Je ziet het na het converteren.</numerusform>
+<numerusform>%n bestanden gevonden. Je zult ze na de conversie zien.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Zet terug</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacybeleid</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Gebruiksvoorwaarden</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Verkeer</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Wandel</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Fiets</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kaartstijlen en -lagen</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Deze lijst is leeg</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Om een bladwijzer toe te voegen, tikt u op een plaats op de kaart en vervolgens op het sterpictogram</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Kleur van alle bladwijzers wijzigen</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Kleur van alle tracks wijzigen</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…meer</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exporteer KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exporteer GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exporteer GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Verwijder lijst</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Snelheidscamera&#x27;s</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Plaatsbeschrijving</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kaartdownloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Waarschuw bij overschrijden snelheidslimiet</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Waarschuw altijd</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Waarschuw nooit</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energiebesparende modus</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Probeer batterijgebruik te verminderen ten koste van enkele functionaliteit.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nooit</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Wanneer batterij bijna leeg is</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Maximale energiebesparing</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Markeer namen op de map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Wanneer er teveel markeringen zijn, kan weergave van de namen op de map vertragen.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Rechts weergeven</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Onderaan weergeven</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Schakel deze optie tijdelijk in om gedetailleerde logboekregistraties omtrent jouw probleem op te slaan en te verzenden tijdens &quot; Rapporteer een probleem&quot; in het help menu. Schakel deze optie alleen in op verzoek van Organic Maps ondersteuning.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Route instellingen</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vermijd tolwegen</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vermijd onverharde wegen</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vermijd veerboten</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vermijd snelwegen</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Kan route niet berekenen</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Helaas konden we geen route berekenen. Dit kan komen door uw gekozen opties of door incomplete OpenStreetMap-data. Wijzig de instellingen en probeer het opnieuw.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definieer wegen om te vermijden</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Route-instellingen ingeschakeld</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Tolweg</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Onverharde weg</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Veerbootverbinding</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nee</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nee</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capaciteit: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Netwerk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>U bent aangekomen!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Oké</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sorteer…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sorteer bladwijzers</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Standaard</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Op type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Op afstand</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Op datum</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Op naam</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Een week geleden</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Een maand geleden</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Meer dan een maand geleden</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Meer dan een jaar geleden</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Dicht bij mij</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Andere</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Routeberekening mislukt</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Aankomst: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Om een route te maken, download en update alle kaarten rondom de route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Je hebt de wereldkaart gewijzigd. Verberg dit niet! Vertel het je vrienden en bewerk haar samen.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Deel met je vrienden</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Nu gesloten</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opent morgen om %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opent %1 om %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opent om %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Sluit om %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Voeg openingstijden toe</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Wachtwoord (minimaal 8 tekens)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Ongeldige gebruikersnaam of ongeldig wachtwoord.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Laatste upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Dank je wel</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Locatienaam</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefoonnummer</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Opgelet</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Downloadfout</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Selecteer categorie</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populair</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Alle categorieën</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Voeg nieuwe plaatsen toe aan de kaart en bewerk de bestaande rechtstreeks vanuit de app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Wijzig locatie</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Om te kunnen downloaden, heb je meer ruimte nodig. Verwijder overbodige gegevens.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ik heb de Organic Maps-kaarten verbeterd</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Gedetailleerde reactie</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Uw voorgestelde wijzigingen worden verzonden naar de OpenStreetMap-gemeenschap. Beschrijf de details die niet kunnen worden bewerkt in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Er is een fout opgetreden tijdens het zoeken naar uw locatie. Controleer of uw apparaat goed werkt en probeer het later opnieuw.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Locatie-identificatie is uitgeschakeld</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Schakel de toegang tot geolocatie in in de instellingen van het apparaat</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Instellingen openen</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tik op locatie</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Selecteer Bij gebruik van app</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Selecteer Privacy en beveiliging</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Selecteer Locatievoorzieningen</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Locatievoorzieningen inschakelen</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Of blijf Organic Maps gebruiken zonder locatie</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Boek</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Bel</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bladwijzernaam</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Verwijder bladwijzer</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Je opmerking wordt verzonden naar OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…meer</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Vastleggen van uw onlangs afgelegde route uitschakelen?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Schakel uit</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Bekijk</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps gebruikt uw geografische positie op de achtergrond om uw onlangs afgelegde route vast te leggen.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Algemene instellingen</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Om de verkeersgegevens weer te geven, moet de applicatie bijgewerkt worden.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Grootte logbestand: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Sleep hier om te verwijderen</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Vervang Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start vanaf</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Log in op OpenStreetMap om al je kaartbewerkingen automatisch te uploaden. Meer informatie</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hier</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Verberg scherm</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 van %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 downloaden…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 toepassen…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Deze naam is te lang</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nieuwe bestanden gedetecteerd</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Zet om</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Fout</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Sommige bestanden zijn niet geconverteerd.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Er is een fout opgetreden</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populair</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Verberg van de kaart</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Er is een fout opgetreden tijdens het laden van tags, probeer het opnieuw</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Rechts</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bodem</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Laten we gaan</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Bestemming</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Opnieuw centreren</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Zoekresultaten</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Dan</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Wilt u de route wijzigen?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Toetsenbord is niet beschikbaar tijdens het rijden</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Kan route vanaf huidige positie niet opbouwen</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Kan route naar het eindpunt niet opbouwen. Kies een ander eindpunt</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Geen GPS-signaal. Ga naar een open omgeving</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Kan route niet berekenen. Selecteer andere tussenpunten</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Om een route te berekenen, download de ontbrekende kaarten</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Iets is fout gegaan. Start de applicatie opnieuw</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>De route wordt opnieuw berekend vanaf uw huidige locatie</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>De route wordt veranderd naar een autoroute</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Niet alle bladwijzers worden getoond</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Schakel over naar de telefoon om alle bladwijzers te zien</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Snelheidscamera&#x27;s</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Snelheidswaarschuwingen</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Download kaarten in de Organic Maps app op uw apparaat</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Afrit nr. %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Standaard sortering</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sorteren op type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sorteer op afstand</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sorteer op datum</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sorteer op naam</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Voedsel</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Bezienswaardigheden</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Musea</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parken</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Zwemmen</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Bergen</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Dieren</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Gebouwen</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Geld</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Winkels</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkeerplaatsen</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzinestations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Geneeskunde</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Zoek in de lijst</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religieuze plaatsen</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Kies een lijst</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro-navigatie is nog niet beschikbaar in deze regio</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Geen metroroute gevonden</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Kies een begin- of eindpunt dichter bij het metrostation</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contourlijnen</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Als u gebruik wilt maken van hoogtelijnen, moet u de kaart van het gewenste gebied bijwerken of downloaden</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Hoogtelijnen zijn nog niet beschikbaar in deze regio</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stijging</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Daling</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. hoogte</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. hoogte</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Moeilijkheid</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Afst.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tijd:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in om hoogte/dal lijnen te bekijken</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloaden</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download de wereldoverzichtskaart</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Het lukt niet om een map aan te maken en bestanden naar het interne geheugen of een SD-kaart te verplaatsen</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Schijffout</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Verbindingsfout</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB-kabel losmaken</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Scherm ingeschakeld houden</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Als deze optie is ingeschakeld, staat het scherm altijd aan als de kaart wordt weergegeven.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Toon op vergrendelscherm</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Indien ingeschakeld, hoeft het scherm niet te worden ontgrendeld wanneer de app actief is.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kaarttaal</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kaartgegevens van OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/nl/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/nl/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/NL:Wat_is_OpenStreetMap%1</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Bedankt voor het gebruik van onze door de community gemaakte kaarten!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Met uw donaties en steun kunnen we de beste kaarten ter wereld maken!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Vind je onze app leuk? Doneer alstublieft om de ontwikkeling te ondersteunen! Vind je het nog niet leuk? Laat het ons weten, dan lossen we het op!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Als u een softwareontwikkelaar kent, kunt u hem of haar vragen een functie te implementeren die u nodig heeft.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tik ergens op de kaart om iets te selecteren. Tik lang om de interface te verbergen en weer te geven.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Wist u dat u uw huidige locatie op de kaart kunt selecteren?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>U kunt helpen onze app in uw taal te vertalen.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Onze app is ontwikkeld door een paar enthousiastelingen en de community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>U kunt de kaartgegevens eenvoudig corrigeren en verbeteren.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Ons belangrijkste doel is om snelle, op privacy gerichte, gebruiksvriendelijke kaarten te maken waar u dol op zult zijn.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Je gebruikt nu Organic Maps op het telefoonscherm</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Je gebruikt nu Organic Maps op het autoscherm</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Je bent verbonden met Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Ga verder op de telefoon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Naar het autoscherm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps heeft locatietoegang nodig. Als het veilig is, controleer je de melding op je telefoon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Deze app heeft je toestemming nodig</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto heeft locatietoestemming nodig om effectief te werken</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Geef toestemming</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Buiten</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webbrowser is niet beschikbaar</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exporteer alle bladwijzers en tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Instellingen spraaksynthesesysteem</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Instellingen voor spraaksynthese zijn niet gevonden, weet je zeker dat je apparaat dit ondersteunt?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Wis de zoekopdracht</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Inzoomen</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom uit</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menulink</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Bekijk menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Openen in een andere applicatie</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Zelfbediening</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selecteer optie</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Zitplaatsen buiten</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Voor de meest nauwkeurige navigatie raden we aan om de energiebesparende modus uit te schakelen in de batterij-instellingen van de telefoon.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Route opnemen</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop opname van route</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track-opname</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stoppen zonder op te slaan</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Opname voortzetten</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Opname opslaan in bladwijzers en tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Route is leeg - niets om op te slaan</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Kan het mappen-selecteerscherm niet weergeven omdat er geen geschikte app op uw apparaat is geïnstalleerd. Installeer een app voor bestandsbeheer en probeer het opnieuw.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Kies een kleur</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Route bewerken</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Geen app geïnstalleerd die de locatie kan openen</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto tijdens navigatie</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Systeem volgen</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Titel van het onderste blad bij delen van het spoor</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Verwijder %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Moeilijkheidsgraad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Gemakkelijk</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Middelmatig</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Moeilijk</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updaten</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Werk uw gedownloade kaarten bij</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Kaarten bijwerken houdt de informatie over objecten actueel</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Werk bij (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Werk later handmatig bij</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Verwijder traject</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Weet u zeker dat u deze track wilt verwijderen?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Trajectnaam</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Verplaats</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Verander kleur</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Kaart</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Wil je een bugrapport naar de ontwikkelaars sturen?
+We vertrouwen op onze gebruikers, want Organic Maps verzamelt geen foutinformatie automatisch. Alvast bedankt voor je steun aan Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Schakel iCloud-synchronisatie in</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronisatie is een experimentele functie in ontwikkeling. Zorg ervoor dat je een back-up hebt gemaakt van al je bladwijzers en tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud is uitgeschakeld</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Schakel iCloud in bij de instellingen van je apparaat om deze functie te gebruiken.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Schakel in</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Back-up</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Storing iCloud-synchronisatie</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Fout: Synchronisatie mislukt door verbindingsfout</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Fout: Synchronisatie mislukt vanwege overschrijding iCloud-quota</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Fout: iCloud is niet beschikbaar</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Onlangs verwijderde lijsten</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Wissen</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Alles verwijderen</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Herstel</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Alles herstellen</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Draag bij aan OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Plaats toevoegen</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Werk de kaart bij om bij te dragen</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>U moet de %1-kaart bijwerken naar de nieuwste versie voordat u kunt bijdragen aan de gegevens van OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Mijn locatie</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mijn plaatsen</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Intern privéopslag</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interne gedeelde opslag</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kaart</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Extern gedeeld geheugen</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postcode</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kaartpunt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mijl</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>voet</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Om routes weer te geven moeten de kaarten bijgewerkt worden.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Uitgang</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ingang</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metrokaart is niet beschikbaar</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Je</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Paarse gedownloade regio&#x27;s</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Het bepalen van je locatie op de achtergrond is noodzakelijk om volledig gebruik te kunnen maken van de app. Dit wordt gebruikt voor navigatie en voor het opslaan van je recent afgelegde route.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Het bepalen van je locatie is noodzakelijk voor navigatie en voor het opslaan van je recent afgelegde route.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Inloggen met wachtwoord</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Inloggen met browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Onlangs gebruikt</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bladwijzerkleur gewijzigd</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Trackkleur gewijzigd</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Schuifregelaars</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROOD</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GROEN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLAUW</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB hexadecimale kleur #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Raster</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/oc/omim.ts
+++ b/qt/translations/oc/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="oc">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Clar de l&#x27;alba fins al crepuscle</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Article de wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/oc/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Utilizats recentament</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectre</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Desplaçadors</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROGE</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERD</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLANC</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Color Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grilha</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/pa/omim.ts
+++ b/qt/translations/pa/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="pa">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>ਵਾਪਿਸ</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>ਰੱਦ ਕਰੋ</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>ਮਿਟਾਓ</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>ਨਕਸ਼ੇ ਡਾਊਨਲੋਡ ਕਰੋ</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>ਡਾਊਨਲੋਡ ਅਸਫਲ। ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਲਈ ਇੱਥੇ ਦੱਬੋ।</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>ਕਿਲੋਮੀਟਰ</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>ਮੀਲ</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>ਬਾਅਦ ਵਿੱਚ</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>ਲੱਭੋ</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>ਨਕਸ਼ਾ ਲੱਭੋ</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>ਤੁਸੀਂ ਇਸ ਵੇਲੇ ਇਸ ਡੀਵਾਈਸ ਜਾਂ ਐਪਲੀਕੇਸ਼ਨ ਲਈ ਸਾਰੀਆਂ ਲੋਕੇਸ਼ਨ ਸੇਵਾਵਾਂ ਨੂੰ ਅਯੋਗ ਬਣਾਇਆ ਹੋਇਆ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਉਹਨਾਂ ਨੂੰ ਯੋਗ ਬਣਾਓ।</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>ਸੀਮਤ ਸ਼ੁੱਧਤਾ</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>ਸਟੀਕ ਨੈਵੀਗੇਸ਼ਨ ਯਕੀਨੀ ਬਣਾਉਣ ਲਈ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਸਟੀਕ ਲੋਕੇਸ਼ਨ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ।</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>ਨਕਸ਼ੇ ਉੱਤੇ ਦਿਖਾਓ</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>ਡਾਊਨਲੋਡ ਅਸਫਲ</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps ਬਾਰੇ</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>ਸਭ ਲਈ ਮੁਫ਼ਤ, ਪਿਆਰ ਨਾਲ ਬਣਾਇਆ ਗਿਆ</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• ਕੋਈ ਇਸ਼ਤਿਹਾਰ ਨਹੀਂ, ਕੋਈ ਟਰੈਕਿੰਗ ਨਹੀਂ, ਕੋਈ ਡਾਟਾ ਇਕੱਠਾ ਨਹੀਂ</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• ਬੈਟਰੀ ਦੀ ਕੋਈ ਖਪਤ ਨਹੀਂ, ਔਫਲਾਈਨ ਕੰਮ ਕਰਦਾ ਹੈ</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• ਤੇਜ਼, ਨਿਊਨਤਮ, ਭਾਈਚਾਰੇ ਦੁਆਰਾ ਵਿਕਸਤ ਕੀਤਾ ਗਿਆ</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>ਉਤਸ਼ਾਹੀਆਂ ਅਤੇ ਵਲੰਟੀਅਰਾਂ ਦੁਆਰਾ ਬਣਾਈ ਗਈ ਓਪਨ-ਸੋਰਸ ਐਪਲੀਕੇਸ਼ਨ।</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>ਲੋਕੇਸ਼ਨ ਸੈਟਿੰਗਾਂ</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>ਬੰਦ ਕਰੋ</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>ਐਪ ਨੂੰ ਹਾਰਡਵੇਅਰ ਐਕਸਲਰੇਟਿਡ OpenGL ਦੀ ਲੋੜ ਹੈ। ਬਦਕਿਸਮਤੀ ਨਾਲ, ਤੁਹਾਡੀ ਡਿਵਾਈਸ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>ਡਾਊਨਲੋਡ</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps ਵਰਤਣ ਲਈ ਕਿਰਪਾ ਕਰਕੇ USB ਕੇਬਲ ਅਨਲੱਗ ਕਰੋ ਜਾਂ ਮੈਮਰੀ ਕਾਰਡ ਲਗਾਓ।</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>ਐਪ ਦੀ ਵਰਤੋਂ ਕਰਨ ਲਈ ਕਿਰਪਾ ਕਰਕੇ ਪਹਿਲਾਂ SD ਕਾਰਡ/USB ਸਟੋਰੇਜ &#x27;ਤੇ ਕੁਝ ਜਗ੍ਹਾ ਖਾਲੀ ਕਰੋ</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>ਐਪ ਦੀ ਵਰਤੋਂ ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ, ਕਿਰਪਾ ਕਰਕੇ ਆਪਣੀ ਡਿਵਾਈਸ &#x27;ਤੇ ਵਿਸ਼ਵ ਸੰਖੇਪ ਨਕਸ਼ਾ ਡਾਊਨਲੋਡ ਕਰੋ।
+ਇਹ %1 ਸਟੋਰੇਜ ਦੀ ਵਰਤੋਂ ਕਰੇਗਾ।</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>ਨਕਸ਼ੇ ਤੇ ਜਾਓ</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>ਡਾਊਨਲੋਡ ਕਰ ਰਿਹਾ %1। ਤੁਸੀਂ ਹੁਣ
+ਨਕਸ਼ੇ &#x27;ਤੇ ਜਾ ਸਕਦੇ ਹੋ।</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>ਡਾਊਨਲੋਡ %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>ਅੱਪਡੇਟ %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>ਵਿਰਾਮ</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>ਜਾਰੀ ਰੱਖੋ</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 ਡਾਊਨਲੋਡ ਅਸਫਲ ਰਿਹਾ</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>ਇੱਕ ਨਵੀਂ ਸੂਚੀ ਸ਼ਾਮਲ ਕਰੋ</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>ਸੂਚੀ ਦਾ ਨਾਮ ਬੁੱਕਮਾਰਕ ਕਰੋ</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>ਬੁੱਕਮਾਰਕ</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>ਬੁੱਕਮਾਰਕ ਅਤੇ ਟਰੈਕ</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>ਨਾਮ</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>ਪਤਾ</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>ਸੂਚੀ</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>ਸੈਟਿੰਗਾਂ</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>ਨਕਸ਼ੇ ਇੱਥੇ ਸੇਵ ਕਰੋ</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>ਨਕਸ਼ੇ ਡਾਊਨਲੋਡ ਕਰਨ ਲਈ ਫੋਲਡਰ ਚੁਣੋ।</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>ਡਾਊਨਲੋਡ ਕੀਤੇ ਨਕਸ਼ੇ</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>ਅੰਧੇਰੇ ਵਿੱਚ ਨੈਵੀਗੇਸ਼ਨ ਕਰਦਿਆਂ ਰਾਤ ਦੀ ਸ਼ੈਲੀ</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>ਸਵੇਰੇ ਤੋਂ ਸ਼ਾਮ ਤੱਕ ਹਲਕਾ</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>ਲੱਖਾਂ ਵਰਤੋਂਕਾਰਾਂ ਨੂੰ ਬਿਨਾਂ ਇਸ਼ਤਿਹਾਰਾਂ ਦੇ ਮੁਫ਼ਤ ਨਕਸ਼ੇ ਤੋਹਫ਼ੇ ਵਿੱਚ ਦਿਓ!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org ਤੋਂ ਲੇਖ</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n ਬੁੱਕਮਾਰਕ</numerusform>
+<numerusform>%n ਬੁੱਕਮਾਰਕ</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n ਫਾਈਲ ਮਿਲੀ। ਤੁਸੀਂ ਇਸਨੂੰ ਬਦਲਣ ਤੋਂ ਬਾਅਦ ਦੇਖ ਸਕਦੇ ਹੋ।</numerusform>
+<numerusform>%n ਫਾਈਲਾਂ ਮਿਲੀਆਂ। ਤੁਸੀਂ ਉਨ੍ਹਾਂ ਨੂੰ ਬਦਲਣ ਤੋਂ ਬਾਅਦ ਦੇਖ ਸਕਦੇ ਹੋ।</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ਟਰੈਕ</numerusform>
+<numerusform>%n ਟਰੈਕ</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>ਸਿਸਟਮ ਮੁਤਾਬਕ</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>ਮੇਰੀ ਸਥਿਤੀ</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>ਮੇਰੀਆਂ ਥਾਵਾਂ</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>ਅੰਦਰੂਨੀ ਨਿੱਜੀ ਸਟੋਰੇਜ</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>ਬੈਂਗਣੀ ਡਾਊਨਲੋਡ ਕੀਤੇ ਖੇਤਰ</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>ਪਾਸਵਰਡ ਨਾਲ ਲੌਗਇਨ ਕਰੋ</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>ਬ੍ਰਾਊਜ਼ਰ ਰਾਹੀਂ ਲੌਗਇਨ ਕਰੋ</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>ਹਾਲ ਹੀ ਵਿੱਚ ਵਰਤੇ ਗਏ</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>ਸਪੈਕਟ੍ਰਮ</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>ਸਲਾਈਡਰ</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ਲਾਲ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ਹਰਾ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ਨੀਲਾ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB ਹੈਕਸ ਰੰਗ #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>ਜਾਲੀ</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/pl/omim.ts
+++ b/qt/translations/pl/omim.ts
@@ -1,0 +1,3936 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="pl">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Wróć</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Usuń</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Pobierz mapy</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Nie udało się pobrać. Proszę nacisnąć, aby spróbować ponownie.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Pobieranie…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometry</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mile</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Później</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Wyszukaj</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Wyszukaj mapy</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Usługi lokalizacji są aktualnie wyłączone dla tego urządzenia lub aplikacji. Proszę włączyć je w ustawieniach.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ograniczona dokładność</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Aby zapewnić dokładną nawigację, proszę włączyć opcję Precyzyjna lokalizacja w ustawieniach.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Wyświetl na mapie</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Nie udało się pobrać</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Spróbuj ponownie</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>O aplikacji Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Darmowa dla wszystkich, wykonana z miłością</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Bez reklam, bez śledzenia, bez gromadzenia danych</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Nie zużywa baterii, działa w trybie offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Szybki, minimalistyczny, opracowany przez społeczność</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplikacja typu open source stworzona przez entuzjastów i wolontariuszy.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Ustawienia lokalizacji</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zamknij</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Wymagana jest sprzętowa akceleracja OpenGL. Aktualne urządzenie nie jest obsługiwane.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Pobierz</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Proszę odłączyć kabel USB albo włożyć kartę pamięci, aby korzystać z Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Proszę zwolnić trochę pamięci na karcie SD/pamięci USB, aby korzystać z aplikacji</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Przed rozpoczęciem prosimy o pobranie ogólnej mapy świata na urządzenie.
+Wymaga to %1 danych.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Przejdź do mapy</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Pobieranie %1. Można teraz
+przejść do mapy.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Pobrać %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Uaktualnić %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Wstrzymaj</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Kontynuuj</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Nie udało się pobrać %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Dodaj nowy zestaw</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nazwa zestawu zakładek</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Zakładki</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Zakładki i trasy</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nazwa</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adres</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Ustawienia</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Zapisz mapy do</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Określa położenie przechowywania pobranych map</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 wolne z %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Przenieść mapy?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Błąd przenoszenia plików map</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>To może zająć kilka minut.
+Proszę czekać…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Jednostki miary</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Wybiera pomiędzy milami, a kilometrami</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Anuluj pobieranie</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Napisz recenzję</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Tak</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Pobierz mapę</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Zestawy zakładek</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Gdzie zjeść</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Produkty</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Stacja paliw</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Zakupy</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Z drugiej ręki</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Atrakcje turystyczne</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Rozrywka</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Życie nocne</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Wypoczynek z dziećmi</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apteka</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Szpital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toaleta</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Poczta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policja</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recykling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Woda</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Kamper</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notatki</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Udostępnione zakładki z Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Cześć!
+
+Załączam moje zakładki z aplikacji Organic Maps. Proszę otwórz je jeżeli masz zaintalowane Organic Maps. Lub, jeżeli nie masz, pobierz aplikację na swoje urządzenie iOS/Android za pomocą tego linka: https://omaps.app/get?kmz
+
+Miłego podróżowania z Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Wczytywanie zakładek</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Wczytano zakładki! Można odnaleźć je na mapie lub na ekranie menedżera zakładek.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Nieudane wczytywanie zakładek. Plik może być uszkodzony lub posiadać defekty.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Typ pliku nie jest rozpoznawany przez aplikację:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nie udało się otworzyć pliku %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edytuj</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Nie określono jeszcze aktualnego położenia</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Przepraszamy, ustawienia pamięci mapy są aktualnie wyłączone.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Trwa pobieranie mapy kraju.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hej, spójrz na moją aktualną lokalizację w Organic Maps! %1 lub %2 Nie masz map offline? Pobierz tutaj: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hej, spójrz na mój znacznik w Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Zobacz moją aktualną lokalizację na mapie przy użyciu Organic Maps</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Cześć,
+
+Jestem teraz tutaj: %1. Naciśnij na ten link %2 lub ten %3, aby zobaczyć to miejsce na mapie.
+
+Dziękuję.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Udostępnij</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Skopiowano do schowka: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Gotowe</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dane OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Czy na pewno chcesz się wylogować ze swojego konta OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trasy</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Długość</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Udostępnij aktualne położenie</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Ustawienia ogólne</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informacje</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Nawigacja</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Przyciski „+” i „-” na mapie</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Wyświetla na ekranie</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Styl nocny podczas nawigacji w ciemności</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Tryb nocny</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Wyłączony</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Włączony</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatycznie</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Widok z perspektywy</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Budynki w 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Budynki 3D są wyłączone w trybie oszczędzania energii</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Komunikaty głosowe</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Wymawiaj nazwy ulic</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Po włączeniu nazwa ulicy lub zjazdu, w który należy skręcić, zostanie wymówiona na głos.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Język komunikatów</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Aby pobrać głos wyższej jakości, otwórz aplikację Ustawienia i przejdź do Dostępność → VoiceOver → Mowa → Głos.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testuj wskazówki głosowe (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Jeśli nie słyszysz głosu, sprawdź głośność lub systemowe ustawienia zamiany tekstu na mowę.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Niedostępne</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatyczne powiększanie</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Dystans</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Wyświetl na mapie</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Strona internetowa</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Wiadomości</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Opinia</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Oceń aplikację</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Pomoc</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Pytania i odpowiedzi</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Wspomóż</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Już przekazano</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Przypomnij później</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Wesprzyj Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Wesprzyj projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Prawa autorskie</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Zgłoś błąd</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Popraw kierunek strzałki, poruszając telefonem w ruchu w kształcie ósemki, aby skalibrować kompas.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Przesuń telefon ruchem w kształcie ósemki, aby skalibrować kompas i ustalić kierunek strzałki na mapie.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ponownie dotknij długo mapy, aby wyświetlić interfejs</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aktualizuj wszystkie</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Anuluj wszystko</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Pobrane</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>W kolejce</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Blisko mnie</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Pobierz wszystkie</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Pobieranie:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Aby usunąć mapę, zatrzymaj nawigację.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Trasy można tworzyć tylko pod warunkiem, że zawarte będą w ramach pojedynczej mapy.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Pobierz mapę</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Powtórz</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Usuń mapę</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aktualizuj mapę</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Usługi lokalizacyjne Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Szybko określ swoją przybliżoną lokalizację przez Bluetooth, WiFi lub sieć komórkową</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Pobierz mapy wzdłuż trasy</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Tworzenie tras wymaga pobrania i zaktualizowania wszystkich map od Twojej lokalizacji do celu podróży.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Brak wolnego miejsca</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Proszę włączyć usługi lokalizacji</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Zapisz</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>utwórz</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Czerwony</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Żółty</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Niebieski</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zielony</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Fioletowy</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Pomarańczowy</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brązowy</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Różowy</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Ciemnopurpurowy</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Jasnoniebieski</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Niebieskozielony</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Szmaragdowy</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Ciemnopomarańczowy</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Szary</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Szaroniebieski</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informacje</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Wersja Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Wygląd</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Jasny</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Ciemny</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Jasny od świtu do zmierzchu</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Inny</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Podaruj darmowe mapy bez reklam milionom użytkowników!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Zgłoś lub napraw nieprawidłowe dane mapy</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Wolontariusz</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Śledź nas i skontaktuj się z nami:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Klient pocztowy nie został skonfigurowany. Proszę skonfigurować go, bądź skorzystać z innych opcji, aby się z nami skontaktować na %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Błąd wysyłania wiadomości</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibracja kompasu</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Dostępne</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Znaleziono</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aktualizacja</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Nieudane</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>zakładka</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Jadąc wyznaczoną trasą, pamiętaj, że:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Warunki na drodze, przepisy ruchu drogowego i znaki drogowe zawsze są ważniejsze niż wskazówki nawigacji;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Mapa może być niedokładna, a sugerowana trasa może nie być optymalnym sposobem dotarcia do celu;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Sugerowane trasy należy traktować jedynie jako rekomendacje;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Prosimy zachować ostrożność na trasach w strefie nadgranicznej: wyznaczone przez naszą aplikację trasy mogą przecinać granice państw w niedozwolonych do przekroczenia miejscach;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Podczas podróży zachowaj czujność i prowadź ostrożnie!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Sprawdź sygnał GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nie można wyznaczyć trasy. Nie można ustalić współrzędnych GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Sprawdź sygnał GPS. Aktywacja Wi-Fi pomoże w precyzyjnym określeniu położenia.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Włącz usługi określania lokalizacji</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Nie można ustalić współrzędnych GPS. Włącz usługi określania lokalizacji, aby wyznaczyć trasę.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Nie można zlokalizować trasy</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Nie można wyznaczyć trasy.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Zmień punkt początkowy lub docelowy.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Zmień punkt początkowy</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Nie wyznaczono trasy. Nie można zlokalizować punktu początkowego.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Wybierz punkt początkowy położony bliżej drogi.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Zmień punkt docelowy</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Nie wyznaczono trasy. Nie można zlokalizować punktu docelowego.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Wybierz punkt docelowy położony bliżej drogi.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nie można zlokalizować punktu postoju.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Dokonaj korekty punktu postoju.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Błąd systemowy</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Nie można wyznaczyć trasy z powodu błędu aplikacji.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Spróbuj ponownie</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nie teraz</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Chcesz pobrać mapę i wyznaczyć lepszą trasę, obejmującą więcej map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Pobierz mapę i wyznacz lepszą trasę, wykraczającą poza granice bieżącej mapy.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Pobierz wymagane pliki</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Pobierz i zaktualizuj dane mapy i wyznaczania trasy wzdłuż planowanej drogi, aby wyznaczyć trasę.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Aby rozpocząć wyszukiwanie i tworzenie tras, pobierz mapę, a nie będzie ci już potrzebne połączenie z Internetem.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Wybierz mapę</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Pokaż</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ukryj</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorie</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historia</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Przepraszamy, nic nie znaleziono.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Proszę pobrać region, w którym Państwo szukają lub spróbować dodać nazwę pobliskiego miasta/wsi.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historia wyszukiwania</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Uzyskaj szybki dostęp do ostatniego hasła wyszukiwania.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Wyczyść historię wyszukiwania</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artykuł pochodzi z wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Twoja lokalizacja</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Trasa od</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Trasa do</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Nawigacja jest dostępna tylko od twojej bieżącej lokalizacji.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Czy chcesz, byśmy zaplanowali trasę z Twojej bieżącej lokalizacji?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Dalej</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Od</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Do</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Dodaj harmonogram</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Usuń harmonogram</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Całą dobę (24 godziny)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Otwarte</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zamknięte</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Dodaj godziny zamknięcia</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Godziny pracy</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Tryb zaawansowany</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Tryb prosty</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Godziny zamknięcia</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Przykładowe wartości</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Popraw błąd</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Proszę wybrać lokalizację</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Prosimy o szczegółowe opisanie problemu, aby użytkownicy OpenStreetMap mogli naprawić błąd.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Albo zrób to sam na https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Wyślij</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>To miejsce nie istnieje</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Zamknięte z powodu prac konserwacyjnych</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Powielone miejsce</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatyczne pobieranie</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Codziennie</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Dziś nieczynne</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Nieczynne</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Dzisiaj</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Otwarcie za %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Zamknięcie za %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zamknięte</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edytuj godziny otwarcia</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nie masz konta w OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Zarejestruj się</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Zaloguj się</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nie zalogowano</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Zaloguj się do OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Hasło</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Nie pamiętasz hasła?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Wyloguj</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edytuj miejsce</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Dodaj język</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Ulica</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numer domu</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Szczegóły</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Media społecznościowe</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Budynek</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Dodaj ulicę</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Proszę wpisz nazwę ulicy</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Wybierz język</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Wybierz ulicę</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuchnia</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Wybierz kuchnię</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email lub nazwa użytkownika</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Dodaj numer telefonu</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Kondygnacja</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Piętro: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Wszystkie zmiany dotyczące mapy zostaną usunięte wraz z nią.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Aktualizuj mapy</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Aby utworzyć trasę, należy zaktualizować wszystkie mapy, a następnie ponownie zaplanować trasę.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Znajdź mapę</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Sprawdź swoje ustawienia i upewnij się, że urządzenie ma połączenie z Internetem.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Brak wolnego miejsca</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Usuń niepotrzebne dane</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Błąd logowania.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Zmiany zweryfikowane</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Proszę przeciągnąć mapę, aby umieścić krzyżyk w miejscu lokalizacji miejsca lub firmy.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Edycja</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Dodawanie</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nazwa miejsca</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Jak napisano w lokalnym języku</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Szczegółowy opis problemu</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Inny problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Dodaj organizację</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Obiekt nie może znajdować się tutaj</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dane OpenStreetMap stworzone przez społeczność na dzień %1. Dowiedz się więcej o tym, jak edytować i aktualizować mapę na stronie OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) to projekt społecznościowy mający na celu stworzenie darmowej i otwartej mapy. Jest to główne źródło danych mapowych w Organic Maps i działa podobnie do Wikipedii. Można dodawać lub edytować miejsca, które stają się dostępne dla milionów użytkowników na całym świecie.
+Dołącz do społeczności i pomóż stworzyć lepszą mapę dla wszystkich!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Proszę utworzyć konto OpenStreetMap lub zalogować się, aby opublikować swoje zmiany na mapie.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 z %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Czy pobrać, używając połączenia z siecią komórkową?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Może to być kosztowne przy niektórych planach taryfowych lub w roamingu.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Wprowadź poprawny numer domu</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Liczba kondygnacji (maks. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Liczba kondygnacji nie może przekraczać %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Kod pocztowy</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Podaj prawidłowy kod pocztowy</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Uwaga dla wolontariuszy OpenStreetMap (opcjonalnie)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Proszę opisać błędy na mapie lub rzeczy, których nie można edytować za pomocą Organic Maps.</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Państwa zmiany są przesyłane do publicznej bazy danych &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Pl:Wstęp&quot;&gt;OpenStreetMap&lt;/a&gt;. Prosimy nie dodawać informacji osobistych lub chronionych prawem autorskim.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Więcej o OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Twoja historia edycji</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Twoje uwagi dotyczące danych mapy</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nie możesz znaleźć odpowiedniej kategorii?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps pozwala na dodawanie tylko prostych kategorii punktów, co oznacza brak miast, dróg, jezior, obrysów budynków itp. Dodaj takie kategorie bezpośrednio do &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Sprawdź nasz &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;przewodnik&lt;/a&gt;, aby uzyskać szczegółowe instrukcje krok po kroku.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Nie pobrano żadnych map</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Aktualna lokalizacja jest nieznana.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>godz</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Więcej</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edytuj zakładkę</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notatki osobiste (tekst lub html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentarz…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Usunąć wszystkie lokalne zmiany?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Usuń</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Usunąć dodane miejsce?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Usuń</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Takie miejsce nie istnieje</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Proszę opisz powód usunięcia miejsca</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Wprowadź poprawny numer telefonu</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Wpisz prawidłowy adres strony internetowej</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Wpisz prawidłowy email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Wprowadź poprawny link, nazwę konta lub nazwę strony na Facebooku</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Wprowadź poprawny link lub nazwę konta na Instagramie</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Wprowadź poprawny adres lub nazwę konta na Twitterze</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Wprowadź poprawny adres lub nazwę konta na VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Wpisz prawidłowy url LINE lub LINE ID</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Dodaj miejsce do OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Możesz też zostawić uwagę dla społeczności OpenStreetMap, aby ktoś inny mógł dodać lub poprawić to miejsce.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Uwaga zostanie wysłana do OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Czy chcesz wysłać je wszystkim użytkownikom?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Upewnij się, że nie podałeś osobistych danych.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Redaktorzy OpenStreetMap sprawdzą zmiany i skontaktują się z Tobą, jeśli będą mieli jakiekolwiek pytania.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Rejestrowanie trasy</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Zaakceptuj</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Odrzuć</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Wykorzystać dane mobilne, aby wyświetlić dane szczegółowe?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Stosuj zawsze</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Tylko dzisiaj</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Nie stosuj dzisiaj</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Dane mobilne</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Dane mobilne są wymagane do powiadomień o aktualizacji map i wyświetlania dokładniejszych informacji o miejscach i zakładkach.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nigdy nie stosuj</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Zawsze pytaj</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Aby wyświetlić dane o ruchu, muszą zostać zaktualizowane mapy.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Powiększ rozmiar czcionki na mapie</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Zaktualizuj Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Dane o ruchu są niedostępne</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Włącz zbieranie danych</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Ogólne uwagi</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Stosujemy system TTS dla komend głosowych. Stosuje go wiele urządzeń z systemem Android, można go pobrać lub zaktualizować z Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>W przypadku niektórych języków wymagana będzie instalacja innego syntezatora lub pakietu językowego ze strony aplikacji (Google Play, Galaxy Store, App Gallery, FDroid). Otwórz ustawienia urządzenia → Język i klawiatura → Mowa → Przetwarzanie tekstu na mowę.
+Możesz w tym miejscu zarządzać ustawieniami syntezy mowy (np. pobrać pakiet językowy do stosowania offline) i wybrać inny silnik przetwarzania tekstu na mowę.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Aby uzyskać więcej informacji, spójrz na ten poradnik.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transkrypcja na alfabet łaciński</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Dowiedz się więcej</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Użyj wyszukiwarki, wybierz zakładkę lub dotknij mapy, aby dodać punkt początkowy trasy</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Użyj wyszukiwarki, wybierz zakładkę lub dotknij mapy, aby dodać punkt docelowy</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Zarządzaj trasą</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Zaplanuj</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Usuń postój</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Dodaj postój</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Zapisano</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Zaloguj się do OpenStreetMap, aby automatycznie przesyłać wszystkie zmiany na mapie. Dowiedz się więcej &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;tutaj&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problem z dostępem do pamięci masowej</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Zewnętrzny nośnik pamięci masowej jest niedostępny. Prawdopodobnie usunięto lub uszkodzono kartę SD bądź jej system plików służy tylko do odczytu. Zweryfikuj to i skontaktuj się z nami pod adresem support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emuluj wadliwą pamięć masową</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Wprowadź poprawną nazwę</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listy</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ukryj wszystkie</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Pokaż wszystkie</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n zakładka</numerusform>
+<numerusform>%n zakładki</numerusform>
+<numerusform>%n zakładek</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Utwórz nową listę</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importuj zakładki i trasy</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nie można udostępnić z powodu błędu aplikacji</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Błąd udostępniania</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Nie można udostępnić pustej listy</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Nazwa nie może być pusta</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Wprowadź nazwę listy</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nowa lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ta nazwa jest już zajęta</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Wybierz inną nazwę</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Proszę czekać…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numer telefonu</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Znaleziono %n plik. Zobaczysz go po konwersji.</numerusform>
+<numerusform>Znaleziono %n pliki. Zobaczysz je po konwersji.</numerusform>
+<numerusform>Znaleziono %n plików. Zobaczysz je po konwersji.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Przywróć</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trasa</numerusform>
+<numerusform>%n trasy</numerusform>
+<numerusform>%n tras</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Prywatność</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Polityka prywatności</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Warunki użytkowania</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Ruch drogowy</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Turystyka piesza</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Jazda rowerem</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Style i warstwy mapy</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Lista jest pusta</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Aby dodać zakładkę, dotknij miejsca na mapie, a następnie dotknij ikony gwiazdy.</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Zmień kolor wszystkich zakładek</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Zmień kolor wszystkich tras</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…więcej</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Eksportuj KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Eksport GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Eksportuj GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Usuń listę</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Fotoradary</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Opis miejsca</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Pobieranie map</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Aby ostrzec Cię przed przekroczeniem prędkości</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Zawsze ostrzegaj</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nigdy nie ostrzegaj</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Tryb oszczędzania energii</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Jeśli jest włączony tryb oszczędzania energii, wtedy aplikacja wyłączy funkcje energochłonne, zależnie od bieżącego poziomu załadowania telefonu</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nigdy</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automatycznie</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Maksymalna oszczędność energii</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nazwy zakładek na mapie</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Jeśli zakładek jest zbyt wiele, wyświetlanie ich nazw na mapie może spowolnić działanie aplikacji.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Pokaż po prawej stronie</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Pokaż na środku</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Ta opcja zostaje włączona do zbierania danych działań w celach diagnostycznych. Pomaga to zespołowi zidentyfikować problemy z aplikacją. Włączaj opcję tylko na żądanie wsparcia technicznego Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Ustawienia nawigacji</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Unikaj płatnych dróg</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Unikaj dróg gruntowych</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Unikaj przepraw promowych</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Unikaj autostrad</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Brak możliwości zbudowania trasy</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Wyznaczanie trasy nie powiodło się. Przyczyną mogą być ustawienia nawigacji lub niekompletne dane OpenStreetMap. Zmień ustawienia i spróbuj ponownie</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Dostosuj ścieżkę objazdu</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Ustawienia objazdu są włączone</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Droga płatna</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Droga gruntowa</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Przeprawa promowa</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Tak</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nie</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Tak</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nie</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Pojemność: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Sieć: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Jesteś na miejscu!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sortuj…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sortuj znaczniki</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Domyślnie</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Wg rodzaju</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Wg odległości</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Wg daty</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Według nazwy</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Tydzień temu</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Miesiąc temu</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Ponad miesiąc temu</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Ponad rok temu</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>W pobliżu</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Inne</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Planowanie trasy nieudane</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Przybycie: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Dokonałeś zmian na mapie świata. Nie kryj się z tym! Powiadom znajomych i edytujcie mapę razem.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Udostępnij znajomym</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Nieczynne</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Otwarcie jutro o %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Otwarcie %1 o %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Otwarcie o %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Zamknięcie o %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Dodaj godziny otwarcia</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Hasło (minimum 8 znaków)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nieprawidłowa nazwa użytkownika lub hasło.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Konto OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Ostatnio przesłane</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Dziękujemy</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nazwa miejsca</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Uwaga!</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Błąd pobierania</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Wybierz kategorię</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popularne</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Wszystkie kategorie</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Dodawaj nowe miejsca do mapy i edytuj już istniejące bezpośrednio z poziomu aplikacji.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Zmień lokalizację</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Aby pobrać, potrzebujesz więcej miejsca. Usuń niepotrzebne dane.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Dokonałem poprawek map na Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Szczegółowy komentarz</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Twoje sugestie zmian zostaną wysłane do społeczności OpenStreetMap. Opisz szczegóły, których nie można edytować w Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Podczas szukania twojej lokalizacji wystąpił błąd. Sprawdź czy twoje urządzenie działa poprawnie i spróbuj ponownie później.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Identyfikacja lokalizacji jest wyłączona</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Włącz dostęp do geolokalizacji w ustawieniach urządzenia</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Uruchom ustawienia</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Dotknij „Lokalizacja”</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Zaznacz Podczas korzystania z aplikacji</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Wybierz Prywatność</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Wybierz Usługi lokalizacji</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Włącz usługi lokalizacji</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Lub kontynuuj korzystanie z Organic Maps bez lokalizacji</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Zarezerwuj</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Zadzwoń</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nazwa zakładki</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Usuń zakładkę</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Twoja notatka zostanie wysłana do OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…więcej</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aktualizuj</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Wyłączyć rejestrowanie niedawno przebytej trasy?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Wyłącz</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Sprawdź</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps używa w tle geolokalizacji w celu rejestrowania niedawno przebytej trasy.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Ustawienia ogólne</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Aby wyświetlić dane o ruchu, należy zaktualizować aplikację.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Rozmiar pliku dziennika: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Przeciągnij tu, aby usunąć</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Zastąp przystanek</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Zacznij od</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Zaloguj się do OpenStreetMap, aby automatycznie przesyłać wszystkie zmiany na mapie. Dowiedz się więcej</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>tutaj</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ukryj ekran</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 z %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Pobieranie %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Stosowanie zmian %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ta nazwa jest za długa</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Wykryto nowe pliki</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konwertuj</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>błąd</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Sommige bestanden waren niet geconverteerd.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Wystąpił błąd</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popularne</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ukryj mapy</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Wystąpił błąd podczas pobierania tagów, spróbuj ponownie</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Prawo</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Przycisk</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Jedźmy</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Meta</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Wyśrodkuj</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Wyniki wyszukiwania</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Dalej</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Czy chcesz wyznaczyć trasę ponownie?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Klawiatura nie jest dostępna podczas ruchu</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Brak możliwości zbudowania trasy od bieżącej lokalizacji</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Brak możliwości zbudowania trasy do punktu końcowego. Wybierz inny</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Brak sygnału GPS. Dostań się do terenu otwartego</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Brak możliwości zbudowania trasy. Wybierz inne punkty trasy</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Aby wyznaczyć trasę, pobierz brakujące mapy na Twoim urządzeniu</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Wystąpił błąd. Uruchom aplikację ponownie</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Trasa zostanie przebudowana z Twojej bieżącej lokalizacji</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Trasa zostanie zmieniona na samochodową</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nie wszystkie zakładki są wyświetlane</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Przełącz się na telefon, aby zobaczyć wszystkie zakładki</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kamery</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Ostrzeżenia o fotoradarach</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Pobierz mapy do aplikacji Organic Maps na swoje urządzenie</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 zjazd</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortuj domyślnie</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sortuj wg rodzaju</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sortuj wg odległości</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sortuj wg daty</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sortuj według nazwy</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Jedzenie</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Zabytki</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzea</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parki</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Pływanie</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Góry</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Zwierzęta</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotele</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Budynki</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Pieniądze</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Sklepy</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkingi</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Stacje paliw</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Lecznictwo</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Wyszukaj na liście</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Święte miejsca</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Wybierz listę</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Nawigacja metrem nie jest jeszcze tutaj dostępna</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Nie znaleziono trasy metra</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Wybierz punkt początkowy lub końcowy trasy najbliżej do stacji metra</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Poziomice</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Do skorzystania z poziomic, pobierz mapę tego obszaru.</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Poziomice nie są jeszcze dostępne w tym regionie</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Wejście</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Zejście</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. wysokość</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. wysokość</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Trudność</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Odległ.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Trasa:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Powiększ mapę, aby zobaczyć poziomice</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Pobieranie</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Pobierz mapę świata</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nie udało się stworzyć folderu i przenieść plików do pamięci wewnętrznej lub karty SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Błąd pamięci</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Błąd połączenia</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Odłącz kabel USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Pozostaw ekran włączony</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Po włączeniu ekran będzie zawsze włączony podczas wyświetlania mapy.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Pokazuj na ekranie blokady</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Po włączeniu tej funkcji nie będziesz musieć odblokowywać urządzenia za każdym razem, gdy aplikacja jest uruchomiona.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Język mapy</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dane mapy z OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/pl/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/pl/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Pl:Wstęp</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Dziękujemy za korzystanie z naszych map stworzonych przez społeczność!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Dzięki Twoim darowiznom i wsparciu możemy tworzyć najlepsze mapy na świecie!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Czy podoba Ci się nasza aplikacja? Przekaż darowiznę, aby wesprzeć rozwój! Jeszcze ci się to nie podoba? Daj nam znać, a my to naprawimy!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Jeśli znasz programistę, możesz poprosić go o wdrożenie potrzebnej funkcji.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Proszę dotknąć dowolnego miejsca na mapie, aby wybrać cokolwiek. Długie dotknięcie pozwala ukryć i wyświetlić interfejs.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Czy wiesz, że możesz wybrać swoją aktualną lokalizację na mapie?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Możesz pomóc w tłumaczeniu naszej aplikacji na swój język.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Nasza aplikacja jest rozwijana przez kilku entuzjastów i społeczność.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Możesz łatwo naprawić i ulepszyć dane mapy.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Naszym głównym celem jest tworzenie szybkich, zapewniających prywatność i łatwych w użyciu map, które pokochasz.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Korzystasz teraz z Organic Maps na ekranie telefonu</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Korzystasz teraz z Organic Maps na ekranie samochodu</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Jesteś połączony z Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Kontynuuj na telefonie</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Do ekranu samochodu</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Aplikacja Organic Maps wymaga dostępu do lokalizacji. Gdy będzie to bezpieczne, sprawdź powiadomienie w telefonie.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ta aplikacja wymaga Twojej zgody</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps w Android Auto wymagają uprawnień do lokalizacji, aby działać efektywnie</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Przyznaj uprawnienia</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Aktywność outdoorowa</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Przeglądarka internetowa jest niedostępna</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Głośność</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksportuj wszystkie zakładki i ścieżki</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Ustawienia systemu syntezy mowy</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nie znaleziono ustawień syntezy mowy, czy Twoje urządzenie na pewno je obsługuje?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Przejazd</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Wyczyść wyszukiwanie</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Powiększ</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Pomniejsz</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link do menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Wyświetl menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Otwórz w innej aplikacji</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Samoobsługa</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Wybierz opcję</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Siedzenia na zewnątrz</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Aby uzyskać najbardziej dokładną nawigację, zalecamy wyłączenie trybu oszczędzania energii w ustawieniach baterii telefonu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Nagraj trasę</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Zatrzymaj nagrywanie trasy</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Nagrywanie trasy</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Zatrzymaj bez zapisywania</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Kontynuuj nagrywanie</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Zapisać nagranie w zakładkach i trasach?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Trasa jest pusta - nic do zapisania</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nie można wyświetlić okna dialogowego wyboru folderu, ponieważ na urządzeniu nie zainstalowano odpowiedniej aplikacji. Proszę zainstalować aplikację menedżera plików i spróbować ponownie</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Wybierz kolor</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edytuj trasę</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Brak zainstalowanej aplikacji, która może otworzyć lokalizację</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto w nawigacji</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Zgodnie z systemem</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Udostępnij trasę</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Usunąć %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Poziom trudności</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Łatwy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Umiarkowany</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Skomplikowany</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Aktualizacja</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Zaktualizuj pobrane mapy</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Aktualizacja map umożliwia uzyskanie bieżących informacji o obiektach</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Zaktualizuj (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Zaktualizuj ręcznie później</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Usuń trasę</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Czy na pewno chcesz usunąć ten ślad?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nazwa śladu</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Przenieś</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trasa</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Zmień kolor</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Chcesz wysłać raport o błędzie do deweloperów?
+Polegamy na naszych użytkownikach, ponieważ Organic Maps nie zbiera żadnych informacji o błędach automatycznie. Z góry dziękujemy za wspieranie Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Włącz synchronizację iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Synchronizacja iCloud jest eksperymentalną funkcją w fazie rozwoju. Upewnij się, że wykonałeś kopię zapasową wszystkich zakładek i utworów.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud jest wyłączony</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aby korzystać z tej funkcji, włącz usługę iCloud w ustawieniach urządzenia.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Włącz</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Kopia zapasowa</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Błąd synchronizacji iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Błąd: Nie udało się zsynchronizować z powodu błędu połączenia</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Błąd: Nie udało się zsynchronizować z powodu przekroczenia limitu iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Błąd: usługa iCloud jest niedostępna</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Ostatnio usunięte listy</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Wyczyść</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Usuń wszystko</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Odzyskaj</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Odzyskaj wszystko</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Współtwórz OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Dodaj miejsce</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Zaktualizuj mapę, aby współtworzyć</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Musisz zaktualizować mapę %1 do najnowszej wersji, zanim będziesz mógł współtworzyć dane OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Moje położenie</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Moje miejsca</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Wewnętrzna pamięć prywatna</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Wewnętrzna pamięć współdzielona</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Karta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Zewnętrzna pamięć współdzielona</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Kod pocztowy</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punkt mapy</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Aby wyświetlić trasy, należy zaktualizować mapy.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Wyjście</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Wejście</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Mapa metra jest niedostępna</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ty</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Fioletowe pobrane regiony</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Trasa</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Określanie w tle bieżącej lokalizacji jest konieczne, aby w pełni korzystać z funkcjonalności aplikacji. Funkcji tej używa się w ramach opcji podążania zgodnie z trasą i zapisywania niedawno przebytej trasy.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Określanie bieżącej lokalizacji używane jest w przypadku opcji podążania trasą i zapisywania ostatnio przebytej trasy.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Proszę zalogować się przy użyciu hasła</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Logowanie za pomocą przeglądarki</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Ostatnio używane</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Kolor zakładek zmieniony</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Kolor tras zmieniony</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Widmo</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Suwaki</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>CZERWONY</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZIELONY</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>NIEBIESKI</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Kolor szesnastkowy sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Siatka</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/pt-BR/omim.ts
+++ b/qt/translations/pt-BR/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="pt-BR">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Voltar</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Apagar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Baixar mapas</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>O download falhou. Toque para tentar de novo.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Baixando…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Quilômetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milhas</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Depois</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Buscar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Procurar no mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Atualmente todos os serviços de localização para este dispositivo ou aplicativo estão desativados. Por favor ative-os em configurações.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisão limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Para garantir uma navegação precisa, ative a Localização Precisa nas configurações.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostrar no mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>O download falhou</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Tente novamente</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Sobre Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Livre para todos, feito com amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sem anúncios, sem rastreamento, sem coleta de dados</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Sem consumo de bateria, funciona off-line</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rápido, minimalista, desenvolvido pela comunidade</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicativo de código aberto criado por entusiastas e voluntários.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Configurações de Localização</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Fechar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>É necessário OpenGL acelerado por hardware. Infelizmente o seu dispositivo não é compatível.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Baixar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Por favor, desconecte o cabo USB ou insira um cartão de memória para utilizar Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Por favor, libere primeiro algum espaço no cartão SD/armazenamento USB para utilizar o aplicativo</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Antes de começar, vamos baixar a visão geral mundial para o seu dispositivo.
+É necessário %1 de armazenamento.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ir para o mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Baixando %1. Você pode
+continuar para o mapa agora.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Baixar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Atualizar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausar</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuar</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>O download de %1 falhou</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Adicionar novo conjunto</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nome da lista de marcadores</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Marcadores</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Favoritos e trilhas</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nome</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Endereço</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Configurações</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Salvar mapas para</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Selecione o local para onde os mapas devem ser baixados.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapas baixados</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 livre de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Mover mapas?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Erro ao mover arquivos de mapas</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Isto pode demorar alguns minutos.
+Por favor, aguarde…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidades de medidas</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Escolha entre milhas e quilômetros</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancelar download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Deixe uma avaliação</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Baixar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Listas de favoritos</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Onde comer</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Mercados</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Combustível</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Estacionamento</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compras</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>De segunda mão</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Atrações</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretenimento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Caixa eletrônico</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida noturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Feriados em família</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banco</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmácia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Banheiro</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Correios</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polícia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclagem</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Água</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Instalações para trailers</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Anotações</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Favoritos do Organic Maps foram compartilhados com você</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Olá!
+
+Segue em anexo meus favoritos do app Organic Maps. Se tiver instalado o Organic Maps, pode abri-los agora. Caso não tenha, baixe o app para o seu dispositivo iOS ou Android via o link https://omaps.app/get?kmz
+
+Disfrute viajar com o Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Carregando favoritos</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Favoritos carregados com sucesso! Você pode encontrá-los no mapa ou na tela de gestão dos favoritos.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Falha no envio dos favoritos. O arquivo pode estar corrompido ou com defeito.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>O tipo de arquivo não é reconhecido pelo aplicativo:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Falha ao abrir o arquivo %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Sua localização ainda não foi determinada</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Lamentamos, as configurações do armazenamento do mapa estão desativadas.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>O download do país está atualmente em progresso.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Confira minha localização atual no Organic Maps! %1 ou %2 Não tem mapas offline? Baixe aqui: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Ei, dê uma olhada no meu pin no Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Veja no mapa a minha localização atual via Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Olá,
+
+Estou aqui agora: %1. Clique neste link %2 ou neste %3 para ver o local no mapa.
+
+Obrigado.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Compartilhar</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiado para a área de transferência: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Feito</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dados do OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Você tem certeza de que deseja sair da sua conta do OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trilhas</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Comprimento</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Compartilhar a minha localização</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Configurações gerais</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informações</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegação</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botões &quot;+&quot; e &quot;-&quot; no mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Mostrar na tela</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estilo noturno ao navegar no escuro</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo Noturno</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desligar</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Em</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automotivo</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Visão em perspectiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Prédios em 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Os edifícios 3D são desativados no modo de economia de energia</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Orientação por voz</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar Nomes de Ruas</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Quando ativado, o nome da rua ou da saída para a qual se deve virar será falado em voz alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Idioma de voz</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Para baixar uma voz de maior qualidade, abra o app Ajustes e acesse Acessibilidade → VoiceOver → Fala → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testar Instruções de Voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Verifique o volume ou as configurações de conversão de texto em fala do sistema se você não estiver ouvindo a voz agora.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Não disponível</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automático</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distância</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver no mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Site</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Notícias</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Opinião</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Avaliar o aplicativo</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ajuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Perguntas Frequentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doação</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Já doou</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Lembrar mais tarde</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Apoiar o Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Apoiar o projeto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Direitos autorais</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Relatar um problema</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Melhore a direção da seta movendo o telefone em um movimento em forma de oito para calibrar a bússola.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mova o telefone em um movimento em forma de oito para calibrar a bússola e fixar a direção da seta no mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Toque longamente no mapa novamente para ver a interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Atualizar tudo</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancelar tudo</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Baixado</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Em fila</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Perto de mim</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Baixar tudo</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Baixando:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Favor parar a navegação para apagar o mapa.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Só podem ser criadas rotas que estejam totalmente contidas em um mapa de uma única região.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Baixar o mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Tentar novamente</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Apagar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Mapa de atualização</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Serviços de localização do Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determine rapidamente sua localização aproximada via Bluetooth, WiFi ou rede móvel</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Baixar todos os mapas ao longo do trajeto</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Para criar uma rota é necessário baixar e atualizar todos os mapas desde sua localização atual até o destino.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Não há espaço suficiente</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Por favor, ative os Serviços de Localização</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Salvar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>criar</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Vermelho</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Amarelo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Roxo</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Laranja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Marrom</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Lilás escuro</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Azul claro</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Ciano</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Azul petróleo</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Verde limão</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Laranja escuro</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Cinza</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Azul escuro</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informações</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versão do Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aparência</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Clara</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Escura</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Claro do amanhecer ao anoitecer</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Outros</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Ofereça mapas gratuitos e sem anúncios a milhões de usuários!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Relatar ou corrigir dados incorretos do mapa</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Voluntarie-se</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Siga-nos e entre em contato conosco:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>O cliente de email não está configurado. Por favor, configure-o ou utilize qualquer outro modo para nos contatar através de %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Erro no envio de email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibração da bússola</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponível</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Encontrado</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Atualização</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Falha</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>marcador de página</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Ao seguir a rota, lembre-se que:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— As condições da estrada, as leis de trânsito e as sinalizações da pista sempre terão prioridade acima das sugestões de navegação;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— O mapa pode estar desatualizado e a rota indicada pode não ser a melhor maneira de chegar ao destino;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— As rotas indicadas devem ser consideradas apenas como sugestões;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Tenha cautela com rotas em zonas fronteiriças: as rotas criadas por nosso aplicativo podem algumas vezes cruzar fronteiras nacionais em locais não autorizados.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Fique sempre alerta nas estradas!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Verificar o sinal de GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>A rota não foi traçada, pois não foi possível identificar as coordenadas do GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifique seu sinal de GPS. A ativação do Wi-Fi melhorará a precisão da localização.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Ativar serviços de localização</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Não foi possível localizar as coordenadas do GPS. Ative os serviços de localização para que a rota seja traçada.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Não é possível localizar a rota</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Não foi possível gerar uma rota.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ajuste seu ponto de partida ou destino.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ajustar o ponto de partida</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>A rota não foi traçada, pois não foi possível localizar o ponto de partida.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Selecione um ponto de partida mais próximo de uma estrada.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajustar o destino</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>A rota não foi traçada, pois não foi possível localizar o ponto de chegada.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Selecione um ponto de destino localizado mais perto de uma estrada.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Incapaz de localizar o ponto intermediário.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Por favor, ajuste seu ponto intermediário.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Erro do sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Não foi possível traçar uma rota devido a um erro no aplicativo.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Por favor, tente novamente</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Agora não</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Deseja baixar o mapa e traçar uma rota melhor, mas que se estenda por mais de um mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Baixe o mapa para traçar uma rota melhor que vai além dos limites desse mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Baixar os arquivos necessários</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Baixe e atualize todos os dados de mapa e roteamento referentes ao trajeto desejado para que a rota seja traçada.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Para começar a pesquisar e criar rotas, por favor, baixe o mapa. Assim, você não precisará mais de uma conexão com a internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Selecionar mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostrar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Esconder</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorias</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>História</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Sinto muito, nenhum resultado foi encontrado.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Faça o download da região onde está pesquisando ou tente adicionar o nome de uma cidade ou povoado ao redor.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Histórico de busca</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Visualizar as buscas recentes.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Limpar histórico de pesquisa</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artigo da wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Sua localização</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Início</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Rota de</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Para</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>A navegação só está disponível a partir de sua localização atual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Deseja planejar uma rota a partir da sua localização atual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Próximo</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Para</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Adicionar horário</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Eliminar horário</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>O dia todo (24 horas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Aberto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Adicionar Horários Não Comerciais</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horários Comerciais</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modo Avançado</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modo Simples</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horários Não Comerciais</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Exemplo de Valores</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Erro correto</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Selecionar Localização</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Por favor, descreva o problema em detalhes para que a comunidade OpenStreetMap possa corrigir o erro.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ou faça-o você mesmo em https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Enviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Esse lugar não existe</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Fechado para manutenção</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lugar duplicado</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Download automático</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diariamente</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Fechado hoje</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hoje</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Abre em %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Fecha em %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editar horário comercial</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Sem conta no OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Abra uma conta no OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Não conectado</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Faça login no OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Senha</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Esqueceu sua senha?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Encerrar sessão</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar local</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Adicionar um idioma</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rua</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>N.º do endereço</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalhes</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Mídia social</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edifício</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Adicionar uma rua</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Por favor, digite o nome da rua</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Escolha um idioma</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Escolha uma rua</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cozinha</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Selecione a culinária</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ou nome de usuário</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Adicionar número de telefone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Piso</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Andar: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Todas as edições no mapa serão excluídas juntamente com o mapa.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Atualizar mapas</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Para criar um itinerário é necessário atualizar todos os mapas e, em seguida, planejá-lo novamente.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Localizar mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Por favor, verifique as suas configurações e certifique-se de que o dispositivo está conectado à internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Não há espaço suficiente</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Exclua todos os dados desnecessários</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Erro no login.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Alterações verificadas</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Arraste o mapa para colocar a cruz na localização do local ou da empresa.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Edição</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adicionando</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nome do local</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Como está escrito no idioma local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descrição detalhada do problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Problema diferente</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Adicionar uma empresa</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Nenhum objeto pode ser localizado aqui</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dados do OpenStreetMap criados pela comunidade em %1. Saiba mais sobre como editar e atualizar o mapa em OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>O OpenStreetMap (OSM) é um projeto comunitário aberto para construir um mapa gratuito. O OSM é a principal fonte de dados de mapas do Organic Maps e funciona de forma semelhante à Wikipédia. Você pode adicionar ou editar lugares e eles ficam disponíveis para milhões de usuários no mundo todo.
+Junte-se à comunidade e ajude a criar um mapa melhor para todos!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Crie uma conta no OpenStreetMap ou faça login para publicar suas edições de mapas para o mundo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Baixar usando uma conexão de rede celular?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Isto pode ser muito caro com alguns planos ou se você estiver em roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Informe o número correto do endereço</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Número de andares (máx. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>O número de andares não pode ser maior que %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>CEP</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Informe o CEP correto</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota para os voluntários do OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Descreva erros no mapa ou coisas que não podem ser editadas com o Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>As suas edições são enviadas à base de dados pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Não adicione informações pessoais ou protegidas por direitos autorais.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mais sobre OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Seu histórico de edição</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Suas notas de dados do mapa</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Você não encontra uma categoria adequada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>O Organic Maps permite que você adicione apenas categorias de pontos simples, o que significa que não há cidades, estradas, lagos, contornos de edifícios etc. Por favor, adicione essas categorias diretamente no &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte nosso &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guia&lt;/a&gt; para obter instruções detalhadas passo a passo.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Você não fez o download de nenhum mapa</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Baixe mapas para pesquisar locais e usar navegação offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>A localização atual é desconhecida.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mais informações</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar marcador</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Anotações pessoais (texto ou html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Descartar todas as modificações locais?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Descartar</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Remover local adicionado?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Remover</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>O lugar não existe</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Por favor, explica o motivo pelo qual você está retirando o local</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Digite um número de telefone correto</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Digite um endereço de site válido</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Digite um endereço de email válido</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Insira um endereço da Web, conta ou nome de página válidos do Facebook</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Insira um nome de usuário ou endereço web válido do Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Insira um nome de usuário ou endereço web válido do Twitter/X</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Insira um nome de usuário ou endereço web VK válido</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Insira um ID ou endereço web válido do LINE</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Adicionar local ao OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ou então escreva uma nota para a comunidade OpenStreetMap para que outra pessoa possa adicionar ou corrigir um lugar aqui.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>A nota será enviada para o OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Deseja enviar para todos os usuários?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Certifique-se de não ter incluído nenhum dado pessoal.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Os editores do OpenStreetMap verificarão as mudanças e entrarão em contato com você se tiverem alguma dúvida.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Pare</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Registro da pista</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aceitar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Declinar</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Utilizar a internet móvel para mostrar informações detalhadas?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Usar sempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Somente hoje</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Não utilizar hoje</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet móvel</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Para visualizar informações detalhadas sobre os locais, tais como fotos, preços e avaliações, é necessário acesso à internet móvel.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nunca usar</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Pergunte sempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Para ver os dados de tráfego, os mapas devem ser atualizados.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumentar o tamanho dos rótulos dos mapas</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Atualize o Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Não existem dados de tráfego</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Ativar o registro</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Comentários gerais</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Utilizamos o sistema TTS (texto-para-voz) para instruções de voz. Muitos dispositivos do Android usam o TTS do Google, você pode baixá-lo ou atualizá-lo no Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Para alguns idiomas, você precisa instalar um sintetizador de fala ou um pacote adicional de linguagem da loja de aplicativo (Google Play Market, Samsung Apps).
+Abra as configurações do seu dispositivo → Idioma e entrada → Fala → Saída de texto para fala.
+Aqui você pode gerenciar as configurações para o sintetizador de fala (por exemplo, baixar pacote de idioma para usar off-line) e selecionar outro motor de texto-para-fala.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Para obter mais informações, consulte este guia.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterar para alfabeto latino</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Saiba mais</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use a busca ou toque no mapa para adicionar um ponto de partida da rota</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use a pesquisa, selecione um marcador ou toque no mapa para adicionar um ponto de destino</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gerenciar rota</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planejar</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remover parada</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Adicionar parada</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Salvo</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Faça login no OpenStreetMap para carregar automaticamente todas as edições de mapas que você fizer. Saiba mais &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aqui&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema de acesso ao armazenamento</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>O armazenamento externo não está disponível. É provável que o cartão SD tenha sido removido, danificado ou o sistema de arquivo seja apenas para leitura. Verifique e entre em contato conosco em support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emular memória ruim</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Por favor, digite um nome correto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listas</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ocultar tudo</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Exibir tudo</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n favorito</numerusform>
+<numerusform>%n favoritos</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Criar uma nova lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar favoritos e trilhas</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Impossível compartilhar devido a um erro do aplicativo</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Erro de compartilhamento</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Impossível compartilhar uma lista vazia</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>O nome não podia estar vazio</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Por favor insira o nome da lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nova lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Esse nome já está sendo usado</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Por favor, escolha outro nome</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Espere, por favor…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de telefone</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil do OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n arquivo foi encontrado. Você vai ver depois da conversão.</numerusform>
+<numerusform>%n arquivos foram encontrados. Você os verá depois da conversão.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurar</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trilha</numerusform>
+<numerusform>%n trilhas</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidade</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Política de privacidade</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Termos de uso</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráfego</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Caminhadas</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metrô</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos e camadas de mapas</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta lista está vazia</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Para adicionar um favorito, toque no mapa e então toque no ícone de estrela</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Alterar a cor de todos os favoritos</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Alterar a cor de todas as trilhas</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mais</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Deletar lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Câmeras de trânsito</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descrição do lugar</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Downloader do mapa</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avisar se estiver em excesso de velocidade</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Sempre avise</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nunca avise</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modo de economia de energia</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Tentar reduzir o consumo de energia em detrimento de algumas funcionalidades.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Quando a bateria está fraca</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nomes de marcadores no mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Se houver muitos favoritos, a exibição de seus nomes no mapa pode deixar o aplicativo lento.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostrar à direita</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostrar na parte inferior</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>A opção ativa logging para realizar diagnósticos. Pode ser útil para nossa equipe de suporte que estão solucionando problemas com o aplicativo. Ative esta opção apenas ao ser solicitado pelo suporte do Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opções de trajeto</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evitar pedágios</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evite estradas não pavimentadas</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evitar balsas</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evitar rodovias</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Incapaz de calcular rota</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Infelizmente, não conseguimos encontrar uma rota, provavelmente por causa das opções escolhidas ou dados do OpenStreetMap em falta. Por favor, altere as configurações e tente novamente.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definir as estradas a serem evitadas</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opções de direção ativadas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Pedágio</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Pista não pavimentada</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Balsa</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Não</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Não</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidade: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rede: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Você chegou!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Tudo bem</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Tipo…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Classificar marcadores</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Por padrão</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Por tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Por distância</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Por data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Por nome</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Há uma semana</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Há um mês</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Há mais de um mês</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Há mais de um ano</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Próximo de mim</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Outros</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Falha no planejamento da rota</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Chegada em %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Baixe e atualize todos os mapas ao longo do caminho projetado para calcular a rota.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Você modificou o mapa-múndi. Não esconda isto! Diga aos seus amigos e edite junto com eles.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Compartilhar com amigos</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Fechado agora</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Abre amanhã em %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Abre %1 em %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Abre em %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Encerra às %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Adicionar horário de funcionamento</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Senha (mínimo de 8 caracteres)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nome de usuário ou senha inválida.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Conta OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Último upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Obrigado</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nome do local</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Observe</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Erro no download</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Selecione a categoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Todas as categorias</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Adicione novos lugares ao mapa e edite os já existentes diretamente no aplicativo.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Alterar local</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>É necessário mais espaço para baixar. Por favor, elimine dados desnecessários.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Eu melhorei os mapas do Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentário detalhado</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Suas sugestões de mudança serão enviadas para a comunidade OpenStreetMap. Descreva em detalhes o que não pode ser editado com o Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Ocorreu um erro na busca por sua localização. Verifique se o seu dispositivo está funcionando corretamente e tente novamente mais tarde.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Serviços de localização estão desativados</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Permita o acesso à geolocalização nas configurações do dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Abra o aplicativo “Ajustes“</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Toque em Localização</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Selecione “Durante uso do aplicativo“</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Selecione “Privacidade e Segurança“</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Selecione “Serviços de Localização“</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ative “Serviços de Localização“</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ou continue usando o Organic Maps sem localização</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reservar</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Ligar</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nome do marcador</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Apagar favorito</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Sua nota será enviada ao OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mais</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Atualização</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Desativar gravação da sua rota recente?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desabilitar</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Procure</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>O Organic Maps usa sua localização geográfica em segundo plano para gravar a sua rota recente.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Definições gerais</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Para mostrar os dados de tráfego, o aplicativo deve ser atualizado.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Tamanho do arquivo de registro: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arraste aqui para remover</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Substituir a parada</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Iniciar a partir de</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Faça login no OpenStreetMap para carregar automaticamente todas as edições de mapas que você fizer. Saiba mais</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aqui</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ocultar tela</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Baixando %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Aplicando %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Esse nome é muito longo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Novos arquivos detectados</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Converter</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Erro</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Alguns arquivos não foram convertidos.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Ocorreu um erro</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Esconder do mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Ocorreu um erro enquanto carregava as etiquetas, por favor, tente novamente</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Certo</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Parte inferior</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Vamos</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destino</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-centralizar</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultados da busca</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Então</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Você deseja retraçar a rota?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>O teclado não está disponível enquanto dirige</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Não foi possível construir uma rota a partir da sua localização atual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Incapaz de traçar rota para o seu destino. Por favor, escolha outro ponto de destino</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Sem sinal de GPS. Por favor, vá para uma região aberta</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Incapaz de traçar rota. Por favor, especifique outros pontos para a rota</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Para criar uma rota, baixe os mapas ausentes no seu dispositivo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Ocorreu um erro. Por favor, reinicie o aplicativo</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>A rota sera retraçada a partir de sua localização atual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>A rota será alterada para uma de automóvel</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nem todos os marcadores são exibidos</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Mudar para o telefone para ver todos os favoritos</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Velocidades</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Alertas de velocidade</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Por favor, baixe mapas no app Organic Maps em seu dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 saída</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenar por padrão</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Classificar por tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenar por distância</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenar por data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Classificar por nome</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Alimentos</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Pontos turíticos</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museus</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Nadar</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montanhas</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animais</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotéis</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Edifícios</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dinheiro</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Lojas</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Estacionamento</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Postos de gasolina</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Remédio</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Buscar na lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Locais religiosos</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Escolher a lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>A navegação por metrô ainda não está disponível nesta região</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Não foi encontrada nenhuma rota de metrô</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Escolha outro ponto de início ou fim perto da estação de metrô</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Relevo</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Para ativar e usar a camada Relevo, atualize ou baixe o mapa da região</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>A camada Relevo ainda não está disponível para esta região</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Subida</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descida</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevação mínima</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevação máxima</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificuldade</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tempo:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Use o zoom para explorar as isolinhas</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Baixando</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Baixar a visão geral mundial</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Não foi possível criar a pasta e mover os arquivos à memória interna ou sdcard do dispositivo</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Erro do armazenamento</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Falha na conexão</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desconecte o cabo USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Manter a tela ligada</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Quando ativada, a tela estará sempre ligada ao exibir o mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostrar na tela de bloqueio</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Quando ativado, você não precisará debloquear seu dispositivo toda vez que o aplicativo estiver funcionando.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Idioma do Mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dados do mapa do OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/pt-BR/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/pt-BR/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Obrigado por você usar nossos mapas criados pela comunidade!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Com suas doações e seu apoio, podemos criar os melhores mapas do mundo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Você gosta do nosso aplicativo? Por favor, doe para apoiar o desenvolvimento! Ainda não gostou? Informe-nos e consertaremos isso!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Se você conhece algum desenvolvedor de software, pode lhe pedir que implemente um recurso de que você precisa.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Toque em qualquer lugar do mapa para selecionar qualquer coisa. Toque longamente para ocultar e mostrar a interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Você sabia que sua posição atual no mapa pode ser selecionada?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Você pode ajudar a traduzir nosso aplicativo para o seu idioma.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Nosso aplicativo foi desenvolvido por alguns entusiastas e pela comunidade.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Você pode corrigir e melhorar facilmente os dados do mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Nosso principal objetivo é construir mapas rápidos, focados na privacidade e fáceis de usar que você vai adorar.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Agora você está usando o Organic Maps na tela do telefone</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Agora você está usando o Organic Maps na tela do carro</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Você está conectado ao Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continuar no celular</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Para tela do carro</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>O Organic Maps precisa de acesso à localização. Quando for seguro, verifique a notificação em seu telefone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Este aplicativo precisa da sua permissão</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>O Organic Maps no Android Auto precisa de uma permissão de localização para funcionar corretamente</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Conceder permissões</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Ar livre</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>O navegador da Web não está disponível</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportar todos os favoritos e trilhas</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Configurações do sistema de síntese de fala</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>As configurações do Speech Synthesis não foram encontradas. Você tem certeza de que seu dispositivo é compatível?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Limpar pesquisa</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Aumentar o zoom</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Reduzir o zoom</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link do cardápio</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Exibir menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir em outro aplicativo</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoatendimento</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selecione a opção</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Assentos ao ar livre</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Para obter uma navegação mais precisa, recomendamos que você desative o modo de economia de energia nas configurações de bateria do telefone.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Gravar trilha</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Parar gravação de trilha</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Gravação de trilha</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Parar sem salvar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuar registrando</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Salvar em Favoritos e Trilhas?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>A trilha está vazia - não há nada para salvar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Não é possível exibir a caixa de diálogo de seleção de pastas porque nenhum aplicativo adequado está instalado no seu dispositivo. Instale um aplicativo gerenciador de arquivos e tente novamente.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Escolha a cor</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar trilha</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nenhum aplicativo instalado que possa abrir o local</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automático na navegação</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Usar o padrão do sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Compartilhar trilha</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Excluir %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nível de dificuldade</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderado</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Atualizando</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Atualize os mapas no seu dispositivo</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>A atualização de mapas mantém as informações sobre objetos atualizadas</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Atualização (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Atualizar manualmente mais tarde</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Apagar trilha</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Você tem certeza de que deseja excluir essa trilha?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nome da trilha</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mover</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trilha</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Mudança de cor</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Você gostaria de enviar um relatório de bug para os desenvolvedores?
+Dependemos de nossos usuários, pois o Organic Maps não coleta nenhuma informação de erro automaticamente. Agradecemos antecipadamente por você apoiar o Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Ativar a sincronização do iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>A sincronização do iCloud é um recurso experimental em desenvolvimento. Certifique-se de que você tenha feito um backup de todos os seus favoritos e trilhas.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>O iCloud está desativado</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ative o iCloud nos Ajustes do seu dispositivo para usar esse recurso.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Ativar</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Cópia de segurança</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Falha na sincronização do iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Erro: Falha na sincronização devido a erro de conexão</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Erro: Falha na sincronização devido ao armazenamento excedido do iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Erro: o iCloud não está disponível</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listas excluídas recentemente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Limpo</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Excluir tudo</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar tudo</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribua com o OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Adicionar local</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Atualizar o mapa para contribuir</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Você precisa atualizar o mapa %1 para a versão mais recente antes de poder contribuir com os dados do OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Minha posição</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Meus locais</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Armazenamento interno privado</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Armazenamento interno compartilhado</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Cartão SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Armazenamento externo compartilhado</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>CEP</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Ponto do mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Para exibir as rotas, os mapas devem ser atualizados.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Sair</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Mapa de metrô está indisponível</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Você</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiões descarregadas roxas</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rota</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>A deteção da localização atual em segundo plano é necessária para desfrutar plenamente da funcionalidade do aplicativo. Ela é usada para navegação e para salvar sua trilha recentemente viajada.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>A determinação de sua localização é necessária para a navegação e para salvar sua trilha recentemente viajada.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login com senha</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Fazer login usando o navegador</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recentes</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Cor dos favoritos alterada</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Cor das trilhas alterada</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Controles deslizantes</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>VERMELHO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>AZUL</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Cor hexadecimal sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grade</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/pt/omim.ts
+++ b/qt/translations/pt/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="pt">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Voltar</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Descarregar mapas</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>O descarregamento falhou, toque novamente para tentar de novo.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>A descarregar…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Quilómetros</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milhas</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Mais tarde</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Pesquisar</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Pesquisar no mapa</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Atualmente tem todos os serviços de localização para este dispositivo ou aplicação desativados. Por favor ative-os nas definições do sistema.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Precisão limitada</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Para garantir uma navegação precisa, active a opção Localização precisa nas definições.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Mostrar no mapa</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>O descarregamento falhou</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Tentar novamente</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Sobre o Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Grátis para todos, feito com amor</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Sem anúncios, rastreamento ou coleta de dados</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Não gasta a bateria, funciona offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rápido, minimalista, desenvolvido pela comunidade</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicativo de código aberto criado por entusiastas e voluntários.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Definições de localização</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Fechar</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>É necessário a acelaração OpenGL por hardware. Infelizmente o seu dispositivo não é compatível.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Descarregar</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Por favor desligue o cabo USB ou introduza um cartão de memória para utilizar o Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Por favor liberte primeiro algum espaço no cartão SD ou armazenamento USB para utilizar a aplicação</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Antes de começar, é recomendável descarregar a visão geral mundial para o seu dispositivo.
+É necessário %1 de espaço disponível.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Ir ao mapa</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>A descarregar %1. Agora pode
+ver o mapa.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Descarregar %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Atualizar %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausar</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuar</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>O descarregamento de %1 falhou</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Adicionar conjunto novo</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Nome do conjunto de favoritos</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Favoritos</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Favoritos e trajetos</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Nome</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Endereço</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Configurações</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Guardar mapas em</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Selecione o local onde os mapas devem ser descarregados.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 livres de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Mover mapas?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Erro ao mover ficheiros de mapa</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Isto pode demorar alguns minutos.
+Por favor aguarde…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unidades de medida</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Escolha entre milhas e quilómetros</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancelar descarregamento</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Faça uma avaliação</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Descarregar mapa</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Conjuntos de favoritos</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Onde comer</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Mercearias</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporte</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Combustível</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Estacionamento</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Compras</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Em segunda mão</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Atrações turísticas</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entretenimento</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Multibanco</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Vida noturna</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Passeios com crianças</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banco</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmácia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Casa de banho</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Correios</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polícia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclagem</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Água</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Para trailers</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notas</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Os favoritos do Organic Maps foram partilhados consigo</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Olá!
+
+Segue em anexo os meus favoritos da aplicação Organic Maps. Por favor abra-os se tiver o Organic Maps instalado. Caso não tenha, descarregue a aplicação para o seu dispositivo iOS ou Android com a hiperligação https://omaps.app/get?kmz
+
+Divirta-se a viajar com o Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>A carregar favoritos</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Os favoritos foram carregados com sucesso! Pode encontrá-los no mapa ou no ecrã de gestão dos favoritos.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Surgiu uma falha ao enviar os favoritos. O ficheiro pode estar corrompido ou com defeito.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>O tipo de ficheiro não é reconhecido pela aplicação:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Falha ao abrir o ficheiro %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Editar</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>A sua localização ainda não foi determinada</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Lamentamos, as definições do armazenamento do mapa estão atualmente desativadas.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>O descarregamento do país está a ser feito neste momento.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Veja a minha localização atual em Organic Maps! %1 ou %2 Não tem mapas offline? Descarregue aqui: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Veja o meu marcador no mapa do Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Veja a minha localização atual no mapa Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Olá,
+
+Estou neste momento aqui: %1. Clique nesta ligação %2 ou nesta %3 para ver o local no mapa.
+
+Obrigado.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Partilhar</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Correio eletrónico</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiado para a área de transferência: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Feito</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dados do OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Tem certeza de que deseja sair da sua conta do OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trajetos</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Comprimento</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Partilhar a minha localização</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Configurações gerais</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informação</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navegação</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Botões «+» e «-» no mapa</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Mostrar no ecrã</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Estilo noturno quando navega no escuro</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo noturno</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Desligado</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Ligado</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automático</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Visão em perspetiva</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Edifícios em 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Os edifícios 3D são desativados no modo de poupança de energia</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instruções de voz</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunciar nomes de ruas</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Quando ativado, o nome da rua ou saída para virar será falado em voz alta.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Idioma da voz</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Para descarregar uma voz de maior qualidade, abra a app Definições e aceda a Acessibilidade → VoiceOver → Fala → Voz.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testa as direcções de voz (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Verifica o volume ou as definições de conversão de texto em voz do sistema se não ouvires a voz agora.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Não disponível</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Ampliação automática</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distância</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Ver no mapa</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Site</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Notícias</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Comentários</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Avaliar a aplicação</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ajuda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Perguntas frequentes</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doar</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Já doei</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Lembre-me mais tarde</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Apoie o Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Apoie o projeto</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Direitos de autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Reportar um problema</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Melhore a direcção das setas movendo o telemóvel num movimento em forma de oito para calibrar a bússola.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mova o telemóvel num movimento em forma de oito para calibrar a bússola e fixar a direcção da seta no mapa.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Dê um toque longo no mapa novamente para ver a interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Atualizar tudo</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancelar tudo</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Descarregado</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Na fila</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Perto de mim</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapas</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Descarregar tudo</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>A descarregar:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Para eliminar o mapa, por favor pare a navegação.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Só podem ser criados trajetos que estejam completamente contidos num único mapa.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Descarregar mapa</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Repetir</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Eliminar mapa</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Atualizar mapa</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Serviços de localização do Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determina rapidamente a tua localização aproximada através de Bluetooth, WiFi ou rede móvel</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Descarregar todos os mapas ao longo do trajeto</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>É necessário descarregar e atualizar todos os mapas entre a sua localização e o destino para criar um trajeto.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Espaço insuficiente</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Por favor ative os serviços de localização</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>criar</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Vermelho</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Amarelo</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Azul</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Roxo</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Laranja</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Castanho</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Purpúreo escuro</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Azul Claro</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Azul-verde</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Esmeralda</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lima</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Laranja escuro</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Cinza</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Azul-cinza</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informação</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versão do Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Apresentação</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Tons claros</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tons escuros</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Claro desde o amanhecer até ao anoitecer</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Outro</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Ofereça mapas gratuitos e sem anúncios a milhões de utilizadores!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Comunica ou corrige dados incorretos do mapa</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Voluntaria-te</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Segue-nos e contacta-nos:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>O programa de email não está configurado. Por favor, configure-o ou utilize qualquer outra forma de nos contactar através de %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Erro ao enviar o email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibração da bússola</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponível</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Encontrado</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Atualizar</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Falhou</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>favorito</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Ao seguir o trajeto, lembre-se que:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— As condições da estrada, as leis de trânsito e os sinais de trânsito têm sempre prioridade sobre as indicações de navegação;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— O mapa pode estar desatualizado e o trajeto indicado pode não ser a melhor para chegar ao destino;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Os trajetos indicados devem ser considerados apenas como sugestões;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Use com cautela em rotas de zonas fronteiriças: as rotas criadas pela nossa aplicação podem algumas vezes cruzar fronteiras nacionais em locais não autorizados.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Fique sempre atento nas estradas!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Verifique o sinal do GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>O trajeto não foi criado porque não foi possível identificar as coordenadas do GPS.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifique o sinal do GPS. Ative o Wi-Fi para melhorar a precisão da localização.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Ative os serviços de localização</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Não foi possível localizar as coordenadas do GPS. Ative os serviços de localização para que o trajeto seja criado.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Não foi possível encontrar uma rota</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Não foi possível criar uma rota.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ajuste o ponto de partida ou o ponto de chegada.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Ajuste o ponto de partida</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>A rota não foi criada, porque não foi possível localizar o ponto de partida.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Selecione um ponto de partida mais perto de uma estrada.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Ajuste o ponto de chegada</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>A rota não foi criada, porque não foi possível localizar o ponto de chegada.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Selecione um ponto de chegada mais perto de uma estrada.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Não foi possível localizar o ponto intermédio.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Ajuste o ponto intermédio.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Erro de sistema</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Não foi possível criar uma rota devido a um erro na aplicação.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Tente novamente</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Agora não</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Quer descarregar o mapa e traçar uma rota melhor, mas que se estenda por mais de um mapa?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Descarregue o mapa para traçar uma rota melhor que vai além dos limites deste mapa.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Descarregar os ficheiros necessários</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Descarregue e atualize todos os dados do mapa e roteamento ao longo do trajeto desejado para que o trajeto seja criado.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Para começar a pesquisar e criar rotas, por favor, descarregue o mapa. Desta forma não irá precisra mais de uma ligação à Internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Selecionar mapa</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Mostrar</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ocultar</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorias</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Histórico</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Lamento, mas não foram encontrados resultados.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Descarregue a região onde está a pesquisar ou tente adicionar o nome de uma cidade ou aldeia próxima.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Histórico de pesquisas</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Ver as pesquisas recentes.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Limpar histórico de pesquisas</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artigo da wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Localização atual</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Iniciar</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>De</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Itinerário para</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Só é possível navegar a partir da sua localização atual.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Quer planear uma rota a partir da sua localização atual?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Próxima</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Das</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Às</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Adicionar horário</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Eliminar horário</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Todo o dia (24 horas)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Aberto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Inserir horas de encerrrado</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Horário de funcionamento</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modo avançado</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modo simples</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Horas sem funcionamento</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Valores de exemplo</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corrigir erro</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Selecione a localização</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Por favor, descreva o problema ao pormenor para que a comunidade OpenStreetMap possa corrigir o erro.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ou faça-o em https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Enviar</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problema</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>O lugar não existe</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Encerrado para manutenção</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Lugar em duplicado</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Descarregamento automático</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Diariamente</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24 horas por dia</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Fechado hoje</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hoje</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Abre em %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Fecha em %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Fechado</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Editar horário de funcionamento</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Não tem uma conta no OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Crie uma conta no OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Iniciar sessão</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Sessão não iniciada</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Entrar no OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Palavra-chave</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Esqueceu-se da palavra-chave?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Terminar sessão</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Editar o local</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Adicionar um idioma</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rua</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Nº de porta</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalhes</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Redes sociais</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Edifício</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Adicionar uma rua</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Por favor, introduza um nome da rua</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Escolher um idioma</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Escolher uma rua</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Culinária</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Selecione a culinária</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ou nome de utilizador</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Adicionar telefone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Andar</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nível: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Todas as alterações ao mapa serão eliminadas juntamente com o mapa.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Atualizar mapas</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Para criar um itinerário é necessário atualizar todos os mapas e, em seguida, planeá-lo novamente.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Encontrar o mapa</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Por favor, verifique as suas opções e certifique-se que o dispositivo está ligado à Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Não tem espaço suficiente</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Por favor, remova os dados desnecessários</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Erro de início de sessão.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Alterações verificadas</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Mova o mapa para colocar a cruz na localização da empresa ou do local.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Edição</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>A adicionar</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Nome do lugar</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Como escrito na língua local</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descrição detalhada do problema</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Um problema diferente</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Adicionar uma organização</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Nenhum objeto pode ser posicionado aqui</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dados do OpenStreetMap criados pela comunidade em %1. Sabe mais sobre como editar e atualizar o mapa em OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>O OpenStreetMap.org (OSM) é um projeto comunitário aberto para construir um mapa gratuito. O OSM é a principal fonte de dados de mapas do Organic Maps e funciona de forma semelhante à Wikipedia. Pode adicionar ou editar locais e estes ficam disponíveis para milhões de utilizadores no mundo todo.
+Junte-se à comunidade e ajude a criar um mapa melhor para todos!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Crie uma conta OpenStreetMap ou inicie sessão para publicar as suas edições de mapas para o mundo.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 de %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Descarregar utilizando uma conexão de rede de telemóveis?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Isto pode ser muito caro com alguns planos ou em roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introduza um número de endereço correto</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Número de pisos (máx. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>O número de pisos não pode ser maior que %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Código Postal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introduza o código postal correto</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Nota para os voluntários do OpenStreetMap (opcional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Descreva erros no mapa ou coisas que não podem ser editadas com o Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>As suas edições são carregadas para a base de dados pública &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Por favor, não adicione informações pessoais ou protegidas por direitos de autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mais sobre o OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>O seu histórico de edições</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>As suas notas de dados do mapa</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operador</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operador: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Não encontra uma categoria adequada?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>O Organic Maps permite-lhe adicionar apenas categorias de pontos simples, ou seja, nada de cidades, estradas, lagos, contornos de edifícios etc. Por favor, adicione essas categorias diretamente ao &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consulte o nosso &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guia&lt;/a&gt; para instruções detalhadas passo a passo.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Não descarregou quaisquer mapas</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Descarregar mapas para encontrar a localização e navegar offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>A localização atual é desconhecida.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>dia</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mais</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Editar favorito</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Notas pessoais (texto ou html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentário…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Eliminar todas as alterações locais?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Eliminar</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Eliminar o local adicionado?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Eliminar</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>O local não existe</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Por favor indique o motivo da exclusão do local</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introduza um número de telefone correto</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Preencha com um endereço válido na Internet</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Preencha com um endereço válido de email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introduza um endereço web, conta ou nome de página válidos do Facebook</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introduza um endereço web válido ou um nome de conta do Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introduza um endereço web válido ou um nome de conta do Twitter</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introduza um endereço web válido ou um nome de conta do VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introduza um endereço web ou ID LINE válido</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Adicionar um local no OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ou, alternativamente, deixe uma nota para a comunidade do OpenStreetMap para que outra pessoa possa adicionar ou corrigir um lugar aqui.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>A nota será enviada ao OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Quer enviar para todos os utilizadores?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Certifique-se que não incluiu nenhuns dados pessoais.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Os editores do OpenStreetMap verificarão as alterações e entrarão em contacto consigo se tiverem alguma dúvida.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Parar</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Registar a pista</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Aceitar</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Recusar</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Utilizar os dados móveis para mostrar informações detalhadas?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Utilizar sempre</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Apenas hoje</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Não usar hoje</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Dados móveis</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Para visualizar informações detalhadas sobre os locais, tais como fotografias, preços e avaliações, é necessário acesso à internet móvel.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nunca utilizar</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Perguntar sempre</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Para ver os dados de tráfego, os mapas têm de ser atualizados.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Aumentar tamanho da fonte no mapa</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Atualize o Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Os dados de tráfego não estão disponíveis</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Ativar o histórico</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Opinão geral</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Utilizamos o sistema TTS para as instruções de voz. Muitos dispositivos Android usam o Google TTS, pode transferir ou atualizá-lo a partir do Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Para alguns idiomas, precisará de instalar outro sintetizador de voz ou um pacote de idiomas adicional a partir da loja de aplicações (Google Play, Galaxy Store, App Gallery, FDroid).&#32;
+Abra as Configurações do seu dispositivo → Idioma e entrada → Voz → Saída de texto para voz.&#32;
+Aqui pode gerir as configurações de síntese de voz (por exemplo, transferir um pacote de idioma para poder utilizá-lo sem estar ligado à Internet) ou selecionar outro motor de texto para voz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Para obter mais informações, consulte este guia.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteração para o alfabeto latino</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Saber mais</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use a busca ou toque no mapa para adicionar um ponto de partida do percurso</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use a busca ou toque no mapa para adicionar um ponto de destino</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gerir rota</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planear</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remover paragem</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Adicionar paragem</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Guardado</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Por favor, faz o login no OpenStreetMap para carregar automaticamente todas as tuas edições de mapas. Sabe mais &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aqui&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problema de acesso ao armazenamento</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>O armazenamento externo não está disponível. Provavelmente porque o cartão SD foi removido, danificado ou o sistema de ficheiros é apenas para leitura. Verifique e contacte-nos através do email support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emular o armazenamento defeituoso</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Introduza um nome correto</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listas</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ocultar tudo</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Mostrar tudo</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n favorito</numerusform>
+<numerusform>%n favoritos</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Criar nova lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importar favoritos e trajetos</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Não foi possível partilhar devido a um erro da aplicação</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Erro ao partilhar</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Não é possível partilhar uma lista vazia</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>O nome não pode estar em branco</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Por favor introduza o nome da lista</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nova lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Este nome já está a ser utilizado</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Por favor escolha outro nome</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Por favor aguarde…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Número de telefone</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Perfil no OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n ficheiro encontrado. Pode vê-lo depois da conversão.</numerusform>
+<numerusform>%n ficheiros encontrados. Pode vê-los depois da conversão.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restaurar</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n trajeto</numerusform>
+<numerusform>%n trajetos</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacidade</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Política de privacidade</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Termos de utilização</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Tráfego</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Caminhada</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclismo</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metropolitano</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Estilos e camadas de mapas</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Esta lista está vazia</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Para adicionar um favorito, toque num lugar do mapa e em seguida toque no ícone da estrela</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Alterar a cor de todos os favoritos</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Alterar a cor de todos os trajetos</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mais</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportar KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportar GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportar GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Eliminar lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radares de velocidade</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descrição do local</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Descarregador de mapas</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avisar se exceder limite de velocidade</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Sempre avisar</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nunca avisar</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modo de economia de energia</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Tente reduzir o consumo de energia em detrimento de algumas funcionalidades.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automático</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Máxima economia de energia</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nomes de marcadores no mapa</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Se houver muitos favoritos, exibir seus nomes no mapa pode deixar o aplicativo lento.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Mostrar à direita</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Mostrar na parte inferior</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Esta opção ativa o registo das ações para diagnóstico. Pode ser útil para os programadores descobrirem o problema na aplicação. Ative esta opção apenas a pedido dos programadores do Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Configurações de direção</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evitar portagens</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evitar não-pavimentadas</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evitar ferribotes</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evitar autoestradas</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Não foi possível calcular a rota</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Infelizmente não foi possível criar o percurso com as opções selecionadas. Altere as opções e tente novamente.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definir as estradas a evitar</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Configurações de direção ativadas</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Estrada com portagem</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Estrada não pavimentada</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Não</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Sim</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Não</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacidade: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rede: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Chegou ao destino!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ordenar…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ordenar favoritos</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Predefinido</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Por tipo</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Por distância</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Por data</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Por nome</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Uma semana atrás</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Um mês atrás</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Mais de um mês atrás</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Mais de um ano atrás</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Perto de mim</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Outros</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Falha no planeamento da rota</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Chegada: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Alterou o mapa mundial. Não mantenha as alterações para si mesmo! Diga aos seus amigos e editem-no juntos.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Partilhar com amigos</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Fechado agora</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Abre amanhã às %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Abre %1 às %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Abre às %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Fecha às %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Adicionar horário de funcionamento</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Palavra-chave (mínimo de 8 caracteres)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nome de utilizador ou palavra-chave inválida.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Conta OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Último envio</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Obrigado</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Nome do local</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Aviso</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Erro de descarregamento</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Selecionar categoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Todas as categorias</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Adicione novos lugares ao mapa e edite os já existentes diretamente a partir da aplicação.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Mudar local</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Para descarregar, é necessário mais espaço. Por favor, elimine os dados desnecessários.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Melhorei os mapas do Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentário detalhado</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>As suas alterações sugeridas irão ser enviadas para a comunidade OpenStreetMap. Descreva os dados que não podem ser editados no Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Ocorreu um erro ao pesquisar a sua localização. Verifique se o seu dispositivo está a funcionar devidamente e volte a tentar mais tarde.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Os serviços de localização estão desativados</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Conceda o acesso à geolocalização nas configurações do dispositivo</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Abra a aplicação “Definições“</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Toque em &quot;Localização&quot;</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Selecione “Durante a utilização da aplicação“</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Selecione “Privacidade e segurança“</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Selecione “Serviços de localização“</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ative “Serviços de localização“</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ou continue a utilizar o Organic Maps sem localização</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Reservas</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Telefonar</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Nome do favorito</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Eliminar favorito</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>A sua nota será enviada ao OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mais</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Atualizar</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Desativar gravação do seu trajeto recente?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Desativar</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Verificar</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>O Organic Maps usa a sua localização geográfica em segundo plano para gravar o seu trajeto recente.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Configurações gerais</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Para mostrar os dados de tráfego, a aplicação tem de ser atualizada.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Tamanho do ficheiro de registo: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Arraste aqui para remover</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Substituir Parada</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Iniciar a partir de</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Por favor, faz o login no OpenStreetMap para carregar automaticamente todas as tuas edições de mapas. Sabe mais</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aqui</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ocultar ecrã</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 de %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>A transferir %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>A aplicar %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Este nome é muito longo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Foram detetados novos ficheiros</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Converter</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Erro</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Alguns ficheiros não foram convertidos.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Surgiu um erro</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Remover do mapa</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Surgiu um erro ao carregar as etiquetas, por favor tente novamente</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Direita</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Fundo</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Começar</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destino</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Recentrar</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Resultados da pesquisa</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>A seguir</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Quer recalcular o percurso?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>O teclado não está disponível ao coduzir</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Não foi possível calcular o percurso a partir da localização atual</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Não foi possível calcular o percurso para o destino. Escolha outro</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Sem sinal de GPS. Desloque-se para uma área sem obstáculos no céu</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Não foi possível calcular o percurso. Escolha outros pontos do percurso</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Para calcular o percurso é preciso descarregar primeiro os mapas</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Surgiu um erro. Por favor reinicie a aplicação</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>O percurso será recalculado a partir da sua localização atual</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>O percurso será convertido num percurso para automóvel</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nem todos os marcadores são mostrados</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Muda para o telemóvel para ver todos os favoritos</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radares</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Avisos de velocidade</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Descarregue mapas da aplicação Organic Maps no seu dispositivo</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 saída</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ordenação predefinida</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ordenar por tipo</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ordenar por distância</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ordenar por data</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Ordenar por nome</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Comida</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Atrações turísticas</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museus</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parques</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Natação</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Montanhas</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animais</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotéis</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Prédios</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Dinheiro</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Lojas</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Estacionamentos</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Postos de combustível</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Pesquisar na lista</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Lugares religiosos</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Selecionar lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>A navegação de metropolitano ainda não está disponível nesta região</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Não foi encontrada nenhuma rota de metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Escolha um ponto inicial ou final do percurso próximo da estação de metropolitano</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terreno</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Para ativar e usar a camada Terreno, por favor atualize ou descarregue o mapa da área</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>A camada Terreno ainda não está disponível nesta área</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Subida</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descida</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Elevação mín.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Elevação máx.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificuldade</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Distância:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tempo:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Amplie o mapa para ver as curvas de nível</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>A descarregar</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Descarregar a visão geral mundial</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Não é possível criar pasta e mover ficheiros na memória interna do dispositivo ou no cartão SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Erro de disco</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Falha na coneção</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Desligue o cabo USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mantém o ecrã ligado</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Quando ativado, o ecrã estará sempre ligado quando apresentares o mapa.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Mostrar no ecrã de bloqueio</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Quando ativado, não precisa de desbloquear o dispositivo para executar a aplicação.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Idioma do mapa</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dados cartográficos do OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/pt/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/pt/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Obrigado por utilizar os nossos mapas construídos pela comunidade!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Com suas doações e apoio, podemos criar o melhor mapa do mundo!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Gosta do nosso aplicativo? Por favor, doe para apoiar o desenvolvimento! Ainda não gostou? Informe-nos, que consertaremos!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Se conhece algum desenvolvedor de software, pode pedir-lhe que implemente um recurso de que precisa.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Toque em qualquer parte do mapa para selecionar qualquer coisa. Toque demoradamente para ocultar e voltar a mostrar a interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Sabia que sua posição atual no mapa pode ser selecionada?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Pode ajudar a traduzir nosso aplicativo para o seu idioma.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Nosso aplicativo foi desenvolvido por alguns entusiastas e pela comunidade.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Pode corrigir e melhorar facilmente os dados do mapa.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Nosso principal objetivo é construir mapas rápidos, focados na privacidade e fáceis de usar que vai adorar.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Está agora a utilizar o Organic Maps no ecrã do telemóvel</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Está agora a utilizar o Organic Maps no ecrã do automóvel</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Está ligado ao Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continuar no telemóvel</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Para ecrã do carro</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>O Organic Maps precisa de acesso à localização. Quando for seguro, verifica a notificação no teu telemóvel.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Esta aplicação precisa da tua autorização</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Os Organic Maps no Android Auto precisam de uma permissão de localização para funcionarem eficazmente</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Conceder permissão</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Caminhadas</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>O navegador de Internet não está disponível</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportar todos os favoritos e trajetos</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Definições do sistema de síntese de voz</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Não foram encontradas definições de síntese de voz. Tens a certeza de que o teu dispositivo é compatível?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servizo ao volante</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Limpar a pesquisa</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Ampliar</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Diminuir o zoom</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Link do menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ver menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Abrir noutra aplicação</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autosserviço</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selecionar opção</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Assentos ao ar livre</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Para uma navegação mais precisa, recomendamos que desactive o modo de poupança de energia nas definições da bateria do telemóvel.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Gravar trajeto</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Parar gravação de trajeto</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Gravação de percurso</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Parar sem guardar</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuar gravação</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Guardar em Favoritos e Trajetos?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>O trajeto está vazio - não há nada para guardar</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Não é possível apresentar a caixa de diálogo de seleção de pastas porque não está instalada nenhuma aplicação adequada no seu dispositivo. Instale uma aplicação de gestão de ficheiros e tente novamente.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Escolher cor</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editar trajeto</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nenhuma aplicação instalada que possa abrir a localização</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto na navegação</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Seguir o sistema</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Compartilhar trilha</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Excluir %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nível de dificuldade</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Fácil</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderado</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Difícil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>A atualizar</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Atualize os seus mapas descarregados</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Atualizar os mapas mantém atualizada a informação sobre os objetos</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Atualizar (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Atualizar manualmente mais tarde</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Apagar trajeto</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Tem a certeza de que pretende apagar este trajeto?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Nome do trajeto</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mover</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trajeto</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Alterar cor</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Gostarias de enviar um relatório de erro para os programadores?
+Contamos com os nossos utilizadores, uma vez que o Organic Maps não recolhe automaticamente qualquer informação de erro. Agradecemos desde já o teu apoio ao Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Ativar a sincronização do iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>A sincronização com o iCloud é uma funcionalidade experimental em desenvolvimento. Certifique-se de que fez uma cópia de segurança de todos os seus favoritos e trajetos.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>O iCloud está desativado</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Para utilizar esta funcionalidade, ative o iCloud nas definições do seu dispositivo.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Ativar</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Cópia de segurança</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Falha de sincronização do iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Erro: Falha na sincronização devido a um erro de ligação</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Erro: Falha na sincronização devido à quota do iCloud ter sido excedida</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Erro: o iCloud não está disponível</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listas eliminadas recentemente</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Limpar</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Eliminar tudo</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperar tudo</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuir para o OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Adicionar local</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Atualizar o mapa para contribuir</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Você precisa atualizar o mapa %1 para a versão mais recente antes de poder contribuir com os dados do OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>A minha posição</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Os meus locais</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Armazenamento interno privado</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Armazenamento interno partilhado</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Cartão SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Armazenamento externo partilhado</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Código postal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Ponto do mapa</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>Km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Para exibir rotas, os mapas devem ser atualizados.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Saída</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrada</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>O mapa de metropolitano não está disponível</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Você</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiões descarregadas a roxo</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rota</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>O acesso à sua localização atual em segundo plano é necessário para usar todas as funcionalidades da aplicação. É necessário para a navegação e guardar o último trajeto percorrido.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>O acesso à sua localização atual é utilizado em determinadas funções, tais como a navegação e guardar o último trajeto percorrido.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Iniciar sessão com palavra-passe</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Inicie sessão utilizando o browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Recentes</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Cor dos favoritos alterada</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Cor dos trajetos alterada</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Espectro</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Deslizadores</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>VERMELHO</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>AZUL</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Cor hexadecimal sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grelha</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ro/omim.ts
+++ b/qt/translations/ro/omim.ts
@@ -1,0 +1,3935 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ro">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Înapoi</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Anulare</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Șterge</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Descarcă hărți</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Descărcarea a eșuat. Atinge pentru a încerca din nou.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Se descarcă…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mile</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Mai târziu</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Caută</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Caută pe hartă</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>În prezent, toate serviciile de localizare pentru acest dispozitiv sau aplicație sunt dezactivate. Le poți activa din setări.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Acuratețe limitată</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Pentru a asigura o navigare precisă, activați Localizare precisă în setări.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Arată pe hartă</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Descărcarea a eșuat</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Mai încearcă</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Despre Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratuit pentru toată lumea, făcut cu dragoste</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Fără reclame, fără urmărire, fără colectare de date</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Nu consumă baterie, funcționează offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rapid, minimalist, dezvoltat de comunitate</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplicație open-source creată de entuziaști și voluntari.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Setări de locație</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Închide</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Această aplicație necesită accelerarea hardware OpenGL. Din păcate, dispozitivul tău nu este compatibil.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Descarcă</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Deconectează cablul USB sau introdu un card de memorie pentru a utiliza Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Spațiul de stocare de pe cardul SD/memoria USB este insuficient pentru a putea utiliza aplicația</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Înainte de a începe, trebuie descărcată harta generală a lumii în dispozitivul tău.
+Se vor descărca %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Mergi la hartă</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Se descarcă %1. Acum poți
+trece la hartă.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Descarci %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Actualizezi %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pauză</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continuă</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Descărcarea %1 a eșuat</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Adaugă o listă nouă</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Denumirea listei</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Locuri preferate</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Locuri preferate și trasee</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Denumire</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresă</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Listă</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Setări</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Salvează hărțile în</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Alege locul în care vrei să fie descărcate hărțile.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Hărți</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 liber de %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Muți hărțile?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Eroare la mutarea fișierelor de hartă</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Poate dura câteva minute.
+Așteaptă…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Unități de măsură</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Alege între mile și kilometri</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Anulează descărcarea</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Lasă un comentariu</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Descarcă harta</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Liste cu locuri preferate</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Unde să mănânci</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Alimentare</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzinărie</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parcare</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Cumpărături</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>La mâna a doua</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Obiective turistice</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Divertisment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bancomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Viață nocturnă</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Divertisment cu copiii</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bancă</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacie</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Spital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toaletă</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Poștă</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Poliția</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Reciclare</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Apă</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Pentru rulote</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Detalii</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Îți trimit locurile mele preferate din Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Bună!
+
+Ți-am atașat locurile mele preferate din aplicația Organic Maps. Deschide-le dacă ai instalată Organic Maps. Dacă nu, o poți descărca pentru iOS sau Android de aici: https://organicmaps.app/</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Se încarcă locurile preferate</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Locuri preferate încărcate cu succes! Le poți găsi pe hartă sau în „Gestionare Locuri preferate”.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Încărcarea locurilor preferate a eșuat. Fișierul poate fi defect.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Tipul de fișier nu este recunoscut de aplicație:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nu a reușit să deschidă fișierul %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Modifică</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Poziția ta nu a fost stabilită încă</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Opțiunile pentru stocarea hărților sunt dezactivate în acest moment.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Harta este în curs de descărcare.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Poți vedea poziția mea pe harta Organic Maps! %1 sau %2 Nu ai descărcat aplicația? O poți descărca de aici: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Poți vedea locul meu preferat pe harta Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Poți vedea poziția mea pe harta Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Bună,
+
+Acum sunt aici: %1. Apasă pe adresa %2 sau pe %3 pentru a vedea locul pe hartă.
+
+Mulțumesc.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Trimite</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copiat în notițe: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Gata</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Date OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Sigur doriți să vă deconectați din contul OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Trasee</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Lungime</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Trimite poziția mea</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Opțiuni generale</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informații</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigare</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Butoanele „+” și „-” pe hartă</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Arată pe hartă</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Stil de noapte atunci când navigați în întuneric</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Mod nocturn</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Oprit</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Pornit</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automat</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Vedere în perspectivă</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Clădiri 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Clădirile 3D sunt oprite în modul de economisire a energiei</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Instrucțiuni vocale</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Anunțați numele străzilor</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Când este activată, numele străzii sau al ieșirii pe care să o pornim va fi rostit cu voce tare.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Limba ghidului vocal</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Pentru a descărca o voce de calitate superioară, deschideți aplicația Configurări și accesați Accesibilitate → VoiceOver → Vorbire → Voce.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testarea indicațiilor vocale (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Dacă nu auziți vocea acum, verificați volumul sau setările sistemului text-to-speech.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nu există</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zoom automat</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distanță</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Vezi pe hartă</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Meniu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Site web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Știri</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Părere</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Evaluează aplicația</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ajutor</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Întrebări frecvente</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donează</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Deja donat</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Amintește mai târziu</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Susține Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Susține proiectul</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Drepturi de autor</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Raportează o eroare</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Îmbunătățiți direcția săgeții prin mișcarea telefonului într-o mișcare în opt pentru a calibra busola.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Mișcați telefonul într-o mișcare în formă de opt pentru a calibra busola și a fixa direcția săgeții pe hartă.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Atingeți lung pe hartă din nou pentru a vedea interfața</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Actualizează tot</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Anulează tot</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Descărcate</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>În așteptare</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Lângă mine</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Hărți</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Descarcă tot</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Se descarcă:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Pentru a șterge harta, oprește navigarea.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Pot fi create numai trasee cuprinse de harta unei singure regiuni.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Descarcă harta</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Mai încearcă</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Șterge harta</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Actualizează harta</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Servicii de localizare Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Determinați rapid locația dvs. aproximativă prin Bluetooth, WiFi sau rețea mobilă</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Descarcă hărțile de pe traseu</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Pentru a crea un traseu, este necesar ca toate hărțile de la poziția ta până la destinație să fie descărcate și actualizate.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Spațiu insuficient</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Activează serviciile de localizare</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Salvează</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>creează</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Roșu</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Galben</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Albastru</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Verde</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Violet</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Portocaliu</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Maro</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Roz</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Violet închis</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Albastru deschis</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Turcoaz</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smarald</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Verde aprins</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Portocaliu închis</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gri</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gri albăstriu</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informații</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versiunea Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Aspect</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Luminos</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Întunecat</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Deschis de la răsărit până la apus</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Altceva</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Oferiți hărți gratuite fără reclame pentru milioane de utilizatori!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Raportați sau remediați datele incorecte de pe hartă</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Pentru a fi voluntar</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Urmăriți-ne și contactați-ne:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Aplicația de email nu a fost stabilită. Stabilește-o sau utilizează alt mod de a ne contacta la %1.</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Eroare de trimitere e-mail</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Calibrare busolă</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Disponibile</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Găsite</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Actualizează</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Eșuat</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>preferat</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Când parcurgi traseul, ai în vedere următoarele:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Condițiile de drum, legile și semnele rutiere sunt mai importante decât indicațiile navigatorului;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Harta poate conține greșeli, iar traseul sugerat pentru a ajunge la destinație nu e întotdeauna cel mai bun;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Traseele sugerate sunt doar niște recomandări;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Ai grijă în zonele de graniță: traseele create de aplicația noastră pot trece granița prin locuri nepermise;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Fii vigilent și condu în siguranță!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Verifică semnalul GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Crearea traseului a eșuat. Coordonatele GPS actuale nu au putut fi identificate.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Verifică semnalul GPS. Pentru a îmbunătăți precizia localizării, activează Wi-Fi.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Activează serviciile de localizare</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Localizarea coordonatelor GPS curente a eșuat. Pentru a calcula traseul, activează serviciile de localizare.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Localizarea traseului a eșuat</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Crearea traseului a eșuat.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Modifică punctul de pornire sau destinația.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Modifică punctul de pornire</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Traseul nu a fost creat. Localizarea punctului de pornire a eșuat.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Alege un punct de pornire mai aproape de un drum.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Schimbă destinația</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Traseul nu a fost creat. Localizarea destinației a eșuat.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Alege un punct de destinație mai aproape de un drum.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Punctul intermediar nu poate fi localizat.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Schimbă punctul intermediar.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Eroare de sistem</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Crearea traseului a eșuat din cauza unei erori a aplicației.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Încearcă din nou</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nu acum</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Vrei să descarci harta și să creezi un traseu mai bun care include mai multe hărți?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Descarcă hărți suplimentare pentru a crea un traseu mai bun care să traverseze limitele acestei hărți.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Descarcă fișierele necesare</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Pentru calcularea traseului, descarcă și actualizează toate hărțile și informațiile traseului pentru calea estimată.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Pentru a putea începe căutarea și crearea unor trasee, descarcă harta. După aceasta nu vei mai avea nevoie de conexiune la internet.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Alege harta</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Arată</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ascunde</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categorii</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Cronologie</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Nu s-a găsit nimic.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Descărcați regiunea în care căutați sau încercați să adăugați numele unei localități din apropiere.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Istoricul căutărilor</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Arată căutările recente.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Șterge istoricul căutărilor</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Articol de pe wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Poziția ta</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Pornește</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>De la</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>La</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigația este disponibilă doar având ca punct de plecare poziția ta actuală.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Vrei să planifici un traseu din poziția ta actuală?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Următorul</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>De la</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>La</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Adaugă planificare</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Elimină planificarea</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Toată ziua (24 ore)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Deschis</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Închis</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Adaugă ore de închidere</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Ore de deschidere</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Mod Avansat</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Mod simplu</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Ore de închidere</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Exemple</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Corectare greșeală</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Selectați locația</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Descrie problema în detaliu, astfel încât comunitatea OpenStreetMap să poată remedia eroarea.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Sau corecteaz-o tu pe https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Trimite</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problemă</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Acest loc nu există</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Închis pentru întreținere</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Loc duplicat</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Descărcare automată</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Zilnic</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Închis astăzi</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Închis</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Azi</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Deschide în %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Închide în %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Închis</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Modifică orele de funcționare</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nu ai un cont OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Înscrie-te</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Autentificare</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Neautentificat</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Conectați-vă la OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Parola</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Ai uitat parola?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Deconectare</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Modifică locul</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Adaugă o limbă</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Stradă</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Număr</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detalii</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Rețele sociale</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Clădire</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Adaugă o stradă</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Introdu numele străzii</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Alege o limbă</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Alege o stradă</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Bucătărie</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Alege bucătăria</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-mail sau nume de utilizator</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Adaugă un număr</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Etaj</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivel: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Toate modificările aduse hărții vor fi șterse împreună cu harta.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Actualizează hărțile</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Pentru a crea un traseu, trebuie să actualizezi toate hărțile, iar apoi să planifici traseul încă o dată.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Caută harta</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Verifică dacă dispozitivul tău este conectat la internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Spațiu insuficient</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Șterge datele care nu sunt necesare</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Eroare de conectare.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Modificări confirmate</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Trageți harta pentru a plasa crucea acolo unde vreți să adăugați un loc sau o afacere.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Modifică</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adaugă</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Numele locului</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Așa cum este scris în limba locală</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Categorie</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Descriere detaliată a problemei</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Altă problemă</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Adaugă o firmă</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Niciun obiect nu poate fi poziționat aici</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Date OpenStreetMap create de comunitate la data de %1. Aflați mai multe despre cum să editați și să actualizați harta la OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) este un proiect comunitar pentru construirea unei hărți libere și deschise. Este principala sursă de date cartografice în Organic Maps și funcționează similar cu Wikipedia. Puteți adăuga sau edita locuri, iar acestea devin disponibile pentru milioane de utilizatori din întreaga lume.
+Alăturați-vă comunității și ajutați la crearea unei hărți mai bune pentru toată lumea!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Creați un cont OpenStreetMap sau conectați-vă pentru a vă publica edițiile de hartă în întreaga lume.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 din %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Vrei să descarci prin rețeaua de telefonie mobilă?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Aceasta poate fi destul de costisitoare în cazul unor abonamente sau în roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Introdu un număr corect</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Număr de etaje (maximum %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Numărul de etaje nu trebuie să depășească %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Cod poștal</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Introdu codul poștal corect</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Notă pentru voluntarii OpenStreetMap (opțional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Descrieți erorile de pe hartă sau lucrurile care nu pot fi editate cu Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Edițiile dvs. sunt încărcate în baza de date publică &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Vă rugăm să nu adăugați informații personale sau protejate prin drepturi de autor.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mai multe despre OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Istoricul dvs. de editare</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Note privind datele hărții dvs.</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nu găsiți o categorie potrivită?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps permite adăugarea doar a unor categorii de puncte simple, ceea ce înseamnă că nu există orașe, drumuri, lacuri, contururi de clădiri, etc. Vă rugăm să adăugați astfel de categorii direct la &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Consultați &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;ghidul nostru&lt;/a&gt; pentru instrucțiuni detaliate pas cu pas.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Nu ai descărcat nicio hartă</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Descarcă hărți pentru a căuta un loc și a naviga fără conectare la internet.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Poziția actuală este necunoscută.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>z</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mai mult</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Modifică locul preferat</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Însemnări personale (text sau html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comentariu…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Ștergi toate modificările locale?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Șterge</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Elimini locul adăugat?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Elimină</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Locul nu există</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Indică motivul pentru care ai eliminat locul</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Introdu un număr de telefon corect</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Introdu o adresă web corectă</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Introdu un e-mail valabil</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Introdu o adresă web, un cont sau un nume de pagină Facebook valabil</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Introdu o adresă web sau un nume de cont Instagram valabil</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Introdu o adresă web sau un nume de utilizator Twitter valabil</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Introdu o adresă web sau un nume de cont VK valabil</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Introdu o adresă web LINE valabilă sau un ID LINE</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Adaugă un loc pe OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Sau, alternativ, lăsați o notă comunității OpenStreetMap, astfel încât altcineva să poată adăuga sau repara un loc aici.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Nota va fi trimisă la OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Vrei să-l trimiți tuturor utilizatorilor?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Asigură-te că nu ai introdus niciun fel de date personale.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Editorii OpenStreetMap vor verifica modificările și vor lua legătura cu dvs. dacă au întrebări.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Oprește</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Înregistrarea traseului</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Acceptă</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Refuză</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Folosești internetul mobil pentru a vedea informații detaliate?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Folosește mereu</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Doar astăzi</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Nu folosi astăzi</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet mobil</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Internetul mobil este necesar pentru a afișa informații detaliate despre locuri generale și cele preferate.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nu utiliza niciodată</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Întreabă întotdeauna</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Pentru a afișa datele privind traficul, hărțile trebuie actualizate.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Mărește dimensiunea literelor pe hartă</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Actualizează Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Datele privind traficul nu sunt disponibile</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Activează jurnalizarea</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Părere generală</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Pentru instrucțiuni vocale utilizăm sistemul TTS. Multe dispozitive Android folosesc Google TTS. Poți descărca sau actualiza aplicația din Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Pentru unele limbi trebuie să instalezi alt sintetizator de voce sau un pachet lingvistic suplimentar din Magazinul de aplicații (Google Play, Galaxy Store, App Gallery, FDroid).
+Deschide setările dispozitivului → Limbă → Transformare text în vorbire → Motor preferat.
+Aici poți alege motorul de transformare a textului în vorbire și poți descărca o limbă pentru utilizare fără internet.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Consultă acest ghid pentru informații suplimentare.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transcrie în alfabet latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Mai multe</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Utilizați funcția de căutare sau atingeți ușor pe hartă pentru a adăuga un punct de plecare</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Utilizați funcția de căutare sau atingeți ușor pe hartă pentru a adăuga un punct de destinație</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Gestionare traseu</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifică</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Scoateți opritorul</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Adaugă oprire</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Salvat</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Vă rugăm să vă conectați la OpenStreetMap pentru a încărca automat toate modificările aduse hărții. Aflați mai multe &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;aici&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problemă de acces la spațiul de stocare</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Spațiul de stocare extern nu este disponibil. Probabil cardul SD nu este introdus, este deteriorat sau sistemul de fișiere este doar pentru citire. Verifică sau contactează-ne la support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Simulare arhivă deteriorată</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Introdu un nume corect</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Liste</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ascunde tot</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Arată tot</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n preferat</numerusform>
+<numerusform>%n preferate</numerusform>
+<numerusform>%n preferate</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Creează o listă nouă</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importați marcaje și piese</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nu poate fi trimis din cauza unei erori a aplicației</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Eroare de trimitere</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Nu poate fi trimisă o listă goală</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Numele listei nu poate fi gol</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Introdu numele listei</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Listă nouă</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Acest nume este deja folosit</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Alege un alt nume</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Așteaptă…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Număr de telefon</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>A fost găsit %n fișier. Îl vei vedea după conversiune.</numerusform>
+<numerusform>Au fost găsite %n fișiere. Le vei vedea după conversiune.</numerusform>
+<numerusform>Au fost găsite %n fișiere. Le vei vedea după conversiune.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restabilește</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n traseu</numerusform>
+<numerusform>%n trasee</numerusform>
+<numerusform>%n trasee</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Intimitate</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Confidențialitate</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Termeni de utilizare</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Drumeții</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Ciclism</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metrou</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stiluri și straturi de hartă</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Lista este goală</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Pentru a adăuga un loc preferat, ține apăsat un loc pe hartă și după aceea atinge simbolul în formă de stea</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Schimbă culoarea tuturor marcajelor</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Schimbă culoarea tuturor traseelor</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mai mult</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportați GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Șterge lista</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radare</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Descrierea locului</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Descărcarea hărților</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Avertizează la depășirea limitei de viteză</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Avertizează mereu</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nu avertiza niciodată</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Economisire a energiei</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Dacă este pornit modul de economisire a energiei, aplicația va deconecta funcțiile care consumă multă energie în dependență de nivelul de încărcare a bateriei.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Niciodată</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automat</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Economisire maximă a energiei</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Nume de marcaje pe hartă</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Dacă există prea multe marcaje, afișarea numelor acestora pe hartă poate încetini aplicația.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Arată la dreapta</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Afișare în partea de jos</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Opțiunea activează jurnalizarea în scopuri de diagnosticare. Aceasta poate fi utilă echipei noastre pentru a rezolva problemele cu aplicația. Activează temporar această opțiune pentru a înregistra și a ne trimite jurnale detaliate despre problema ta.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Opțiuni de ocolire</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Evitați drumurile cu taxă</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Evită drumurile neasfaltate</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Evită trecerile cu bac</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Evitați autostrăzile</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nu poate fi creat un traseu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Din păcate, nu putem elabora un traseu cu opțiunile alese. Modifică-le și încearcă din nou.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Stabilește drumurile de evitat</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Opțiuni de ocolire activate</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Drum cu plată</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Drum neasfaltat</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Trecere cu bac</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nu</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nu</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacitate: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rețea: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Ai ajuns!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Bine</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sortare…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sortează preferatele</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Prestabilit</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>După tip</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>După distanță</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>După dată</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>După nume</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Acum o săptămână</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Acum o lună</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Acum mai mult de o lună</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Cu mai mult de un an în urmă</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Lângă mine</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Altele</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Planificarea traseului a eșuat</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Sosire la %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Pentru a crea un traseu, descarcă și actualizează toate hărțile de pe parcursul traseului.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Ai modificat harta lumii. Nu ascunde acest lucru! Spune-le prietenilor și modificați-o împreună.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Trimite prietenilor</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Închis acum</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Deschide mâine la %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Deschide %1 la %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Deschide la %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Închide la %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Adaugă orele de funcționare</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Parola (minim 8 caractere)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nume de utilizator sau parolă incorecte.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Cont OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Ultima încărcare</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Mulțumesc</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Numele locului</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Reține</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Eroare de descărcare</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Alege categoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Toate categoriile</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Adaugă locuri noi pe hartă și modifică-le pe cele existente direct din aplicație.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Schimbă poziția</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Ai nevoie de mai mult spațiu pentru a descărca. Șterge datele care nu sunt necesare.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Am îmbunătățit hărțile Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Comentariu detaliat</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Modificările aduse hărții, sugerate de tine, vor fi trimise comunității OpenStreetMap. Descrie orice detalii suplimentare care nu pot fi modificate în Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>S-a produs o eroare la căutarea poziției tale. Verifică dacă dispozitivul funcționează corect și încearcă din nou.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Serviciile de localizare sunt dezactivate</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Activează accesul la geolocalizare din setările dispozitivului</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Deschide Configurări</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Apasă pe Localizare</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Alege „În timp ce folosești aplicația”</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Selectează Intimitate și securitate</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Selectează Servicii de localizare</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Activează Servicii de localizare</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Sau continuă să folosești Organic Maps fără Locație</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervare</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Apelează</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Numele locului preferat</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Șterge locul preferat</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Nota dvs. va fi trimisă către OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mai mult</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Actualizează</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Dezactivezi înregistrarea celui mai recent traseu efectuat?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Dezactivează</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Verifică</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps folosește poziția ta geografică pentru a înregistra cel mai recent traseu urmat.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Opțiuni generale</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Pentru a afișa datele privind traficul, aplicația trebuie actualizată.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Dimensiunea fișierului jurnal: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Trage aici pentru a elimina</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Înlocuiți oprirea</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Pornește de la</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Vă rugăm să vă conectați la OpenStreetMap pentru a încărca automat toate modificările aduse hărții. Aflați mai multe</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>aici</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ascunde pagina</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 din %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Se descarcă %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Se aplică %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Acest nume e prea lung</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Au fost detectate fișiere noi</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convertește</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Eroare</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Unele fișiere nu au fost convertite.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>A apărut o eroare</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populare</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ascunde de pe hartă</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>A apărut o eroare la încărcarea etichetelor, încearcă din nou</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Corect</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Fund</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Să mergem</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinație</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Centrează</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Rezultatul căutării</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Apoi</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vrei să refaci traseul?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tastatura nu poate fi folosită cât timp conduci</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Traseul de la locul în care te afli nu poate fi alcătuit</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Traseul către destinația aleasă nu poate fi alcătuit. Alege altă destinație.</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nu este semnal GPS. Mergi la loc deschis.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nu poate fi alcătuit un traseu. Alege alte puncte ale traseului</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Pentru a crea un traseu, descarcă hărțile lipsă în dispozitivul tău</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Eroare. Repornește aplicația.</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Traseul va fi refăcut de la locul în care te afli</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Traseul va fi înlocuit cu unul pentru autovehicule</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nu sunt afișate toate marcajele</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Treceți la telefon pentru a vedea toate marcajele</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radare</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Info radare</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Descarcă hărțile în aplicația Organic Maps din dispozitivul tău</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 ieșire</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortare standard</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sortează după tip</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sortează după distanță</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sortează după dată</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sortează după nume</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Mâncare</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Obiective turistice</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzee</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parcuri</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Înot</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Munți</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animale</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteluri</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Clădiri</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Bani</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Magazine</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parcări</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzinării</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Farmacii</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Caută în listă</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Locuri sfinte</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Alege lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigarea pentru metrou nu este încă disponibilă în această regiune</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Traseul metroului nu a fost găsit</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Alege un punct de plecare sau de sosire mai aproape de o stație de metrou</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Înălțimi</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Pentru a activa și utiliza stratul topografic actualizează sau descarcă harta zonei</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Stratul topografic nu este încă disponibil în această zonă</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Urcare</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Coborâre</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. altitudine</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. altitudine</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Dificultate</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Timp:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Mărește harta pentru a vedea izoliniile</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Se descarcă</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Descarcă harta lumii</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Imposibilitatea de a crea foldere și de a muta fișiere pe memoria internă a dispozitivului sau pe cardul sd</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Eroare de disc</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Eroare de conectare</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Deconectează cablul USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Păstrați ecranul pornit</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Atunci când este activat, ecranul va fi întotdeauna aprins la afișarea hărții.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Arată pe ecranul de blocare</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Când este activată, nu trebuie să deblochezi telefonul de fiecare dată când aplicația este în funcțiune.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Limbă hartă</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Date cartografice din OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Vă mulțumim că utilizați hărțile create de comunitatea noastră!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Cu donațiile și sprijinul dumneavoastră, putem crea cele mai bune hărți din lume!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Îți place aplicația noastră? Vă rugăm să donați pentru a sprijini dezvoltarea! Nu-ți place încă? Vă rugăm să ne anunțați și vom remedia!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Dacă cunoașteți un dezvoltator de software, îi puteți cere să implementeze o caracteristică de care aveți nevoie.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Atingeți oriunde pe hartă pentru a selecta orice. Atingeți lung pentru a ascunde și a reda interfața.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Știți că vă puteți selecta locația curentă pe hartă?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Puteți ajuta la traducerea aplicației noastre în limba dvs.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Aplicația noastră este dezvoltată de câțiva entuziaști și de comunitate.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Puteți remedia și îmbunătăți cu ușurință datele hărții.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Scopul nostru principal este să construim hărți rapide, axate pe confidențialitate și ușor de utilizat, care să vă placă.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Acum utilizați Organic Maps pe ecranul telefonului</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Acum utilizați Organic Maps pe ecranul mașinii</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Sunteți conectat la Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continuați în telefon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>La ecranul mașinii</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps are nevoie de acces la locație. Când este sigur, verificați notificarea de pe telefon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Această aplicație are nevoie de permisiunea dvs.</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps din Android Auto are nevoie de o permisiune de localizare pentru a funcționa eficient</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Acordarea de permisiuni</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Drumeție</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Browserul web nu este disponibil</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volum</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportați toate marcajele și piesele</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Setări ale sistemului de sinteză vocală</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nu au fost găsite setările de sinteză vocală, sunteți sigur că dispozitivul dvs. le acceptă?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Servire în mașină</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Ștergeți căutarea</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>A mari</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>A micsora</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Legătura de meniu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Vezi meniul</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Deschidere în altă aplicație</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Autoservire</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Selectați opțiunea</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Scaune în aer liber</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Pentru o navigare cât mai precisă, vă recomandăm să dezactivați modul de economisire a energiei în setările pentru baterie ale telefonului.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Înregistrați traseul</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Opriți înregistrarea traseului</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Înregistrare traseu</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Oprire fără salvare</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continuați înregistrarea</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Salvați în Locuri preferate și trasee?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Traseul este gol - nu este nimic de salvat</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nu se poate afișa dialogul de selectare a dosarelor deoarece pe dispozitivul dvs. nu este instalată nicio aplicație adecvată. Vă rugăm să instalați o aplicație de gestionare a fișierelor și să încercați din nou</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Alegeți culoarea</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Editează traseul</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nu există nicio aplicație instalată care să poată deschide locația</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto în navigație</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Urmează sistemul</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Partajează traseul</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Ștergeți %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Nivel de dificultate</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Ușor</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mediu</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Dificil</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Se actualizează</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Actualizează hărțile descărcate</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Actualizarea hărților menține actualizate informațiile despre obiecte</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Actualizează (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Actualizează manual mai târziu</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Elimină traseul</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Sunteți sigur că doriți să ștergeți această pistă?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Numele traseului</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Mută</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Traseu</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Schimbă culoarea</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Hartă</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Doriți să trimiteți un raport de eroare dezvoltatorilor?
+Ne bazăm pe utilizatorii noștri, deoarece Organic Maps nu colectează automat nicio informație privind erorile. Vă mulțumim anticipat pentru susținerea Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Activați Sincronizarea iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Sincronizarea iCloud este o funcție experimentală aflată în curs de dezvoltare. Asigurați-vă că ați făcut o copie de rezervă a tuturor marcajelor și pieselor dvs.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud este dezactivat</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Vă rugăm să activați iCloud în setările dispozitivului dvs. pentru a utiliza această funcție.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Activați</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Eșecul sincronizării iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Eroare: Nu s-a reușit sincronizarea din cauza unei erori de conexiune</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Eroare: Nu s-a reușit sincronizarea din cauza depășirii cotei iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Eroare: iCloud nu este disponibil</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Liste șterse recent</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Șterge</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Ștergeți toate</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recuperare</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recuperează tot</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribuie la OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Adaugă loc</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Actualizează harta pentru a contribui</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Trebuie să actualizați harta %1 la cea mai recentă versiune înainte de a putea contribui la datele OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Poziția mea</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Locurile mele</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Depozit intern privat</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Stocare partajată internă</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Card SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Stocare partajată externă</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wi-Fi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Cod poștal</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Punct Hartă</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>picioare</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Pentru a afișa rutele, hărțile trebuie să fie actualizate.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Ieșire</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Intrare</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Harta de metrou nu este disponibilă</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Tu</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Regiuni descărcate violete</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Traseu</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detectarea locației în fundal este necesară pentru a beneficia pe deplin de funcționalitatea aplicației. Este folosită pentru navigație și pentru salvarea traseului parcurs recent.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determinarea locației dvs. este necesară pentru navigare și pentru salvarea traseului parcurs recent.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Autentificare cu parolă</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Conectare folosind browserul</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Folosite recent</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Culoarea marcajelor a fost schimbată</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Culoarea traseelor a fost schimbată</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectru</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Glisoare</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ROȘU</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>VERDE</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ALBASTRU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Culoare Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grilă</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/ru/omim.ts
+++ b/qt/translations/ru/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="ru">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Отмена</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Удалить</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Загрузить карты</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Ошибка загрузки. Нажмите, чтобы повторить попытку.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Загружается…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Километры</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Мили</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Не сейчас</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Поиск</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Поиск на карте</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Геолокация выключена в настройках устройства. Пожалуйста, включите её для удобного использования программы.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Точность местоположения ограничена</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Включите в настройках точное определение местоположения.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Показать на карте</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Ошибка загрузки</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Попробуйте ещё раз</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Про Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Бесплатно для всех, сделано с любовью</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Без рекламы, без трекинга, без слежки</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Не разряжает батарею, работает в автономном режиме</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Быстрый, минималистичный, разработанный сообществом</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Приложение с открытым исходным кодом, созданное энтузиастами и волонтёрами.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Настройки местоположения</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Закрыть</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Для работы приложения необходим аппаратно ускоренный OpenGL. К сожалению, ваше устройство не поддерживается.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Загрузить</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Для использования приложения Organic Maps отсоедините USB-кабель или вставьте карту памяти</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Недостаточно свободного места на SD карте/в памяти устройства для использования программы</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Для начала работы скачайте, пожалуйста, обзорную карту мира на ваше устройство.
+Потребуется %1 данных.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Перейти на карту</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Пока загружается %1,
+вы можете пользоваться картой.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Загрузить %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Обновить %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Приостановить</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Продолжить</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Не удалось загрузить %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Добавить список</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Название списка меток</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Метки</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Метки и треки</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Название</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Адрес</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Список</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Настройки</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Сохранять карты в</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Выберите папку куда загружать карты.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Загруженные карты</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 свободно из %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Переместить карты?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Ошибка перемещения файлов карт</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Это может занять несколько минут.
+Пожалуйста, подождите…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Единицы измерения</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Использовать километры или мили</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Отменить загрузку</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Написать отзыв</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Загрузить карту</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Списки меток</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Где поесть</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Продукты</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Транспорт</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Заправка</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Парковка</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Шоппинг</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Секонд-хенд</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Гостиница</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Достопримечательности</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Развлечения</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Банкомат</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Ночная жизнь</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Отдых с детьми</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Банк</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Аптека</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Больница</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Туалет</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Почта</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Полиция</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Переработка</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Вода</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Для автодомов</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Примечание</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>С вами поделились метками Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Здравствуйте!
+
+В прикреплённом файле мои метки из офлайновых карт Organic Maps. Для того чтобы открыть этот файл, вам потребуется приложение Organic Maps, которое можно установить по ссылке: https://omaps.app/get?kmz
+
+Спасибо!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Загрузка меток</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Метки успешно загружены! Вы можете увидеть их на карте или в ваших сохранённых метках.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Файл с метками не был загружен. Возможно, файл повреждён или неисправен.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Тип файла не поддерживается приложением:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Не удалось открыть файл %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Редактировать</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ваше местоположение ещё не определено</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Извините, настройки места хранения карт сейчас недоступны.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Идет процесс загрузки карт.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Проверьте моё текущее местоположение в приложении Organic Maps! %1 или %2 У вас нет офлайн-карт? Скачайте их здесь: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Проверь мою метку на карте Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Проверь моё текущее местоположение на карте Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Привет!
+
+Я сейчас здесь: %1. Чтобы увидеть это место на карте Organic Maps, открой эту ссылку %2 или эту %3
+
+Спасибо.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Поделиться</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Электронная почта</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Скопировано в буфер обмена: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Готово</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Данные OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Вы уверены, что хотите выйти из своей учетной записи OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Треки</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Длина</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Поделиться местоположением</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Общие настройки</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Информация</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Навигация</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Кнопки «+» и «-» на карте</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Показать на карте</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Ночной стиль при навигации в темноте</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Ночной режим</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Выключен</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Включен</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Автоматически</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Перспективный вид</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D здания</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-здания отключаются в режиме энергосбережения</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Голосовые инструкции</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Проговаривать названия улиц</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>При включении название улицы или съезда, на который нужно повернуть, будет произноситься вслух.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Язык подсказок</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Чтобы загрузить голос более высокого качества, откройте приложение Настройки и перейдите в Универсальный доступ → VoiceOver → Речь → Голос.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Протестировать голосовые подсказки (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Проверьте громкость или системные настройки преобразования текста в речь, если сейчас ничего не слышно.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Не доступны</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Автозум</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Расстояние</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Посмотреть на карте</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Меню</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Вебсайт</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Новости</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Связаться с нами</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Оценить приложение</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Справка</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Вопросы и ответы</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Поддержать деньгами</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Уже пожертвовано</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Напомнить позже</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Поддержать Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Помочь проекту</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Копирайт</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Сообщить о проблеме</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Улучшите направление стрелки, перемещая телефон восьмёркой, чтобы откалибровать компас.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Двигайте телефон восьмёркой, чтобы откалибровать компас и зафиксировать направление стрелки на карте.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Долгое нажатие на карту вернёт интерфейс обратно</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Обновить все</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Отменить все</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Загруженные</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>В очереди</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Возле меня</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Карт</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Загрузить все</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Загружается:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Чтобы удалить карту, пожалуйста, остановите навигацию.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Маршрут может быть проложен только внутри карты одного региона.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Загрузить карту</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Повторить</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Удалить карту</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Обновить карту</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Службы определения местоположения в Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Быстрое определение приблизительного местоположения с помощью Bluetooth, WiFi или мобильной сети</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Загрузите все карты по пути следования</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Для создания маршрута необходимо загрузить и обновить все карты на пути следования.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Недостаточно места</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Пожалуйста, включите геолокацию</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Сохранить</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>создать</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Красный</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Жёлтый</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Синий</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Зелёный</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Пурпурный</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Оранжевый</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Коричневый</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Розовый</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Тёмно-пурпурный</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Голубой</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Сине-зелёный</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Изумрудный</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Лайм</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Тёмно-оранжевый</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Серый</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Серо-голубой</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Информация</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Версия Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Оформление</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Светлое</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Темное</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Светлая с рассвета до заката</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Другой</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Подарите миллионам пользователей бесплатные карты без рекламы!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Сообщить или исправить неправильные данные на карте</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Стать волонтёром</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Подписывайтесь и пишите нам:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Почтовый клиент не настроен. Настройте его или используйте другие способы для связи. Наш адрес - %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Ошибка при отправлении письма</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Калибровка компаса</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Доступные</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Найдено</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Обновить</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Ошибка</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>метка</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>При движении по маршруту помните:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Дорожная обстановка, ПДД и дорожные знаки приоритетнее подсказок навигатора;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Карта может быть неточной, а предложенный маршрут не всегда оптимален;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Предлагаемые маршруты — лишь рекомендации;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Будьте внимательны с маршрутами в приграничных зонах: маршруты, построенные нашей программой иногда могут пересекать границы в неположенных местах.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Будьте внимательны на дорогах и берегите себя!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Проверьте сигнал GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Маршрут не построен. Текущая геопозиция не определена.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Пожалуйста, проверьте сигнал GPS. Для улучшения точности геопозиции включите Wi-Fi.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Включите режим определения геопозиции</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Текущая геопозиция не определена. Для построения маршрута включите режим определения геопозиции.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Маршрут не найден</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Не получилось построить маршрут.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Пожалуйста, измените начальную или конечную точку маршрута.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Измените начальную точку маршрута</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Маршрут не построен. Не определена начальная точка маршрута.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Пожалуйста, выберите начальную точку маршрута ближе к дороге.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Измените конечную точку маршрута</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Маршрут не построен. Не определена конечная точка маршрута.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Пожалуйста, выберите конечную точку маршрута ближе к дороге.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Не определена промежуточная точка маршрута.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Пожалуйста, измените промежуточную точку маршрута.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Системная ошибка</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Не удалось проложить маршрут из-за ошибки приложения.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Попробуйте снова</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Не сейчас</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Загрузить карту и построить более оптимальный маршрут с пересечением границы карты?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Для построения более оптимального маршрута с пересечением границы требуется загрузить карту.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Загрузите необходимые файлы</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Для построения маршрута загрузите и обновите все карты и файлы маршрутов по пути следования.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Для поиска мест и построения маршрутов скачайте карту, и интернет вам больше не понадобится.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Выбрать карту</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Показать</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Скрыть</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Категории</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>История</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>К сожалению, мы ничего не нашли.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Загрузите регион, в котором ищете, или попробуйте добавить название близлежащего города/деревни.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>История поиска</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Быстрый доступ к последним поисковым запросам.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Очистить историю поиска</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Википедия</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Статья с сайта wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Ваше местоположение</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Начать</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Отсюда</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Сюда</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Навигация возможна только из текущего местоположения.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Хотите перестроить маршрут от вашего местоположения?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Далее</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>С</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>До</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Добавить расписание</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Удалить расписание</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Весь день (24 часа)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Открыто</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Закрыто</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Добавить перерыв</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Время работы</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Расширенный режим</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Простой режим</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Перерыв</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Примеры значений</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Исправьте ошибку</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Выберите местоположение</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Пожалуйста, напишите подробно о проблеме, чтобы сообщество OpenStreetMap исправило ошибку.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Или сделайте это самостоятельно на сайте https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Отправить</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Проблема</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Места не существует</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Закрыто на ремонт</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Повторяющееся место</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Автоматическая загрузка</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Ежедневно</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Круглосуточно</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Сегодня закрыто</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Закрыто</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Сегодня</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Открывается через %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Закроется через %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Закрыто</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Редактировать время работы</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Не зарегистрированы в OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Зарегистрироваться</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Войти</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Не выполнен вход</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Войти в OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Забыли пароль?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Выйти</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Редактировать место</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Добавить язык</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Улица</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Номер дома</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Подробнее</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Социальные сети</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Здание</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Добавить улицу</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Введите название улицы</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Выбрать язык</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Выбрать улицу</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Кухня</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Выбрать кухню</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Эл. почта или имя пользователя</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Добавить телефон</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Этаж</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Этаж: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Вместе с картой удалятся и внесённые вами правки на этой карте.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Обновите карты</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Для построения маршрутов необходимо обновить все карты и построить маршрут заново.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Найти карту</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Проверьте настройки и убедитесь, что устройство подключено к интернету.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Недостаточно места</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Удалите ненужные данные</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Произошла ошибка при авторизации.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Учтённые правки</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Перетащите карту, чтобы поместить крестик на место расположения добавляемого объекта или заведения.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Редактирование</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Добавление</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Название места</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>На местном языке</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Категория</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Подробное описание проблемы</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Другая проблема</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Добавить организацию</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Объект не может находиться в этом месте</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Созданные сообществом данные OpenStreetMap по состоянию на %1. Узнайте больше о том, как редактировать и обновлять карту, на сайте OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) - это открытый проект сообщества по созданию бесплатной карты. Он является основным источником картографических данных в Organic Maps и работает как Википедия. Кто угодно может добавлять или редактировать места, которые позже увидят миллионы пользователей по всему миру.
+Присоединяйтесь к сообществу и помогите сделать лучшую карту для всех!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Создайте учетную запись OpenStreetMap или войдите в нее, чтобы опубликовать свои правки на карте для всего мира.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 из %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Загрузить через сотовую связь?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>На некоторых тарифных планах или в роуминге это может привести к значительным расходам.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Введите корректный номер дома</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Количество этажей (максимум %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Количество этажей не должно превышать %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Почтовый индекс</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Введите корректный почтовый индекс</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Примечание для волонтеров OpenStreetMap (необязательно)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Опишите ошибки на карте или то, что нельзя редактировать с помощью Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Ваши правки будут загружены в общедоступную базу данных &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/RU:О_проекте&quot;&gt;OpenStreetMap&lt;/a&gt;. Пожалуйста, не добавляйте личную информацию или информацию, защищенную авторским правом.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Подробнее об OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Ваша история редактирования</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Ваши заметки о данных карты</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Оператор</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Оператор: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Нет подходящей категории?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps позволяет добавлять на карту только простые типы объектов, то есть никаких городов, дорог, озер, контуров зданий. Пожалуйста, добавляйте такие категории на сайте &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Также рекомендуем ознакомиться с нашими &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;подробными пошаговыми инструкциями и другими приложениями для редактирования карты&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>У вас нет загруженных карт</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Местоположение не найдено.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>км/ч</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ми/ч</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ч</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>мин</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>д</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>с</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Ещё</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Редактировать метку</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Примечание (текст или html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Комментарий…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Сбросить все локальные правки?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Сбросить</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Удалить добавленный вами объект?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Удалить</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Места не существует</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Пожалуйста, укажите причину удаления</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Введите корректный номер телефона</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Введите корректный веб-адрес</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Введите корректный email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Введите корректный веб-адрес Facebook страницы или имя пользователя</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Введите корректный веб-адрес Instagram страницы или имя пользователя</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Введите корректный веб-адрес Twitter страницы или имя пользователя</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Введите корректный веб-адрес VK страницы или имя пользователя</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Введите корректный веб-адрес LINE страницы или LINE ID</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Добавить место в OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Или, в качестве альтернативы, оставьте заметку для сообщества OpenStreetMap, чтобы кто-то другой мог добавить или исправить место здесь.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Ваша заметка будет отправлена в OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Отправить всем пользователям?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Убедитесь, что вы не ввели личные данные.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Редакторы OpenStreetMap проверят изменения и свяжутся с вами, если у них возникнут вопросы.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Стоп</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Запущена запись трека</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Принять</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Отклонить</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Загружать дополнительную информацию через мобильный интернет?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Всегда</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Только сегодня</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Не использовать сегодня</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Мобильный интернет</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Мобильный интернет требуется для уведомлений об обновлении карты и для отображения более подробной информации о местах и метках.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Никогда не использовать</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Всегда спрашивать</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Для отображения пробок необходимо обновить карты.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Увеличить шрифт на карте</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Обновите Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Данные о пробках недоступны</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Включить запись логов</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Отправить отзыв</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Подсказки озвучиваются системным синтезатором речи (TTS). На многих устройствах используется Google TTS, его можно загрузить или обновить в Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Для некоторых языков, возможно, необходимо установить дополнительный синтезатор речи (TTS) из магазина приложений (Google Play, Galaxy Store, App Gallery, FDroid).
+Чтобы настроить синтезатор речи, перейдите в Настройки → Язык и ввод → Синтез речи.
+Здесь можно установить дополнительные языковые пакеты или выбрать синтезатор речи.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Более подробная информация — в этом руководстве.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Транслитерировать в Латинский алфавит</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Узнать больше</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Используйте поиск, выберите метку, или коснитесь карты, чтобы добавить начальную точку маршрута</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Используйте поиск, выберите метку, или коснитесь карты, чтобы добавить точку назначения</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Изменить маршрут</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Построить</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Удалить остановку</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Добавить остановку</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Сохранено</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Пожалуйста войдите в аккаунт OpenStreetMap.org, чтобы публиковать ваши изменения карты. Подробности по &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ссылке&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Проблема с доступом к хранилищу</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Внешнее хранилище устройства недоступно. Возможно SD карта была удалена, повреждена или файловая система в режиме только для чтения. Проверьте вашу SD карту или свяжитесь с нами через support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Эмуляция ошибки с внешней памятью</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Пожалуйста, введите название правильно</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Списки</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Спрятать все</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Показать все</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n метка</numerusform>
+<numerusform>%n метки</numerusform>
+<numerusform>%n меток</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Создать новый список</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Импортировать метки и треки</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Не удалось поделиться из-за ошибки приложения</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Ошибка при попытке поделиться</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Нельзя делиться пустыми списками</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Имя списка не может быть пустым</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Введите имя списка, пожалуйста</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Новый список</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Такое имя уже занято</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Выберите, пожалуйста, другое имя</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Пожалуйста, подождите…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Номер телефона</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Профиль OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n файл был найден. Вы увидите его после конвертации.</numerusform>
+<numerusform>%n файла были найдены. Вы увидите их после конвертации.</numerusform>
+<numerusform>%n файлов были найдены. Вы увидите их после конвертации.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Восстановить</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n трек</numerusform>
+<numerusform>%n трека</numerusform>
+<numerusform>%n треков</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Приватность</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Политика конфиденциальности</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Условия использования</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Пробки</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Пешие маршруты</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Веломаршруты</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Метро</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Стили и слои карты</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Список пустой</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Чтобы добавить метку, нажмите на место на карте, а затем на иконку звёздочки</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Изменить цвет всех меток</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Изменить цвет всех треков</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…ещё</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Экспорт KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Экспорт GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Экспорт GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Удалить список</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Камеры скорости</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Описание места</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Загрузка карт</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Предупреждать при превышении скорости</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Всегда предупреждать</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Никогда не предупреждать</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Режим энергосбережения</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Попробовать уменьшить потребление заряда аккумулятора за счёт отключения некоторых функций.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Никогда</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Авто</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Максимальное энергосбережение</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Названия меток на карте</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Если меток очень много, отображение их названий на карте может замедлить работу приложения.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Справа</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Под меткой</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Данная настройка включается для записи действий в целях диагностики, чтобы помочь нашей команде выявить проблемы с приложением. Временно включайте эту настройку только для отправки детальной информации о найденной вами проблеме в приложении через кнопку &quot;Сообщить о проблеме&quot;.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Настройки объезда</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Избегать платных дорог</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Избегать грунтовые дороги</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Избегать паромы</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Избегать автомагистрали</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Невозможно построить маршрут</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Маршрут не найден. Это могло быть спровоцировано вашими настройками прокладки маршрута или неполными данными OpenStreetMap. Пожалуйта, измените ваши настройки прокладки маршрута и попробуйте снова.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Настроить пути объезда</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Настройки объезда включены</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Платная дорога</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Грунтовая дорога</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Паромная переправа</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Нет</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Есть</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Нет</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Вместимость: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Сеть: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Вы прибыли!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ок</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Сортировать…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Сортировать метки</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>По умолчанию</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>По типу</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>По расстоянию</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>По дате</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>По имени</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Неделю назад</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Месяц назад</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Больше месяца назад</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Больше года назад</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Рядом со мной</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Другие</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Ошибка построения маршрута</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Прибытие в %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Для построения маршрута загрузите и обновите все карты по пути следования.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Вы изменили карту мира. Не скрывайте это, расскажите друзьям и редактируйте вместе.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Поделиться с друзьями</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Сейчас закрыто</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Откроется завтра в %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Открывается в %1 в %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Открывается в %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Закрывается в %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Добавить время работы</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Пароль (минимум 8 символов)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Неверное имя пользователя или пароль.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Аккаунт</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Последняя отправка</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Спасибо</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Название</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Телефон</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Обратите внимание</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Ошибка загрузки</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Выбрать категорию</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Популярные</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Все категории</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Добавляйте новые объекты и редактируйте старые прямо из приложения.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Измените местоположение</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Для загрузки требуется больше свободного места. Пожалуйста, удалите ненужные данные.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Я улучшил карты Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Подробный комментарий</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Предложенные вами изменения на карте будут отправлены в OpenStreetMap. Опишите дополнительные сведения об объекте, которые Organic Maps не позволяет отредактировать.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>При поиске местоположения произошла неизвестная ошибка. Проверьте работоспособность устройства и попробуйте найти местоположение позднее.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Определение местоположения отключено</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Разрешите доступ к геопозиции в настройках устройства</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Откройте Настройки</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Нажмите Геопозиция</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Выберите «При использовании программы»</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Выберите Конфиденциальность</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Выберите Службы геолокации</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Включите Службы геолокации</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Или продолжите использование Organic Maps без определения местоположения</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Забронировать</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Позвонить</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Название метки</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Удалить метку</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ваша заметка будет отправлена в OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…ещё</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Обновить</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Выключить запись недавно пройденого пути?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Выключить</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Посмотри</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps использует вашу геопозицию в фоновом режиме для записи недавно пройденного пути.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Общие настройки</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Для отображения пробок необходимо обновить приложение.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Размер файла логов: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Перетяните сюда, чтобы удалить</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Заменить остановку</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Начать от</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Пожалуйста войдите в аккаунт OpenStreetMap.org, чтобы публиковать ваши изменения карты. Подробности по</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ссылке</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Скрыть</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 из %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Загрузка %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Применение %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Слишком длинное название</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Обнаружены новые файлы</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Конвертировать</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Ошибка</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Некоторые файлы не конвертировались.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Произошла ошибка</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Популярно</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Скрыть с карты</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Во время загрузки тегов произошла ошибка, пожалуйста, попробуйте ещё раз</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Справа</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Снизу</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Поехали</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Цель</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Отцентровать</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Результаты поиска</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Затем</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Хотите перестроить маршрут?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Клавиатура недоступна во время движения</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Невозможно построить маршрут от текущего местоположения</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Невозможно построить маршрут до конечной точки. Выберите другую</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Нет сигнала GPS. Проследуйте на открытую местность</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Невозможно построить маршрут. Выберите другие точки маршрута</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Чтобы построить маршрут, загрузите недостающие карты на своём устройстве</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Произошла ошибка. Перезапустите приложение</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Маршрут будет перестроен от вашего текущего местоположения</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Маршрут будет изменён на автомобильный</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Отображаются не все метки</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Переключитесь на телефон, чтобы увидеть все метки</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Камеры</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Инфо о камерах</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Скачайте карты в приложении Organic Maps на своём устройстве</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 съезд</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Сортировать по умолчанию</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Сортировать по типу</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Сортировать по расстоянию</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Сортировать по дате</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Сортировать по имени</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Еда</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Достопримечательности</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Музеи</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Парки</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Плавание</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Горы</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Животные</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Отели</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Здания</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Деньги</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Магазины</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Парковки</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Заправки</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Медицина</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Искать в списке</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Святые места</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Выбрать список</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Навигация на метро ещё недоступна в данном регионе</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Маршрут метро не найден</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Выберите начальную или конечную точку маршрута ближе к станции метро</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Высоты</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Чтобы воспользоваться линиями высот, обновите или загрузите карту нужной местности</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Линии высот пока не доступны в этом регионе</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Подъём</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Спуск</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Мин. высота</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Макс. высота</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Сложность</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Расст.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>В пути:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Увеличьте карту, чтобы увидеть изолинии</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Загрузка</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Скачать обзорную карту мира</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Не могу создать папку и переместить файлы на устройстве</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Ошибка диска</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Ошибка подключения</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Отсоедините USB кабель</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Держи экран включённым</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Если эта функция включена, то при отображении карты экран будет всегда включен.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Показывать на экране блокировки</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Если эта функция включена, вам не нужно каждый раз разблокировать устройство во время работы приложения.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Язык карты</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Картографические данные из OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsRu</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/ru/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/ru/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/RU:О_проекте</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Спасибо, что пользуетесь нашими картами, созданными сообществом!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Благодаря вашим пожертвованиям и поддержке мы сможем создать лучшие карты на свете!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Вам нравится наше приложение? Поддержите его развитие деньгами! Пока ещё не нравится? Пожалуйста, сообщите нам, почему, и мы это исправим!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Если вы знаете толкового разработчика программного обеспечения, попросите его реализовать нужную вам функцию для приложения.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Коснитесь любого места на карте, чтобы выбрать что-либо. Длительное нажатие скрывает и возвращает интерфейс.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>А вы знали, что своё местоположение на карте можно выбрать?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Вы можете помочь перевести наше приложение на ваш язык.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Наше приложение разработано несколькими энтузиастами и сообществом.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Вы можете легко исправить и улучшить данные карты.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Наша главная цель — создать быстрые, конфиденциальные и простые в использовании карты, которые вам понравятся.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Сейчас Вы используете Organic Maps на экране телефона</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Сейчас Вы используете Organic Maps на экране автомобиля</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Вы подключены к Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Продолжить в телефоне</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Продолжить в авто</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps нужен доступ к местоположению. Когда будет безопасно, проверьте уведомление на телефоне.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Этому приложению нужно ваше разрешение</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Для эффективной работы Organic Maps в Android Auto необходимы разрешения на определение местоположения</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Разрешить</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Активный отдых</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Веб-браузер недоступен</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Громкость</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Экспортировать все метки и треки</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Системные настройки синтеза речи</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Настройки синтеза речи не найдены, вы уверены, что ваше устройство поддерживает их?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>С окошком для водителей</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Очистите поиск</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Приблизить</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Отдалить</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Ссылка на меню</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Посмотреть меню</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Открыть в другом приложении</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Самообслуживание</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Выберите вариант</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Сидения на открытом воздухе</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Для наиболее точной навигации мы рекомендуем отключить режим энергосбережения в настройках батареи телефона.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Записать трек</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Остановить запись трека</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Запись трека</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Остановить без сохранения</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Продолжить запись</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Сохранить в метки и треки?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Трек пуст - нечего сохранять</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Невозможно отобразить диалог выбора папки, потому что на вашем устройстве не установлено подходящее приложение. Пожалуйста, установите менеджер файлов и повторите попытку.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Выберите цвет</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Редактировать трек</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Не установлено приложение, которое может открыть местоположение</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Авто в навигации</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Как в системе</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Поделиться треком</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Удалить %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Уровень сложности</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Лёгкий</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Умеренный</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Сложный</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Обновление</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Обновите ваши загруженные карты</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Обновление карт поддерживает информацию об объектах в актуальном состоянии</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Обновить (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Обновить вручную позже</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Удалить трек</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Вы уверены, что хотите удалить этот трек?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Название трека</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Переместить</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Трек</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Изменить цвет</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Карта</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Хотите отправить разработчикам сообщение об ошибке?
+Мы полагаемся на наших пользователей, так как Organic Maps не собирает информацию об ошибках автоматически. Заранее спасибо за поддержку Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Включить синхронизацию с iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Синхронизация с iCloud - это экспериментальная функция, которая находится в стадии разработки. Убедитесь, что вы сделали резервную копию всех своих меток и треков.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud отключен</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Чтобы воспользоваться этой функцией, включите iCloud в настройках своего устройства.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Включить</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Резервная копия</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Сбой синхронизации iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Ошибка: Не удалось выполнить синхронизацию из-за ошибки подключения</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Ошибка: Не удалось выполнить синхронизацию из-за превышения квоты iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Ошибка: iCloud недоступен</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Недавно удаленные списки</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Очистить</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Удалить всё</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Восстановить</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Восстановить всё</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Внести вклад в OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Добавить место</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Обновить карту, чтобы внести вклад</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Чтобы внести изменения в данные OpenStreetMap, необходимо сначала обновить карту %1 до последней версии</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>МБ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ГБ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Мое местоположение</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Мои Метки</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Внутренний скрытый накопитель</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Внутренний общий накопитель</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-карта</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Внешний общий накопитель</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Почтовый индекс</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Точка на карте</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>м</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>км</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ми</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>фут</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Обновите карты, чтобы увидеть маршруты.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Выход</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Вход</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Карта метро недоступна</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Вы</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Фиолетовые загруженные регионы</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Маршрут</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Определение местоположения в фоне необходимо для полноценного пользования приложением. Оно используется в движении по маршруту и сохранении недавно пройденного пути.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Определение местоположения используется в движении по маршруту и сохранении недавно пройденного пути.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Вход с паролем</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Вход в систему с помощью браузера</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Недавно использованные</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Цвет меток изменён</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Цвет треков изменён</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Спектр</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Слайдеры</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>КРАСНЫЙ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ЗЕЛЕНЫЙ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>СИНИЙ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Сетка</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sk/omim.ts
+++ b/qt/translations/sk/omim.ts
@@ -1,0 +1,3935 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sk">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Späť</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Zrušiť</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Zmazať</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Stiahnuť mapy</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Sťahovanie zlyhalo, skúste to znova.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Sťahovanie…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometre</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Míle</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Neskôr</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Hľadať</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Prehľadať mapu</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Aktuálne máte všetky možnosti pre určovanie polohy vypnuté. Prosím, povoľte ich v Nastaveniach.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Obmedzená presnosť</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Ak chcete zabezpečiť presnú navigáciu, v nastaveniach povoľte funkciu Presná poloha.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Ukázať na mape</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Sťahovanie zlyhalo</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Skúsiť znova</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>O aplikácii Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Zadarmo pre každého, vyrobené s láskou</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Žiadne reklamy, žiadne sledovanie, žiadny zber údajov</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Žiadne vybíjanie batérie, funguje v režime offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Rýchly, minimalistický, vyvinutý komunitou</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplikácia s otvoreným zdrojovým kódom vytvorená nadšencami a dobrovoľníkmi.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Nastavenia polohy</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zavrieť</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Je vyžadovaná hardwarová akcelerácia OpenGL. Bohužial, vaše zariadenie nie je podporované.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Stiahnuť</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Prosím, odpojte USB kábel alebo vložte pamäťovú kartu pre použitie s Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Prosím, uvoľnite najprv miesto na SD karte/USB úložisku</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Skôr ako začnete, bude treba stiahnuť základnú mapu sveta.
+Zaberie to %1.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Prejsť na mapu</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Sťahovanie %1. Teraz môžete
+prejsť na mapu.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Stiahnuť %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Aktualizovať %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pauza</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Pokračovať</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Sťahovanie zlyhalo: %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Pridať novú skupinu záložiek</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Meno záložky</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Záložky</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Záložky a stopy</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Názov</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresa</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Zoznam</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Nastavenia</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Uložiť mapy do</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Vyberte miesto, kam sa majú sťahovať mapy</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>Voľných %1 z %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Presunúť mapy?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Chyba pri presune mapových súborov</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Táto akcia môže trvať niekoľko minút.
+Prosím čakajte…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Meracie jednotky</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Vyberte si míle alebo kilometre</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Zrušiť sťahovanie</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Spätná väzba</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Áno</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Stiahnite si mapu</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Skupiny záložiek</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Kde sa najesť</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Potraviny</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Doprava</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Čerpacia stanica</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkovisko</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Nakupovanie</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second-hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Pamätihodnosť</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Zábava</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nočný život</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Rodinná dovolenka</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Lekáreň</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Nemocnica</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Záchody</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pošta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polícia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recyklácia</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Voda</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Pre RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Poznámky</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Zdielané záložky Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Ahoj!
+
+V prílohe sú moje záložky z aplikácie Organic Maps. Ak ju nemáš nainštalovanú, môžeš si ju stiahnuť tu: https://omaps.app/get?kmz
+
+Prajem šťastnú cestu s Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Načítavanie záložiek</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Záložky boli úspešne načítané! Môžete ich nájsť na mape alebo na obrazovke Správca záložiek.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Načítavanie záložiek sa nepodarilo. Súbor môže byť poškodený alebo chybný.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Aplikácia nerozpoznáva typ súboru:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Nepodarilo sa otvoriť súbor %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Upraviť</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Vaša poloha zatiaľ nebola určená</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Prepáčte, nastavenie uloženia máp je dočasne nedostupné.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Práve prebieha sťahovanie krajiny.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Pozrite si moju aktuálnu polohu v aplikácii Organic Maps! %1 alebo %2 Nemáte offline mapy? Stiahnite si ich tu: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Pozri na moju značku na mape Organic Maps</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Pozrite si moju aktuálnu polohu na mape Organic Maps</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Ahoj,
+
+Práve som tu: %1. Stlačte jeden z týchto odkazov %2, %3 a uvidíte toto miesto na mape.
+
+Vďaka</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Zdieľať</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-mail</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Skopírované do schránky: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Hotovo</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Údaje OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ste si istí, že sa chcete odhlásiť zo svojho účtu OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Stopy</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Dĺžka</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Zdieľať moju polohu</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Všeobecné nastavenia</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informácie</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigácia</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Tlačidlá „+“ a „-“ na mape</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Zobraziť na obrazovke</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nočný štýl pri navigácii v tme</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nočný režim</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Vypnúť</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Zapnúť</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automaticky</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektívne zobrazenie</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D budovy</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D budovy sú vypnuté v režime úspory energie</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Hlasové povely</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Oznámte názvy ulíc</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Keď je táto možnosť povolená, nahlas sa vysloví názov ulice alebo výjazdu, na ktorý sa má odbočiť.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Nastavenia jazyka povelov</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Ak si chcete stiahnuť hlas vo vyššej kvalite, otvorte apku Nastavenia a prejdite do Prístupnosť → VoiceOver → Reč → Hlas.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testovanie hlasových pokynov (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Ak teraz nepočujete hlas, skontrolujte hlasitosť alebo systémové nastavenia prevodu textu na reč.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nie je k dispozícii</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatický zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Vzdialenosť</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Zobraziť na mape</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Ponuka</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webové stránky</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Správy</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Spätná väzba</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Ohodnotiť aplikáciu</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Nápoveda</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Otázky a odpovede</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Darovať</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Už darované</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Pripomeň neskôr</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Podporiť Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Podporte projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Autorské práva</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Nahlásiť chybu</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Zlepšite smer šípok pohybom telefónu v tvare osmičky, aby ste kalibrovali kompas.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Pohybom telefónu v tvare osmičky kalibrujte kompas a zafixujte smer šípky na mape.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Opätovným dlhým ťuknutím na mapu zobrazíte rozhranie</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Aktualizovať všetko</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Zrušiť všetko</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Stiahnuté</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>V rade</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Neďaleko mňa</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Mapy</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Stiahnuť všetko</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Sťahovanie:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Ak chcete odstrániť mapy, prosím, zastavte navigáciu.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Cesty môžu byť vytvorené len tak, že sú plne obsiahnuté v jednej mape.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Stiahnuť mapu</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Zopakovať</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Zmazať mapu</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Aktualizovať mapu</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Lokalizačné služby Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Rýchle určenie približnej polohy cez Bluetooth, WiFi alebo mobilnú sieť</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Stiahnite si mapy pozdĺž trasy</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Aby bolo možné naplánovať cestu, je potrebné stiahnuť všetky mapy od vašej pozície po cieľové miesto.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nedostatok miesta</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Prosím, povoľte Služby určovania polohy</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Uložiť</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>vytvoriť</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Červená</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Žltá</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Modrá</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zelená</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purpurová</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranžová</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Hnedá</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Ružová</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tmavofialová</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Svetlo modrá</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Tyrkysová</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Modrozelená</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limetková</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Tmavo oranžová</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Sivá</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Modro sivá</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Viac informácií</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Verzia Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Vzhľad</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Svetlý</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tmavý</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Svetlý od úsvitu do súmraku</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Iný</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Darujte bezplatné mapy bez reklám miliónom používateľov!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Nahlásenie alebo oprava nesprávnych údajov mapy</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Dobrovoľníctvo</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Sledujte nás a kontaktujte nás:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Emailový klient nebol nastavený. Nakonfigurujte ho prosím alebo použite iný spôsob k tomu, abyste nás kontaktovali na %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Chyba pri odosielaní emailu</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrácia kompasu</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Dostupné</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Nájdených</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Aktualizácia</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Zlyhalo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>záložka</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Pri sledovaní trasy majte na pamäti nasledujúce:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Podmienky na ceste, dopravné predpisy a značenie majú vždy prednosť pred pokynmi z navigácie;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Mapa nemusí byť presná a navrhovaná trasa nemusí byť vždy optimálna na dosiahnutie cieľa;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Navrhované trasy by sa mali brať len ako odporúčania;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Buďte opatrní na cestách v pohraničných oblastiach: trasy vytvorené aplikáciou môžu prekročiť hranice štátov na nepovolených miestach;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Na cestách buďte vždy ostražitý a dbajte na bezpečnosť!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Skontrolujte signál GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nedá sa vytvoriť trasa. Aktuálne súradnice GPS sa nedajú identifikovať.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Skontrolujte signál GPS. Zapnutie Wi-Fi zlepší presnosť vašej lokalizácie.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Zapnite lokalizačné služby</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Aktuálne súradnice GPS sa nedajú lokalizovať. Aktivujte lokalizačné služby na výpočet trasy.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Trasa sa nedá lokalizovať</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Trasa sa nedá vytvoriť.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Prosím, upravte váš východiskový bod alebo cieľové miesto.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Nastavte východiskový bod</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Trasa nebola vytvorená. Nedá sa lokalizovať východiskový bod.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Vyberte východiskový bod bližšie k ceste.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Nastavte cieľové miesto</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Trasa nebola vytvorená. Nedá sa lokalizovať cieľové miesto.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Vyberte cieľové miesto nachádzajúce sa bližšie k ceste.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Zastávku sa nepodarilo nájsť.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Upravte zastávku.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systémová chyba</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Nedá sa vytvoriť trasa z dôvodu aplikačnej chyby.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Skúste znova, prosím</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Nie teraz</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Chcete si prevziať mapu a vytvoriť optimálnejšiu trasu, ktorá si vyžaduje viac ako jednu mapu?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Prevezmite si mapu na vytvorenie optimálnejšej trasy, ktorá prekračuje okraje tejto mapy.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Prevezmite si požadované súbory</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Prevezmite si a aktualizujte všetky mapy a informácie o trase pozdĺž naplánovanej trasy na výpočet trasy.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Stiahnutím mapy už nebudete potrebovať pripojenie k internetu a môžete si začať vyhľadávať a vytvárať trasy.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Vybrať mapu</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Ukázať</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Skryť</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategórie</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Archív</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ľutujeme, ale nič sme nenašli.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Stiahnite si región, v ktorom hľadáte, alebo skúste pridať názov blízkeho mesta/obce.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>História vyhľadávania</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Rýchlo pristupujte k nedávnym hľadaným výrazom.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Vymazať históriu vyhľadávania</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipédia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Článok z wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Vaša poloha</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Štart</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Cesta z</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Cesta do</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigácia je dostupná iba z vašej aktuálnej polohy.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Máme naplánovať trasu z vašej súčasnej pozície?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Nasledujúca</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Od</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Do</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Pridať rozvrh</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Zmazať rozvrh</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Nepretržite (24 hodín)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Otvorené</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zatvorené</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Pridať hodiny zatvorenia</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Otváracie hodiny</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Rozšírený režim</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Jednoduchý režim</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Hodiny zatvorenia</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Príklady hodnôt</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Opraviť chybu</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Vyberte miesto</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Prosím, pridajte detailný popis problému, aby mohla komunita OpenStreetMap opraviť danú chybu.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>K oprave môžete prispieť aj vy na stránke https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Odoslať</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problém</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Dané miesto neexistuje</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Zatvorené kvôli prebiehajúcej údržbe</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicitné miesto</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automaticky stiahnuť</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Denne</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Deň a noc</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Dnes deň voľna</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Zatvorené</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Dnes</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Otvoria o %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Zatvoria o %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zatvorené</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Upraviť otváracie hodiny</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nemáte účet v OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Zaregistrovať sa</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Prihlásiť sa</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nie ste prihlásený</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Prihláste sa do OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Heslo</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Zabudli ste heslo?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Odhlásiť sa</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Upraviť miesto</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Pridať jazyk</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Ulica</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Číslo domu</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Podrobnosti</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociálne médiá</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Budova</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Pridať ulicu</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Zadajte názov ulice</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Vybrať jazyk</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Vybrať ulicu</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuchyňa</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Vyberte si kuchyňu</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email alebo používateľské meno</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Pridať telefónne číslo</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Podlaha</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Úroveň: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Všetky zmeny týkajúce sa mapy budú vymazané spolu s mapou.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Aktualizovať mapy</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Ak chcete vytvoriť cestu, musíte najskôr aktualizovať všetky mapy a potom odznova naplánovať trasu.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Nájsť mapu</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Prosím, skontrolujte svoje nastavenia a uistite sa, že váš počítač je pripojený k internetu.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nemáte dostatok miesta</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Prosím, odstráňte prebytočné dáta</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Pri prihlasovaní sa vyskytla chyba.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Overené zmeny</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Potiahnutím mapy umiestnite krížik na miesto, kde sa nachádza miesto alebo podnik.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Úprava</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Nové</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Názov miesta</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Tak, ako sa píše v miestnom jazyku</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategória</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Podrobný popis problému</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Iný problém</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Pridať organizáciu</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Objekt sa tu nedá umiestniť</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Údaje OpenStreetMap vytvorené komunitou od %1. Viac informácií o tom, ako upravovať a aktualizovať mapu, nájdete na stránke OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) je komunitný projekt na vytvorenie bezplatnej a otvorenej mapy. Je hlavným zdrojom mapových údajov v službe Organic Maps a funguje podobne ako Wikipédia. Môžete pridávať alebo upravovať miesta a tie sa stanú dostupnými pre milióny používateľov na celom svete.
+Pridajte sa ku komunite a pomôžte vytvoriť lepšiu mapu pre všetkých!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Vytvorte si účet OpenStreetMap alebo sa prihláste a zverejnite svoje úpravy mapy na celom svete.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 z %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Sťahovať prostredníctvom pripojenia na mobilnú sieť?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>V prípade niektorých plánov alebo použitím roamingu by to mohlo byť značne nákladné.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Zadajte správne číslo domu</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Počet poschodí (max %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Počet poschodí nesmie byť väčší ako %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>PSČ</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Zadajte správne PSČ</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Poznámka pre dobrovoľníkov OpenStreetMap (nepovinné)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Popíšte chyby na mape alebo veci, ktoré nie je možné upravovať, na adrese Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vaše úpravy sa nahrajú do verejnej databázy &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Prosím, nepridávajte osobné informácie alebo informácie chránené autorskými právami.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Viac o OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Vaša história úprav</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vaše poznámky k mapovým údajom</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Prevádzkovateľ</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Prevádzkovateľ: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nemôžete nájsť vhodnú kategóriu?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps umožňuje pridávať iba jednoduché kategórie bodov, čo znamená, že nie sú k dispozícii mestá, cesty, jazerá, obrysy budov atď. Takéto kategórie prosím pridávajte priamo na &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Podrobné pokyny krok za krokom nájdete v našom &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;návode&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Neprevzali ste žiadne mapy</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Prevziať mapy na nájdenie pozície a navigovanie off-line.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Súčasná pozícia je neznáma.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>hod</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Viac</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Upraviť záložku</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Osobné poznámky (text alebo html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Poznámka…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Resetovať všetky miestne časy?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Resetovať</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Odstrániť pridané miesto?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Odstrániť</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Miesto neexistuje</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Prosím, uveďte prečo chcete zmazať toto miesto</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Zadajte správne telefónne číslo</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Zadajte platnú webovú adresu</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Zadajte platný email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Zadajte platnú facebookovú adresu, účet alebo názov stránky</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Zadajte platné používateľské meno alebo webovú adresu pre Instagram</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Zadajte platné používateľské meno alebo adresu pre Twitter/X</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Zadajte platné používateľské meno alebo adresu pre VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Zadajte platné LINE ID alebo webovú adresu</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Pridať miesto do OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Prípadne zanechajte poznámku komunite OpenStreetMap, aby sem mohol pridať alebo opraviť miesto niekto iný.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Poznámka bude odoslaná do OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Odoslať všetkým používateľom?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Nezadávajte žiadne osobné udaje.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Redaktori OpenStreetMap skontrolujú zmeny a budú vás kontaktovať, ak budú mať nejaké otázky.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Zastavte</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Zaznamenávanie trasy</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Prijať</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Odmietnuť</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Použiť mobilný internet na zobrazenie podrobnejších informácií?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Vždy použiť</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Iba dnes</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Dnes nepoužiť</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilný internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Na zobrazenie podrobnejších informácií o miestach, napríklad fotografií, cien a recenzií, sa vyžaduje mobilný internet.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nikdy nepoužiť</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Vždy sa opýtať</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Na zobrazenie dopravných informácií je potrebné aktualizovať mapy.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Zväčšiť veľkosť písma na mape</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Aktualizujte si aplikáciu Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Dopravné informácie nie sú k dispozícii</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Zapnúť zaznamenávanie</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Všeobecné pripomienky</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Na hlasové pokyny používame systém TTS. Mnohé zariadenia s Adroidom používajú Google TTS, ktorý si môžete stiahnuť alebo aktualizovať z obchodu Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Pre niektoré jazyky bude potrebné nainštalovať syntetizátor reči alebo balík doplnkového jazyka z obchodu s aplikáciami (Google Play, Galaxy Store, App Gallery, FDroid). Otvorte nastavenia zariadenia → Jazyk a vstup → Reč → Prevod textu na reč. Tu môžete spravovať nastavenia pre syntézu reči (napríklad stiahnuť jazykový balík pre použitie v režime offline) a vybrať iný jazyk.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Viac informácií nájdete v tomto návode.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Prepis do latinky</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Zistiť viac</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Pomocou vyhľadávania alebo ťuknutím na mapu môžete pridať východiskový bod trasy</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Pomocou vyhľadávania alebo ťuknutím na mapu môžete pridať cieľový bod</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Spravovať trasu</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Naplánovať</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Odstrániť zastávku</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Pridať zastávku</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Uložené</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Prihláste sa do OpenStreetMap, aby ste mohli automaticky nahrať všetky svoje úpravy mapy. Viac informácií sa dozviete &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;tade&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problém s prístupom k úložisku</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Externý úložný priestor nie je dostupný, pravdepodobne je vytiahnutá alebo poškodená SD karta alebo je systém súborov určený iba na čítanie. Skontrolujte to, prosím, a kontaktujte nás na support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Imitovať poškodené úložisko</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Prosím, zadajte správne meno</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Zoznamy</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Skryť všetko</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Zobraziť všetko</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n záložka</numerusform>
+<numerusform>%n záložiek</numerusform>
+<numerusform>%n záložiek</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Vytvoriť nový zoznam</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importovanie záložiek a stôp</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Pre chybu aplikácie nie je zdieľanie možné</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Chyba zdieľania</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Prázdny zoznam nie je možné zdieľať</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Názov nemôže byť prázdny</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Zadajte názov zoznamu</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nový zoznam</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Tento názov už bol prijatý</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Vyberte iné meno</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Prosím čakajte…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefónne číslo</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Bol nájdený %n súbor. Uvidíte ho po konverzii.</numerusform>
+<numerusform>Boli nájdené %n súbory. Uvidíte ich po konverzii.</numerusform>
+<numerusform>Bolo nájdených %n súborov. Uvidíte ich po konverzii.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Obnoviť</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n sledovanie</numerusform>
+<numerusform>%n sledovania</numerusform>
+<numerusform>%n sledovania</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Súkromie</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Zásady ochrany osobných údajov</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Podmienky používania</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Dopravné informácie</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Turistika</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cyklistika</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Štýly a vrstvy mapy</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Tento zoznam je prázdny</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Pre pridanie záložky kliknite na miesto na mape a potom na ikonu hviezdičky</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Zmeniť farbu všetkých záložiek</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Zmeniť farbu všetkých trás</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…viac</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportovať KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportovať GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Vymazať zoznam</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Rýchlostné kamery</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Popis miesta</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Sťahovač máp</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Varovanie pred prekročením rýchlosti</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Vždy upozorniť</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nikdy neupozorňovať</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Úsporný režim</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Keď je zvolený automatický režim, aplikácia začne vypínať funkcie, ktoré vybíjajú batériu v závislosti od aktuálnej úrovne nabitia batérie</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nikdy</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Automaticky</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Maximálna úspora batérie</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Názvy záložiek na mape</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ak je záložiek príliš veľa, zobrazovanie ich názvov na mape môže aplikáciu spomaliť.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Zobraziť vpravo</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Zobraziť v dolnej časti</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Týmto zapnete záznamenávanie diagnostických informácií, ktoré môžete poslať našej technickej podpore v prípade problémov s aplikáciou. Záznam môže obsahovať údaje o vašej polohe.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Možnosti trasy</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Vyhnúť sa spoplatneným cestám</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Vyhnúť sa nespevneným cestám</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vyhnúť sa prechodom na trajekte</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Vyhnúť sa diaľniciam</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nepodarilo sa vypočítať trasu</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Bohužiaľ sme nemohli nájsť trasu pravdepodobne z dôvodu definovaných možností. Zmeňte nastavenia a skúste to prosím znova</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definovať cesty, ktorým sa treba vyhnúť</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Možnosti trasy povolené</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Spoplatnená cesta</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Nespevnená cesta</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Prechod trajektom</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Áno</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nie</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Áno</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nie</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapacita: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Sieť: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Prišli ste do cieľa!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Zoradiť…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Zoradiť záložky</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Podľa predvoleného</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Podľa typu</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Podľa vzdialenosti</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Podľa dátumu</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Podľa mena</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Pred týždňom</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Pred mesiacom</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Pred viac ako mesiacom</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Pred viac ako rokom</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Blízko mňa</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Iné</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Plánovanie trasy zlyhalo</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Pricestovať: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Zmenili ste mapu sveta. Nemusíte to skrývať! Povedzte o tom svojim priateľom a začnite ju spolu upravovať.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Zdieľaj s priateľmi</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Teraz zatvorené</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Otvoria zajtra o %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Otvoria v %1 o %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Otvárajú o %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Zatvárajú o %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Pridať otváracie hodiny</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Heslo (minimálne 8 znakov)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Nesprávne používateľské meno alebo heslo.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM účet</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Posledné nahrávanie</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Ďakujeme Vám</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Názov miesta</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefón</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Upozorňujeme vás, že</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Chyba pri sťahovaní</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Vybrať kategóriu</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Obľúbené</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Všetky kategórie</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Zmeniť polohu</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Ak chcete pokračovať v sťahovaní, musíte uvoľniť viac miesta na ukladacom priestore. Prosím, odstráňte prebytočné dáta.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Vďaka mne sú mapy na Organic Maps lepšie</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Zmazaná poznámka</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vami navrhované zmeny sa odošlú do komunity OpenStreetMap. Popíšte detaily, ktoré sa nedajú upraviť v Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Počas vyhľadávania vašej pozície došlo k chybe. Skontrolujte, či zariadenie pracuje správne a skúste to znova.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Identifikácia lokality je zablokovaná</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Povoliť prístup ku geolokalizácii v nastaveniach prístroja</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Otvorte Nastavenia</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Kliknite na položku Lokalita</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Vyberte si počas používania aplikácie</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Vyberte položku Ochrana osobných údajov</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Vyberte položku Služby určovania polohy</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Zapnutie lokalizačných služieb</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Alebo pokračujte v používaní Organic Maps bez polohy</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervovať</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Zavolať</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Názov záložky</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Zmazať záložku</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Vaša poznámka bude odoslaná do OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…viac</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Aktualizovať</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Znemožniť nahrávanie vami nedávno precestovanej trasy?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Znemožniť</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Pozrite si</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Všeobecné nastavenia</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Ak chcete zobraziť dopravné informácie, musíte si aktualizovať aplikáciu.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Veľkosť súboru protokolu: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Presunutím sem odstránite</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Nahradiť zastávku</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Začať od</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Prihláste sa do OpenStreetMap, aby ste mohli automaticky nahrať všetky svoje úpravy mapy. Viac informácií sa dozviete</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>tade</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Skryť obrazovku</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 z %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Sťahovanie %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Použitie %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Tento názov je príliš dlhý</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Zistené nové súbory</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Premeniť</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Chyba</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Niektoré súbory neboli konvertované.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Vyskytla sa chyba</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Obľúbené</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Nezobrazovať na mape</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Počas načítavania značiek sa vyskytla chyba, skúste to znova</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Vpravo</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Spodná časť</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Poďme</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Cieľ</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Vycentrovať</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Výsledky vyhľadávania</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Potom</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Chcete znova vytvoriť trasu?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Počas jazdy nie je klávesnica k dispozícii</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Z vašej aktuálnej polohy nie je možné vytvoriť trasu</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nie je možné vytvoriť trasu do cieľa. Prosím vyberte iný bod</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Žiaden GPS signál. Presuňte sa na otvorené priestranstvo</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nie je možné vytvoriť trasu. Prosím zadajte iné body trasy</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Pre vytvorenie trasy si stiahnite do zariadenia chýbajúce mapy</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Vyskytla sa chyba. Prosím reštartujte aplikáciu</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Trasa bude obnovená z vašej aktuálnej polohy</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Trasa bude upravená na jazdu autom</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Nezobrazujú sa všetky záložky</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Prepnutie na telefón a zobrazenie všetkých záložiek</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radary</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Rýchl. upozorn.</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Prosím stiahnite si mapy v aplikácii Organic Maps vo vašom zariadení</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 výjazd</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Zoradiť Predvolené</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Zoradiť podľa typu</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Zoradiť podľa vzdialenosti</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Zoradiť podľa dátumu</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Zoradiť podľa názvu</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Jedlo</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Pamiatky</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Múzeá</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parky</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Plávanie</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Hory</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Zvieratá</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotely</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Budovy</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Peniaze</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Obchody</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkovanie</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Čerpacie stanice</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicína</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Vyhľadať v zozname</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Náboženské miesta</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Vybrať zoznam</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigácia metra v tejto oblasti ešte nie je k dispozícii</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Trasa metra sa nenašla</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Vyberte počiatočný alebo konečný bod bližšie k stanici metra</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terén</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Ak chcete aktivovať a používať topografickú vrstvu, aktualizujte alebo stiahnite mapu oblasti</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Topografická vrstva ešte nie je v tejto oblasti k dispozícii</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stúpanie</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Klesanie</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. výška</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. výška</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Obtiažnosť</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Vzdial.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Čas:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Priblížením preskúmajte izočiary</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Sťahovanie</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Stiahnuť mapu sveta</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nepodarilo sa vytvoriť priečinok a presunúť súbory do internej pamäte alebo na SD kartu</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Chyba disku</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Chyba spojenia</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Odpojte USB kábel</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Nechať obrazovku zapnutú</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Ak je táto funkcia zapnutá, obrazovka bude pri zobrazovaní mapy vždy zapnutá.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Zobraziť na uzamknutej obrazovke</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Ak je táto funkcia zapnutá, aplikácia bude aktívna aj keď je zariadenie uzamknuté</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Jazyk mapy</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Mapové údaje z OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Ďakujeme, že používate naše mapy vytvorené komunitou!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>S vašimi darmi a podporou môžeme vytvoriť tie najlepšie mapy na svete!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Páči sa vám naša aplikácia? Prosím, prispejte na podporu rozvoja! Ešte sa ti to nepáči? Dajte nám vedieť a my to napravíme!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ak poznáte vývojára softvéru, môžete ho požiadať, aby implementoval funkciu, ktorú potrebujete.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Ťuknutím na ľubovoľné miesto na mape vyberte čokoľvek. Dlhým ťuknutím skryjete a zobrazíte späť rozhranie.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Viete, že si môžete vybrať svoju aktuálnu polohu na mape?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Môžete pomôcť preložiť našu aplikáciu do vášho jazyka.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Naša aplikácia je vyvinutá niekoľkými nadšencami a komunitou.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Mapové údaje môžete jednoducho opraviť a vylepšiť.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Naším hlavným cieľom je vytvárať rýchle, na súkromie, ľahko použiteľné mapy, ktoré si zamilujete.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Na obrazovke telefónu teraz používate službu Organic Maps</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Na obrazovke auta teraz používate službu Organic Maps</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Ste pripojení k službe Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Pokračujte v telefóne</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Na obrazovku auta</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Služba Organic Maps potrebuje prístup k polohe. Keď je to bezpečné, skontrolujte oznámenie na telefóne.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Táto aplikácia potrebuje vaše povolenie</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps v službe Android Auto potrebujú na efektívnu prácu povolenie na určenie polohy</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Udelenie oprávnení</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Turistika</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webový prehliadač nie je k dispozícii</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Hlasitosť</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export všetkých záložiek a stôp</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Nastavenia systému syntézy reči</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nastavenia syntézy reči neboli nájdené, ste si istí, že ich vaše zariadenie podporuje?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-thru</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Vymazať vyhľadávanie</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Priblíženie</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zväčšenie</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Odkaz na menu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Zobraziť menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Otvoriť v inej aplikácii</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Samoobslužné služby</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Vyberte možnosť</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Vonkajšie sedenie</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Pre čo najpresnejšiu navigáciu odporúčame vypnúť režim úspory energie v nastaveniach batérie telefónu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Nahrať trasu</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Zastaviť nahrávanie trasy</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Záznam trasy</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Zastaviť bez uloženia</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Pokračovať v nahrávaní</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Uložiť do záložiek a stôp?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Trasa je prázdna - nie je čo ukladať</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nie je možné zobraziť dialógové okno výberu priečinka, pretože v zariadení nie je nainštalovaná žiadna vhodná aplikácia. Nainštalujte si aplikáciu správcu súborov a skúste to znova</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Vyberte farbu</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Upraviť trasu</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Nie je nainštalovaná žiadna aplikácia, ktorá by mohla otvoriť umiestnenie</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automaticky v navigácii</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Podľa systému</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Zdieľať trať</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Vymazať %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Úroveň obtiažnosti</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Jednoduchá</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mierna</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Náročná</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Aktualizovanie</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Aktualizujte svoje stiahnuté mapy</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Aktualizácia máp udržuje informácie o objektoch na mape aktuálne</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Aktualizovať (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manuálne aktualizovať neskôr</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Zmazať záznam trasy</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ste si istí, že chcete túto skladbu odstrániť?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Názov trasy</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Presunúť</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Trasa</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Zmena farby</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Mapa</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Chcete poslať vývojárom hlásenie o chybe?
+Spoliehame sa na našich používateľov, pretože spoločnosť Organic Maps nezhromažďuje žiadne informácie o chybách automaticky. Vopred vám ďakujeme za podporu Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Povolenie synchronizácie iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Synchronizácia s iCloudom je experimentálna funkcia, ktorá je vo vývoji. Uistite sa, že ste si vytvorili zálohu všetkých svojich záložiek a skladieb.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>Služba iCloud je vypnutá</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ak chcete túto funkciu používať, povoľte iCloud v nastaveniach zariadenia.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Povoliť</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Zálohovanie</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Zlyhanie synchronizácie iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Chyba: Nepodarilo sa synchronizovať z dôvodu chyby pripojenia</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Chyba: Nepodarilo sa synchronizovať z dôvodu prekročenia kvóty iCloudu</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Chyba: iCloud nie je k dispozícii</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nedávno odstránené zoznamy</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Vymazať</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Odstrániť všetko</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Obnoviť</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Obnoviť všetko</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Prispieť do OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Pridať miesto</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Aktualizovať mapu na prispievanie</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Musíte aktualizovať mapu %1 na najnovšiu verziu, aby ste mohli prispievať do údajov OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Moja poloha</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Moje miesta</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Interné privátne úložisko</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Interné zdieľané úložisko</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD karta</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Externé zdieľané úložisko</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>PSČ</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Bod na mape</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>stopa</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Na zobrazenie trás je potrebné aktualizovať mapy.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Výstup</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Vchod</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Mapa metra nie je dostupná</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Vy</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Fialové stiahnuté regióny</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Trasa</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Definovanie súčasnej polohy na pozadí je potrebné pre plnú funkčnosť appky. Využíva sa to v možnostiach nasledovania trasy či uloženia Vašej nedávnej cesty.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Údaj o aktuálnej polohe bude použitý v možnostiach pri sledovaní trasy a pri uložení Vašej naposledy prejdenej cesty.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Prihlásenie pomocou hesla</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Prihlásenie pomocou prehliadača</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nedávno použité</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Farba záložiek bola zmenená</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Farba trás bola zmenená</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Posuvníky</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ČERVENÁ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZELENÁ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Hexadecimálna farba sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Mriežka</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sl/omim.ts
+++ b/qt/translations/sl/omim.ts
@@ -1,0 +1,3940 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sl">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Nazaj</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Prekliči</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Izbriši</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Prenesi zemljevide</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Prenos ni uspel. Dotaknite se za ponovni poskus.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Prenašanje…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometri</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milje</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Kasneje</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Iskanje</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Išči po zemljevidu</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Trenutno imate onemogočene vse lokacijske storitve za to napravo ali aplikacijo. Omogočite jih v nastavitvah.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Omejena natančnost</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Za zagotovitev natančne navigacije v nastavitvah omogočite natančno lokacijo.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Pokaži na zemljevidu</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Prenos ni uspel</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Poskusi znova</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>O Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Brezplačno za vse, narejeno z ljubeznijo</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Brez oglasov, brez sledenja, brez zbiranja podatkov</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Ne prazni baterije, deluje brez povezave</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Hitro, minimalistično, razvito s strani skupnosti</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Odprtokodna aplikacija, ki so jo ustvarili navdušenci in prostovoljci.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Nastavitve lokacije</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Zapri</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Aplikacija zahteva strojno pospešen OpenGL. Žal vaša naprava ni podprta.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Prenesi</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Za uporabo Organic Maps odklopite kabel USB ali vstavite pomnilniško kartico</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Za uporabo aplikacije najprej sprostite nekaj prostora na kartici SD/pomnilniku USB</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Preden začnete uporabljati aplikacijo, prenesite na svojo napravo pregledni zemljevid sveta.
+Uporabil bo %1 prostora.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Pojdi na zemljevid</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Prenašanje %1. Zdaj lahko
+nadaljujete na zemljevid.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Prenesem %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Posodobim %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Premor</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Nadaljuj</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Prenos %1 ni uspel</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Dodaj nov seznam</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Ime seznama zaznamkov</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Zaznamki</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Zaznamki in sledi</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Ime</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Naslov</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Seznam</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Nastavitve</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Shrani zemljevide v</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Izberite mapo za prenos zemljevidov.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Preneseni zemljevidi</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 prostega od %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Premaknem zemljevide?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Napaka pri premikanju datotek zemljevidov</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>To lahko traja več minut.
+Prosimo, počakajte…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Merske enote</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Izberite med miljami in kilometri</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Prekliči prenos</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Pustite mnenje</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Prenesi zemljevid</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Seznami</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Kje jesti</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Živila</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Prevoz</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Bencin</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkirišče</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Nakupovanje</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Rabljeno</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Znamenitosti</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Zabava</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nočno življenje</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Družinske počitnice</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Lekarna</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Bolnišnica</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Stranišče</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Pošta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policija</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recikliranje</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Voda</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Oprema za avtodome</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Opombe</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Z vami so bili deljeni zaznamki Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Živjo!
+
+V priponki so moji zaznamki; odprite jih v Organic Maps. Če aplikacije nimate nameščene, jo lahko prenesete tukaj: https://omaps.app/get?kmz
+
+Uživajte v potovanju z Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Nalaganje zaznamkov</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Zaznamki so bili uspešno naloženi! Najdete jih na zemljevidu ali na zaslonu Upravitelja zaznamkov.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Nalaganje zaznamkov ni uspelo. Datoteka je morda poškodovana ali okvarjena.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Aplikacija ne prepozna vrste datoteke:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Odpiranje datoteke %1 ni uspelo
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Uredi</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Vaša lokacija še ni bila določena</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Žal so nastavitve shrambe zemljevidov trenutno onemogočene.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Prenos zemljevida je v teku.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Oglejte si mojo trenutno lokacijo v Organic Maps! %1 ali %2 Nimate zemljevidov brez povezave? Prenesite jih tukaj: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hej, poglej moj žebljiček v Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hej, poglej mojo trenutno lokacijo na zemljevidu Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Živjo,
+
+Zdaj sem tukaj: %1. Kliknite to povezavo %2 ali to %3, da vidite kraj na zemljevidu.
+
+Hvala.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Deli</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-pošta</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopirano v odložišče: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Končano</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Podatki OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ste prepričani, da se želite odjaviti iz svojega računa OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Sledi</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Dolžina</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Deli mojo lokacijo</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Splošne nastavitve</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informacije</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigacija</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Gumbi „+“ in „-“ na zemljevidu</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Prikaži na zemljevidu</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nočni slog pri navigaciji v temi</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nočni način</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Izklopljeno</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Vklopljeno</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Samodejno</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivni pogled</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D zgradbe</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D zgradbe so onemogočene v načinu varčevanja z energijo</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Glasovna navodila</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Izgovori imena ulic</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Ko je omogočeno, bo ime ulice ali izvoza, na katerega je treba zaviti, izgovorjeno na glas.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Jezik glasu</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Če želite prenesti glas višje kakovosti, odprite aplikacijo Nastavitve in pojdite v Dostopnost → VoiceOver → Govor → Glas.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Preizkusi glasovna navodila (TTS, pretvorba besedila v govor)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Preverite glasnost ali sistemske nastavitve pretvorbe besedila v govor, če zdaj ne slišite glasu.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Ni na voljo</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Samodejna povečava</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Razdalja</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Prikaži na zemljevidu</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Meni</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Spletna stran</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Novice</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Povratne informacije</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Oceni aplikacijo</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Pomoč</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Pogosto zastavljena vprašanja</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Doniraj</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Že donirano</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Opomni me kasneje</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Podprite Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Podprite projekt</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Avtorske pravice</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Prijavi napako</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Izboljšajte smer puščice tako, da telefon premikate v obliki osmice, da umerite kompas.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Premaknite telefon v obliki osmice, da umerite kompas in popravite smer puščice na zemljevidu.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ponovno se dolgo dotaknite zemljevida, da vidite vmesnik</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Posodobi vse</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Prekliči vse</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Preneseno</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>V čakalni vrsti</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>V bližini</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Zemljevidi</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Prenesi vse</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Prenašanje:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Za brisanje zemljevida ustavite navigacijo.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Poti je mogoče ustvariti le, če so v celoti znotraj zemljevida ene regije.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Prenesi zemljevid</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Poskusi znova</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Izbriši zemljevid</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Posodobi zemljevid</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Lokacijske storitve Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Hitro določite svojo približno lokacijo z uporabo Bluetooth, WiFi ali mobilnega omrežja</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Prenesi vse zemljevide vzdolž poti</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Za ustvarjanje poti je treba prenesti in posodobiti vse zemljevide od vaše lokacije do cilja.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Ni dovolj prostora</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Omogočite lokacijske storitve</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Shrani</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>Ustvari</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Rdeča</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Rumena</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Modra</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Zelena</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Vijolična</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Oranžna</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Rjava</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Roza</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Temno vijolična</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Svetlo modra</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cian</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Zelenomodra</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limeta</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Temno oranžna</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Siva</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Modro siva</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Informacije</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Različica Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Videz</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Svetla</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Temna</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Svetla od zore do mraka</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Drugo</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Podarite brezplačne zemljevide brez oglasov milijonom uporabnikov!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Prijavite ali popravite napačne podatke zemljevida</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Prostovoljec</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Sledite nam in nas kontaktirajte:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-poštni odjemalec ni nastavljen. Prosimo, konfigurirajte ga ali nas kontaktirajte na %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Napaka pri pošiljanju e-pošte</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Umerjanje kompasa</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Na voljo</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Najdeno</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Posodobi</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Ni uspelo</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>zaznamek</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Pri sledenju poti upoštevajte:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Stanje na cestah, prometni predpisi in prometni znaki imajo vedno prednost pred navigacijskimi namigi;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Zemljevid je lahko netočen in predlagana pot morda ni vedno najbolj optimalen način za dosego cilja;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Predlagane poti je treba razumeti le kot priporočila;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Bodite previdni pri poteh v obmejnih območjih: poti, ki jih ustvari naša aplikacija, lahko včasih prečkajo državne meje na nepooblaščenih mestih.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Prosimo, bodite pozorni in varni na cestah!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Preverite signal GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Poti ni mogoče ustvariti. Trenutnih koordinat GPS ni bilo mogoče določiti.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Preverite signal GPS. Omogočanje Wi-Fi bo izboljšalo natančnost vaše lokacije.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Omogočite lokacijske storitve</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Trenutnih koordinat GPS ni mogoče najti. Omogočite lokacijske storitve za izračun poti.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Poti ni mogoče najti</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Poti ni mogoče ustvariti.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Prilagodite svojo začetno točko ali cilj.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Prilagodite začetno točko</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Pot ni bila ustvarjena. Začetne točke ni mogoče najti.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Izberite začetno točko bližje cesti.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Prilagodite cilj</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Pot ni bila ustvarjena. Cilja ni mogoče najti.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Izberite ciljno točko, ki se nahaja bližje cesti.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Vmesne točke ni mogoče najti.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Prilagodite svojo vmesno točko.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistemska napaka</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Poti ni mogoče ustvariti zaradi napake v aplikaciji.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Poskusite znova</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Ne zdaj</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Ali želite prenesti zemljevid in ustvariti bolj optimalno pot, ki se razteza čez več kot en zemljevid?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Prenesite dodatne zemljevide, da ustvarite boljšo pot, ki prečka meje tega zemljevida.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Prenesite zahtevane datoteke</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Prenesite ali posodobite vse zemljevide vzdolž predvidene poti za izračun poti.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Za začetek iskanja in ustvarjanja poti prenesite zemljevid. Po tem ne boste več potrebovali internetne povezave.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Izberite zemljevid</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Prikaži</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Skrij</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorije</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Zgodovina</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ups, ni bilo najdenih rezultatov.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Prenesite regijo, kjer iščete, ali poskusite dodati ime bližnjega mesta/vasi.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Zgodovina iskanja</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Oglejte si svoja nedavna iskanja.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Počisti zgodovino iskanja</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedija</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Člen iz wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Vaša lokacija</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Začetek</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Pot od</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Pot do</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigacija je na voljo samo z vaše trenutne lokacije.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Ali želite načrtovati pot z vaše trenutne lokacije?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Naprej</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Od</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Do</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Dodaj urnik</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Izbriši urnik</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Ves dan (24 ur)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Odprto</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Zaprto</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Dodaj neposlovni čas</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Delovni čas</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Napredni način</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Enostaven način</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Neposlovni čas</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Primeri vrednosti</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Popravi napako</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Izberite lokacijo</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Podrobno opišite težavo, da jo bo skupnost OpenStreetMap lahko odpravila.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ali pa to storite sami na https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Pošlji</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Težava</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>To mesto ne obstaja</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Zaprto zaradi vzdrževanja</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Dvojnik mesta</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Samodejni prenos zemljevidov</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Dnevno</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Danes zaprto</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Zaprto</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Danes</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Odpira se čez %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Zapira se čez %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Zaprto</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Uredi delovni čas</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nimate računa OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrirajte se na OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Prijava</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Niste prijavljeni</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Prijavite se v OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Geslo</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Ste pozabili geslo?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Odjava</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Uredi mesto</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Dodaj jezik</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Ulica</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Hišna številka</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Podrobnosti</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Družbena omrežja</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Zgradba</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Dodaj ulico</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Vnesite ime ulice</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Izberite jezik</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Izberite ulico</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuhinja</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Izberite kuhinjo</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-pošta ali uporabniško ime</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Dodaj telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Nadstropje</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nadstropje: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Vsa vaša urejanja zemljevida bodo izbrisana skupaj z zemljevidom.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Posodobi zemljevide</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Za ustvarjanje poti morate posodobiti vse zemljevide in nato ponovno načrtovati pot.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Najdi zemljevid</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Prepričajte se, da je vaša naprava povezana z internetom.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Ni dovolj prostora</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Izbrišite nepotrebne podatke</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Napaka pri prijavi.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Preverjene spremembe</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Povlecite zemljevid, da postavite križec na lokacijo mesta ali podjetja.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Urejanje</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Dodajanje</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Ime mesta</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Kot je napisano v lokalnem jeziku</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategorija</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Podroben opis težave</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Druga težava</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Dodaj podjetje</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Tukaj ni mogoče locirati nobenega objekta</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Podatki OpenStreetMap, ki jih je ustvarila skupnost, od %1. Več o tem, kako urejati in posodabljati zemljevid, preberite na OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) je projekt skupnosti za izgradnjo brezplačnega in odprtega zemljevida. Je glavni vir podatkov o zemljevidih v Organic Maps in deluje podobno kot Wikipedija. Lahko dodajate ali urejate mesta, ki postanejo na voljo milijonom uporabnikov po vsem svetu.
+Pridružite se skupnosti in pomagajte ustvariti boljši zemljevid za vse!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Ustvarite račun OpenStreetMap ali se prijavite, da objavite svoja urejanja zemljevida svetu.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 od %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Prenesem prek mobilne omrežne povezave?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>To je lahko pri nekaterih paketih ali gostovanju precej drago.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Vnesite veljavno hišno številko</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Število nadstropij (največ %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Število nadstropij ne sme presegati %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Poštna številka</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Vnesite veljavno poštno številko</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Opomba za prostovoljce OpenStreetMap (neobvezno)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Opišite napake na zemljevidu ali stvari, ki jih ni mogoče urejati z Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Vaša urejanja se naložijo v javno bazo podatkov &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Prosimo, ne dodajajte osebnih ali avtorsko zaščitenih podatkov.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Več o OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Vaša zgodovina urejanja</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vaše opombe k podatkom zemljevida</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Upravljavec</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Upravljavec: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Ne najdete primerne kategorije?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps omogoča dodajanje samo preprostih točkovnih kategorij, kar pomeni, da ni mest, cest, jezer, obrisov zgradb itd. Takšne kategorije dodajte neposredno na &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Preverite naš &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;vodnik&lt;/a&gt; za podrobna navodila po korakih.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Niste prenesli nobenega zemljevida</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Prenesite zemljevide za iskanje in navigacijo brez povezave.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Trenutna lokacija ni znana.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Več</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Uredi zaznamek</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Osebne opombe (besedilo ali html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Zavrnem vse lokalne spremembe?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Zavrzi</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Izbrišem dodano mesto?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Izbriši</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Mesto ne obstaja</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Navedite razlog za brisanje mesta</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Vnesite veljavno telefonsko številko</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Vnesite veljaven spletni naslov</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Vnesite veljaven e-poštni naslov</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Vnesite veljaven spletni naslov, račun ali ime strani na Facebooku</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Vnesite veljavno uporabniško ime ali spletni naslov na Instagramu</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Vnesite veljavno uporabniško ime ali spletni naslov na Twitterju</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Vnesite veljavno uporabniško ime ali spletni naslov na VK</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Vnesite veljaven ID ali spletni naslov LINE</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Dodaj mesto v OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ali pa pustite opombo skupnosti OpenStreetMap, da bo nekdo drug lahko dodal ali popravil mesto tukaj.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Opomba bo poslana v OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Ali želite to poslati vsem uporabnikom?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Prepričajte se, da niste vnesli nobenih zasebnih ali osebnih podatkov.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Uredniki OpenStreetMap bodo preverili spremembe in vas kontaktirali, če bodo imeli kakršna koli vprašanja.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Ustavi</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Snemanje sledi</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Sprejmi</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Zavrni</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Uporabim mobilni internet za prikaz podrobnih informacij?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Vedno uporabi</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Samo danes</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Danes ne uporabi</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilni internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobilni internet je potreben za obvestila o posodobitvah zemljevidov in nalaganje urejanj.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Nikoli ne uporabi</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Vedno vprašaj</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Za prikaz podatkov o prometu je treba posodobiti zemljevide.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Povečaj velikost oznak na zemljevidu</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Posodobite Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Podatki o prometu niso na voljo</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Omogoči beleženje</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Splošne povratne informacije</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Za glasovna navodila uporabljamo sistemski TTS. Številne naprave Android uporabljajo Google TTS, ki ga lahko prenesete ali posodobite iz Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Za nekatere jezike boste morali namestiti sintetizator govora ali dodaten jezikovni paket iz trgovine z aplikacijami (Google Play, Galaxy Store, App Gallery, FDroid).
+Odprite nastavitve naprave → Jezik in vnos → Govor → Izhod besedila v govor.
+Tu lahko upravljate nastavitve za sintezo govora (na primer prenesete jezikovni paket za uporabo brez povezave) in izberete drug mehanizem za pretvorbo besedila v govor.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Za več informacij preverite ta vodnik.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliteriraj v latinico</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Več o tem</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Uporabite iskanje ali se dotaknite zemljevida, da dodate začetno točko poti</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Uporabite iskanje ali se dotaknite zemljevida, da dodate ciljno točko</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Upravljaj pot</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Načrtuj</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Odstrani postanek</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Dodaj postanek</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Shranjeno</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Prijavite se v OpenStreetMap, da samodejno naložite vsa svoja urejanja zemljevida. Več o tem &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;tukaj&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Težava z dostopom do shrambe</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Zunanja shramba ni dostopna. Kartica SD je morda bila odstranjena, poškodovana ali pa je datotečni sistem samo za branje. Preverite svojo kartico SD ali nas kontaktirajte na support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emuliraj slabo shrambo</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Vnesite pravilno ime</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Seznami</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Skrij vse</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Prikaži vse</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n zaznamek</numerusform>
+<numerusform>%n zaznamka</numerusform>
+<numerusform>%n zaznamki</numerusform>
+<numerusform>%n zaznamkov</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Ustvari nov seznam</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Uvozi zaznamke in sledi</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Deljenje ni mogoče zaradi napake v aplikaciji</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Napaka pri deljenju</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Praznega seznama ni mogoče deliti</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Ime ne sme biti prazno</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Vnesite ime seznama</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Nov seznam</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>To ime je že zasedeno</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Izberite drugo ime</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Prosimo, počakajte…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonska številka</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profil OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Najdena je bila %n datoteka. Po pretvorbi si jo lahko ogledate.</numerusform>
+<numerusform>Najdeni sta bili %n datoteki. Po pretvorbi si ju lahko ogledate.</numerusform>
+<numerusform>Najdene so bile %n datoteke. Po pretvorbi si jih lahko ogledate.</numerusform>
+<numerusform>Najdenih je bilo %n datotek. Po pretvorbi si jih lahko ogledate.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Obnovi</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n sled</numerusform>
+<numerusform>%n sledi</numerusform>
+<numerusform>%n sledi</numerusform>
+<numerusform>%n sledi</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Zasebnost</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politika zasebnosti</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Pogoji uporabe</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Promet</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Pohodništvo</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Kolesarjenje</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Podzemna železnica</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Slogi in plasti zemljevida</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Ta seznam je prazen</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Če želite dodati zaznamek, se dotaknite mesta na zemljevidu in nato ikone zvezdice</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Spremeni barvo vseh zaznamkov</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Spremeni barvo vseh sledi</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…več</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Izvozi KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Izvozi GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Izvozi GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Izbriši seznam</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Radarji</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Opis mesta</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Prenosnik zemljevidov</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Opozori ob prekoračitvi hitrosti</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Vedno opozori</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Nikoli ne opozori</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Način varčevanja z energijo</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Poskusite zmanjšati porabo energije na račun nekaterih funkcionalnosti.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Nikoli</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Ko je baterija skoraj prazna</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Vedno</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Imena zaznamkov na zemljevidu</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Če je zaznamkov preveč, lahko prikaz njihovih imen na zemljevidu upočasni aplikacijo.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Prikaži na desni</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Prikaži na dnu</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>To možnost omogočite začasno, da posnamete in nam ročno pošljete podrobne diagnostične dnevnike o vaši težavi z uporabo &quot;Prijavi napako&quot; v pogovornem oknu Pomoč. Dnevniki lahko vključujejo podatke o lokaciji.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Možnosti načrtovanja poti</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Izogibaj se cestninam</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Izogibaj se makadamu</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Izogibaj se trajektom</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Izogibaj se avtocestam</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Poti ni mogoče izračunati</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Poti ni bilo mogoče najti. To je lahko posledica vaših možnosti načrtovanja poti ali nepopolnih podatkov OpenStreetMap. Spremenite možnosti načrtovanja poti in poskusite znova.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Določite ceste, ki se jim želite izogniti</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Možnosti načrtovanja poti omogočene</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Cestninska cesta</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Makadamska cesta</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Prečkanje s trajektom</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Da</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ne</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapaciteta: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Omrežje: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Prispeli ste!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>V redu</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Razvrsti…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Razvrsti zaznamke</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Privzeto</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Po vrsti</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Po razdalji</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Po datumu</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Po imenu</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Pred enim tednom</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Pred enim mesecem</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Pred več kot mesecem dni</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Pred več kot letom dni</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>V bližini</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Drugo</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Načrtovanje poti ni uspelo</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Prihod ob %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Prenesite in posodobite vse zemljevide vzdolž predvidene poti za izračun poti.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Spremenili ste zemljevid sveta! Ne obdržite ga zase; povejte prijateljem in ga urejajte skupaj.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Deli s prijatelji</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Trenutno zaprto</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Odpira se jutri ob %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Odpira se %1 ob %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Odpira se ob %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Zapira se ob %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Dodaj delovni čas</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Geslo (najmanj 8 znakov)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Neveljavno uporabniško ime ali geslo.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Račun OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Zadnje nalaganje</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Hvala</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Ime mesta</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Prosimo, upoštevajte</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Napaka pri prenosu</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Izberite kategorijo</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Priljubljeno</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Vse kategorije</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Dodajte nova mesta na zemljevid in urejajte obstoječa neposredno iz aplikacije.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Spremeni lokacijo</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Za prenos potrebujete več prostora. Izbrišite nepotrebne podatke.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Izboljšal sem zemljevide Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Podroben komentar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Vaše predlagane spremembe zemljevida bodo poslane skupnosti OpenStreetMap. Prosimo, opišite vse dodatne podrobnosti, ki jih ni mogoče urejati v Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Pri določanju vaše lokacije je prišlo do napake. Preverite, ali vaša naprava deluje pravilno, in poskusite znova pozneje.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Lokacijske storitve so onemogočene</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Omogočite dostop do geolokacije v nastavitvah naprave</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Odprite Nastavitve</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Dotaknite se Lokacija</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Izberite Med uporabo aplikacije</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Izberite Zasebnost</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Izberite Lokacijske storitve</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Vklopite Lokacijske storitve</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ali pa nadaljujte z uporabo Organic Maps brez lokacije</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezerviraj</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Kliči</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Ime zaznamka</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Izbriši zaznamek</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Vaša opomba bo poslana v OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…več</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Posodobi</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Onemogočim snemanje vaše nedavno prevožene poti?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Onemogoči</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Poglej</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uporablja vašo lokacijo v ozadju za snemanje vaše nedavno prevožene poti.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Splošne nastavitve</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Za prikaz podatkov o prometu je treba posodobiti aplikacijo.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Velikost datoteke dnevnika: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Povlecite sem za odstranitev</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Zamenjaj postanek</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Začni od</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Prijavite se v OpenStreetMap, da samodejno naložite vsa svoja urejanja zemljevida. Več o tem</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>tukaj</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Skrij zaslon</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 od %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Prenašanje %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Uporaba %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>To ime je predolgo</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Zaznane nove datoteke</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Pretvori</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Napaka</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Nekatere datoteke niso bile pretvorjene.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Prišlo je do napake</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Priljubljeno</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Skrij z zemljevida</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Pri nalaganju oznak je prišlo do napake, poskusite znova</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Desno</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Dno</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Gremo</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Cilj</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Ponovno centriraj</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Rezultati iskanja</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Nato</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Ali želite ponovno zgraditi pot?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tipkovnica med vožnjo ni na voljo</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Poti z vaše trenutne lokacije ni mogoče zgraditi</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Poti do vašega cilja ni mogoče najti. Izberite drugo končno točko</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ni signala GPS. Premaknite se na odprto območje</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Poti ni mogoče zgraditi. Določite druge točke poti</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Za ustvarjanje poti prenesite manjkajoče zemljevide na svojo napravo</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Prišlo je do napake. Znova zaženite aplikacijo</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Pot bo ponovno zgrajena z vaše trenutne lokacije</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Pot bo pretvorjena v avtomobilsko</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Niso prikazani vsi zaznamki</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Preklopite na telefon, da vidite vse zaznamke</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Radarji</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Opozorila o hitrosti</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Prenesite zemljevide v aplikaciji na vaši mobilni napravi</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 izvoz</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Razvrsti privzeto</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Razvrsti po vrsti</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Razvrsti po razdalji</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Razvrsti po datumu</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Razvrsti po imenu</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Hrana</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Znamenitosti</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzeji</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parki</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Plavanje</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Gore</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Živali</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteli</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Zgradbe</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Denar</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Trgovine</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkirišče</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Bencinske črpalke</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicina</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Išči na seznamu</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Verski kraji</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Izberite seznam</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Navigacija s podzemno železnico v tej regiji še ni na voljo</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Ni najdene poti s podzemno železnico</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Izberite začetno ali končno točko bližje postaji podzemne železnice</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Plastnice</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Aktiviranje plastnic zahteva prenos podatkov zemljevida za to območje</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Plastnice na tem območju še niso na voljo</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Vzpon</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Spust</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. višina</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. višina</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Težavnost</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Razd.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Čas:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Povečajte za raziskovanje plastnic</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Prenašanje</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Prenesite pregledni zemljevid sveta</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Mape ni mogoče ustvariti in datotek premakniti na notranji pomnilnik naprave ali kartico SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Napaka diska</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Napaka povezave</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Odklopite kabel USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Ohrani zaslon vklopljen</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Ko je omogočeno, bo zaslon vedno vklopljen pri prikazu zemljevida.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Prikaži na zaklenjenem zaslonu</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Ko je omogočeno, bo aplikacija delovala na zaklenjenem zaslonu, tudi ko je naprava zaklenjena.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Jezik zemljevida</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Podatki zemljevida iz OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Hvala, ker uporabljate naše zemljevide, ki jih je ustvarila skupnost!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Z vašimi donacijami in podporo lahko ustvarimo najboljše zemljevide na svetu!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Vam je všeč naša aplikacija? Prosimo, donirajte za podporo razvoju! Vam še ni všeč? Sporočite nam, zakaj, in popravili bomo!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Če poznate razvijalca programske opreme, ga lahko prosite, da implementira funkcijo, ki jo potrebujete.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Dotaknite se kjerkoli na zemljevidu, da izberete karkoli. Dolg dotik se uporablja za skrivanje in prikaz vmesnika.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Ali ste vedeli, da je mogoče izbrati vašo trenutno lokacijo na zemljevidu?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Lahko pomagate prevesti našo aplikacijo v vaš jezik.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Našo aplikacijo razvija nekaj navdušencev in skupnost.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Podatke zemljevida lahko enostavno popravite in izboljšate.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Naš glavni cilj je zgraditi hitre, zasebnosti prijazne in enostavne zemljevide, ki jih boste vzljubili.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Zdaj uporabljate Organic Maps na zaslonu telefona</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Zdaj uporabljate Organic Maps na zaslonu avtomobila</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Povezani ste z Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Nadaljuj na telefonu</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Na zaslon avtomobila</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps potrebuje dostop do lokacije. Ko bo varno, preverite obvestilo na telefonu.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ta aplikacija potrebuje vaše dovoljenje</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps v Android Auto potrebuje dovoljenja za lokacijo za učinkovito delovanje</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Podeli dovoljenja</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Na prostem</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Spletni brskalnik ni na voljo</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Glasnost</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Izvozi vse zaznamke in sledi</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Sistemske nastavitve sinteze govora</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Nastavitve sinteze govora niso bile najdene, ste prepričani, da vaša naprava to podpira?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Vožnja skozi</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Počisti iskanje</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Povečaj</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Pomanjšaj</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Povezava do menija</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Ogled menija</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Odpri v drugi aplikaciji</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Samopostrežba</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Izberite možnost</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sedenje na prostem</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Za najbolj natančno navigacijo priporočamo, da v nastavitvah baterije telefona onemogočite način varčevanja z energijo.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Snemaj sled</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Ustavi snemanje sledi</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Snemanje sledi</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Ustavi brez shranjevanja</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Nadaljuj snemanje</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Shranim v Zaznamke in sledi?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Sled je prazna - ničesar za shraniti</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Pogovornega okna za izbiro mape ni mogoče prikazati, ker na vaši napravi ni nameščene primerne aplikacije. Namestite aplikacijo za upravljanje datotek in poskusite znova.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Izberite barvo</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Uredi sled</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ni nameščene aplikacije, ki bi lahko odprla lokacijo</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Samodejno v navigaciji</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Sledi sistemu</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Deli sled</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Izbrišem %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Težavnost</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Lahka</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Zmerna</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Težka</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Posodabljanje</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Posodobi prenesene zemljevide</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Posodabljanje zemljevidov ohranja informacije o objektih ažurne</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Posodobi (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Ročno posodobi kasneje</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Izbriši sled</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ste prepričani, da želite izbrisati to sled?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Ime sledi</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Premakni</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Sled</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Spremeni barvo</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Zemljevid</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Ali želite poslati poročilo o napaki razvijalcem?
+Zanašamo se na naše uporabnike, saj Organic Maps ne zbira samodejno nobenih informacij o napakah. Hvala vnaprej za podporo Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Omogoči sinhronizacijo z iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Sinhronizacija z iCloud je eksperimentalna funkcija v razvoju. Prepričajte se, da ste naredili varnostno kopijo vseh svojih zaznamkov in sledi.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud je onemogočen</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Za uporabo te funkcije omogočite iCloud v nastavitvah naprave.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Omogoči</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Varnostna kopija</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Napaka pri sinhronizaciji z iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Napaka: Sinhronizacija ni uspela zaradi napake v povezavi</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Napaka: Sinhronizacija ni uspela zaradi presežene kvote iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Napaka: iCloud ni na voljo</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nedavno izbrisani seznami</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Počisti</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Izbriši vse</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Obnovi</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Obnovi vse</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Prispevajte k OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Dodaj mesto</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Posodobite zemljevid za prispevanje</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Preden lahko prispevate k podatkom OpenStreetMap, morate posodobiti zemljevid %1 na najnovejšo različico</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Moj položaj</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Moja mesta</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Notranja zasebna shramba</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Notranji pomnilnik v skupni rabi</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Kartica SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Zunanji pomnilnik v skupni rabi</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Poštna številka</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Točka na zemljevidu</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Za prikaz poti je treba posodobiti zemljevide.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Izhod</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Vhod</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Zemljevid podzemne železnice ni na voljo</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Vi</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Vijolična prenesena območja</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Pot</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Zaznavanje lokacije v ozadju je potrebno za polno funkcionalnost aplikacije. Uporablja se za navigacijo in shranjevanje vaše nedavne sledi.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Določanje vaše lokacije je potrebno za navigacijo in shranjevanje vaše nedavne sledi.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Prijava z geslom</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Prijava z uporabo brskalnika</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Nedavno uporabljeno</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Barva zaznamkov je spremenjena</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Barva sledi je spremenjena</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spekter</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Drsniki</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RDEČA</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ZELENA</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLUE</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex Color #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Mreža</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sq/omim.ts
+++ b/qt/translations/sq/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sq">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Prapa</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Anulo</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Fshi</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Shkarko Harta</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Shkarkimi dështoi. Prekni për të provuar përsëri.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Duke shkarkuar…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometra</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Milje</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Më vonë</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Kërko</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Kërko në Hartë</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Aktualisht i keni të çaktivizuara të gjitha Shërbimet e Vendndodhjes për këtë pajisje ose aplikacion. Ju lutemi aktivizoni ato në Cilësimet.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Saktësi e Kufizuar</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Për të siguruar lundrim të saktë, aktivizoni Vendndodhjen e Saktë në cilësimet.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Shfaq në hartë</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Shkarkimi dështoi</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Provo Përsëri</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Rreth Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Falas për të gjithë, bërë me dashuri</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Pa reklama, pa gjurmim, pa mbledhje të dhënash</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Nuk harxhon baterinë, punon jashtë linje</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• I shpejtë, minimalist, zhvilluar nga komuniteti</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Aplikacion me burim të hapur i krijuar nga entuziastë dhe vullnetarë.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Cilësimet e Vendndodhjes</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Mbyll</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Aplikacioni kërkon OpenGL të përshpejtuar nga hardueri. Fatkeqësisht, pajisja juaj nuk mbështetet.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Shkarko</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Ju lutemi shkëputni kabllon USB ose futni kartën e memories për të përdorur Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Ju lutemi lironi pak hapësirë në kartën SD/ruajtjen USB fillimisht për të përdorur aplikacionin</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Para se të filloni të përdorni aplikacionin, ju lutemi shkarkoni hartën e përgjithshme të botës në pajisjen tuaj.
+Ajo do të përdorë %1 të hapësirës.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Shko te Harta</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Duke shkarkuar %1. Tani mund të
+vazhdoni te harta.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Shkarko %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Përditëso %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pauzë</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Vazhdo</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 shkarkimi dështoi</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Shto një Listë të Re</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Emri i Listës së Faqeshënuesve</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Faqeshënuesit</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Faqeshënuesit dhe Gjurmët</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Emri</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adresa</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Cilësimet</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Ruaj hartat në</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Zgjidhni dosjen ku të shkarkohen hartat.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Hartat e shkarkuara</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 të lira nga %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Leviz hartat?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Gabim gjatë lëvizjes së skedarëve të hartës</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Kjo mund të zgjasë disa minuta.
+Ju lutemi prisni…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Njësitë matëse</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Zgjidhni midis miljeve dhe kilometrave</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Anulo Shkarkimin</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Lini një vlerësim</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Po</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Shkarko Hartën</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Listat e Faqeshënuesve</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Ku të hani</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Ushqimore</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transporti</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Karburant</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkim</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Pazari</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Të përdorura</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Vende turistike</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Argëtim</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Jeta e natës</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Pushime familjare</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Farmacia</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Spitali</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Tualet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Policia</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Riciklimi</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Ujë</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Objekte për RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Shënime</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Faqeshënuesit e Organic Maps u ndanë me ju</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Përshëndetje!
+
+Bashkëngjitur janë faqeshënuesit e mi; ju lutemi hapini ato në Organic Maps. Nëse nuk e keni të instaluar, mund ta shkarkoni këtu: https://omaps.app/get?kmz
+
+Shijoni udhëtimin me Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Duke ngarkuar Faqeshënuesit</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Faqeshënuesit u ngarkuan me sukses! Mund t&#x27;i gjeni në hartë ose në ekranin e Menaxherit të Faqeshënuesve.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Dështoi ngarkimi i faqeshënuesve. Skedari mund të jetë i dëmtuar ose me defekt.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Lloji i skedarit nuk njihet nga aplikacioni:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Dështoi hapja e skedarit %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Ndrysho</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Vendndodhja juaj nuk është përcaktuar ende</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Na vjen keq, cilësimet e Ruajtjes së Hartës janë aktualisht të çaktivizuara.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Shkarkimi i hartës është në progres tani.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Shikoni vendndodhjen time aktuale në Organic Maps! %1 ose %2 Nuk keni harta offline? Shkarkoni këtu: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hej, shiko vendosjen time në Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hej, shiko vendndodhjen time aktuale në hartën e Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Përshëndetje,
+
+Unë jam këtu tani: %1. Klikoni këtë lidhje %2 ose këtë tjetrën %3 për të parë vendin në hartë.
+
+Faleminderit.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Ndaj</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>U kopjua në kujtesën e fragmenteve: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>U krye</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Të dhënat OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Jeni i sigurt që dëshironi të dilni nga llogaria juaj OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Gjurmët</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Gjatësia</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Ndaj Vendndodhjen Time</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Cilësimet e përgjithshme</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Informacion</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Lundrimi</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Butonat “+” dhe “-” në hartë</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Shfaq në hartë</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Stili nate kur navigoni në errësirë</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modaliteti i Natës</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Jo</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Po</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Automatike</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Pamja perspektive</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Ndërtesat 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Ndërtesat 3D janë të çaktivizuara në modalitetin e kursimit të energjisë</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Udhëzimet Zanore</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Shpall Emrat e Rrugëve</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Kur aktivizohet, emri i rrugës ose daljes për t&#x27;u kthyer do të thuhet me zë të lartë.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Gjuha e Zërit</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Për të shkarkuar një zë me cilësi më të lartë, hapni aplikacionin Cilësimet dhe shkoni te Aksesueshmëria → VoiceOver → Të folurit → Zëri.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testoni Udhëzimet me Zë (TTS, Tekst-në-Fjalë)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kontrolloni volumin ose cilësimet e sistemit Tekst-në-Fjalë nëse nuk e dëgjoni zërin tani.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Nuk Disponohet</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Zmadhim automatik</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distanca</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Shiko në hartë</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menuja</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Faqja e internetit</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Lajme</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Reagime</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Vlerësoni aplikacionin</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Ndihmë</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Pyetjet e Bëra Shpesh</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Dhuroni</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Tashmë keni dhuruar</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Kujto më vonë</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Mbështet Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Mbështet projektin</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>E drejta e autorit</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Raporto një problem</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Përmirësoni drejtimin e shigjetës duke lëvizur telefonin në formë teti për të kalibruar busullën.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Lëvizni telefonin në formë teti për të kalibruar busullën dhe për të rregulluar drejtimin e shigjetës në hartë.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Prekni gjatë në hartë përsëri për të parë ndërfaqen</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Përditëso të Gjitha</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Anulo të Gjitha</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Shkarkuar</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Në radhë</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Pranë meje</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Hartat</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Shkarko të Gjitha</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Duke shkarkuar:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Për të fshirë hartën, ju lutemi ndaloni lundrimin.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Rrugët mund të krijohen vetëm nëse përfshihen plotësisht brenda hartës së një rajoni të vetëm.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Shkarko hartën</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Riprovo</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Fshi Hartën</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Përditëso Hartën</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Shërbimet e Vendndodhjes Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Përcaktoni shpejt vendndodhjen tuaj të përafërt duke përdorur Bluetooth, WiFi, ose rrjetin celular</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Shkarkoni të gjitha hartat përgjatë rrugës suaj</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Për të krijuar një rrugë, duhet të shkarkojmë dhe përditësojmë të gjitha hartat nga vendndodhja juaj deri në destinacion.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Nuk ka hapësirë të mjaftueshme</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Ju lutemi aktivizoni Shërbimet e Vendndodhjes</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Ruaj</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>krijo</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>E kuqe</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>E verdhë</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>E gjelbër</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Vjollcë</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Portokalli</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Kafe</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rozë</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Vjollcë e errët</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Blu e hapur</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limoni</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Portokalli e thellë</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gri</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Gri Blu</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Versioni Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Pamja</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Dritë</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Errësirë</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>E çelët nga agimi deri në perëndim</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Tjetër</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Dhuroni harta falas pa reklama për miliona përdorues!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Raporto ose rregullo të dhënat e gabuara të hartës</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Vullnetar</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Na ndiqni dhe na kontaktoni:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Klienti i emailit nuk është konfiguruar. Ju lutemi konfigurojeni ose na kontaktoni në %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Gabim gjatë dërgimit të emailit</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibrimi i busullës</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Në dispozicion</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>U gjet</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Përditëso</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Dështoi</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>faqeshënues</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Kur ndiqni rrugën, ju lutemi mbani parasysh:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Kushtet e rrugës, ligjet e trafikut dhe shenjat rrugore kanë gjithmonë përparësi ndaj udhëzimeve të navigimit;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Harta mund të jetë e pasaktë dhe rruga e sugjeruar mund të mos jetë gjithmonë mënyra më optimale për të arritur destinacionin;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Rrugët e sugjeruara duhet të kuptohen vetëm si rekomandime;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Tregoni kujdes me rrugët në zonat kufitare: rrugët e krijuara nga aplikacioni ynë ndonjëherë mund të kalojnë kufijtë shtetërorë në vende të paautorizuara.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Ju lutemi qëndroni vigjilentë dhe të sigurt në rrugë!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Kontrollo sinjalin GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Nuk mund të krijohet rruga. Koordinatat aktuale GPS nuk mund të identifikoheshin.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Ju lutemi kontrolloni sinjalin tuaj GPS. Aktivizimi i Wi-Fi do të përmirësojë saktësinë e vendndodhjes suaj.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktivizo shërbimet e vendndodhjes</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Nuk mund të gjenden koordinatat aktuale GPS. Aktivizoni shërbimet e vendndodhjes për të llogaritur rrugën.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Nuk mund të gjendet rruga</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Nuk mund të krijohet rruga.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Ju lutemi rregulloni pikën e nisjes ose destinacionin.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Rregullo pikën e nisjes</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Rruga nuk u krijua. Nuk mund të gjendet pika e nisjes.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Ju lutemi zgjidhni një pikë nisjeje më afër një rruge.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Rregullo destinacionin</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Rruga nuk u krijua. Nuk mund të gjendet destinacioni.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Ju lutemi zgjidhni një pikë destinacioni të vendosur më afër një rruge.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Nuk mund të gjendet pika e ndërmjetme.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Ju lutemi rregulloni pikën tuaj të ndërmjetme.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Gabim sistemi</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Nuk mund të krijohet rruga për shkak të një gabimi në aplikacion.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Ju lutemi provoni përsëri</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Jo Tani</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>A dëshironi të shkarkoni hartën dhe të krijoni një rrugë më optimale që përfshin më shumë se një hartë?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Shkarkoni harta shtesë për të krijuar një rrugë më të mirë që kalon kufijtë e kësaj harte.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Shkarko skedarët e kërkuar</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Shkarkoni ose përditësoni të gjitha hartat përgjatë rrugës së planifikuar për të llogaritur një rrugë.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Për të filluar kërkimin dhe krijimin e rrugëve, ju lutemi shkarkoni hartën. Pas kësaj nuk do të keni më nevojë për lidhje interneti.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Zgjidh Hartën</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Shfaq</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Fshih</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategoritë</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historiku</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ups, nuk u gjetën rezultate.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Shkarkoni rajonin ku po kërkoni ose provoni të shtoni emrin e një qyteti/fshati të afërt.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historiku i Kërkimit</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Shikoni kërkimet tuaja të fundit.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Pastro Historikun e Kërkimit</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikull nga wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Vendndodhja Juaj</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Fillo</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Rruga nga</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rruga për</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Lundrimi është i disponueshëm vetëm nga vendndodhja juaj aktuale.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>A dëshironi të planifikoni një rrugë nga vendndodhja juaj aktuale?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Tjetra</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Nga</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Për</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Shto Orar</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Fshi Orarin</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Gjithë Ditën (24 orë)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Hapur</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Mbyllur</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Shto Orarin Jo-Punues</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Orari i Punës</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Modaliteti i Avancuar</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modaliteti i Thjeshtë</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Orari Jo-Punues</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Vlerat Shembull</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Korrigjo gabimin</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Zgjidh Vendi</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Ju lutemi përshkruani problemin në detaje në mënyrë që komuniteti OpenStreetMap ta rregullojë atë.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Ose bëjeni vetë në https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Dërgo</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Çështje</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Ky vend nuk ekziston</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Mbyllur për mirëmbajtje</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Vend i dyfishtë</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Shkarko automatikisht hartat</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Çdo ditë</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Mbyllur sot</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Mbyllur</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Sot</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Hapet në %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Mbyllet në %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Mbyllur</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Ndrysho orarin e punës</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Nuk keni një llogari OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Regjistrohuni në OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Hyrja</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Nuk jeni i regjistruar</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Hyni në OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Fjalëkalimi</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Keni harruar fjalëkalimin?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Dilni</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Ndrysho Vendin</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Shto një gjuhë</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Rruga</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Numri i ndërtesës</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detajet</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Media Sociale</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Ndërtesa</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Shto një rrugë</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Ju lutemi vendosni një emër rruge</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Zgjidhni një gjuhë</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Zgjidhni një rrugë</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Kuzhina</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Zgjidh kuzhinën</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email ose emri i përdoruesit</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Shto Telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Kati</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Niveli: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Të gjitha ndryshimet e hartës suaj do të fshihen së bashku me hartën.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Përditëso Hartat</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Për të krijuar një rrugë, duhet të përditësoni të gjitha hartat dhe më pas të planifikoni rrugën përsëri.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Gjej hartën</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Ju lutemi sigurohuni që pajisja juaj është e lidhur me internetin.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Nuk ka hapësirë të mjaftueshme</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Ju lutemi fshini të dhënat e panevojshme</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Gabim në hyrje.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Ndryshime të Verifikuara</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Tërhiqni hartën për të vendosur kryqin në vendndodhjen e vendit ose biznesit.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Duke ndryshuar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Duke shtuar</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Emri i vendit</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Siç shkruhet në gjuhën vendase</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Përshkrim i detajuar i problemit</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Problem tjetër</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Shto biznes</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Asnjë objekt nuk mund të vendoset këtu</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Të dhëna të OpenStreetMap të krijuara nga komuniteti që nga %1. Mësoni më shumë për mënyrën se si të redaktoni dhe përditësoni hartën në OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) është një projekt komunitar për të ndërtuar një hartë të lirë dhe të hapur. Është burimi kryesor i të dhënave të hartës në Organic Maps dhe funksionon ngjashëm me Wikipedia. Ju mund të shtoni ose redaktoni vende dhe ato bëhen të disponueshme për miliona përdorues në të gjithë botën.
+Bashkohuni me komunitetin dhe ndihmoni për të bërë një hartë më të mirë për të gjithë!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Krijoni një llogari OpenStreetMap ose hyni për të publikuar ndryshimet tuaja të hartës për botën.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 nga %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Të shkarkohet përmes një lidhjeje rrjeti celular?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Kjo mund të jetë mjaft e shtrenjtë me disa plane ose nëse jeni në roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Vendosni një numër të vlefshëm ndërtese</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Numri i kateve (maksimumi %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Numri i kateve nuk duhet të kalojë %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Kodi Postar</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Vendosni një kod postar të vlefshëm</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Shënim për vullnetarët e OpenStreetMap (opsionale)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Përshkruani gabimet në hartë ose gjërat që nuk mund të redaktohen me Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Ndryshimet tuaja ngarkohen në bazën e të dhënave publike &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;. Ju lutemi mos shtoni informacione personale ose të mbrojtura nga e drejta e autorit.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Më shumë rreth OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Historiku juaj i redaktimit</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Shënimet tuaja të të dhënave të hartës</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatori</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatori: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Nuk mund të gjeni një kategori të përshtatshme?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps lejon shtimin e kategorive të thjeshta të pikave, që do të thotë jo qytete, rrugë, liqene, konture ndërtesash, etj. Ju lutemi shtoni kategori të tilla drejtpërdrejt në &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Kontrolloni &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;udhëzuesin tonë&lt;/a&gt; për udhëzime të detajuara hap pas hapi.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Nuk keni shkarkuar asnjë hartë</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Shkarkoni harta për të kërkuar dhe lundruar jashtë linje.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Vendndodhja aktuale është e panjohur.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>o</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Më shumë</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Ndrysho Faqeshënuesin</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Shënime personale (tekst ose html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Komento…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Të hiqen të gjitha ndryshimet vendase?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Hiq dorë</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Fshi vendin e shtuar?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Fshi</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Vendi nuk ekziston</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Ju lutemi tregoni arsyen për fshirjen e vendit</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Vendosni një numër telefoni të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Vendosni një adresë uebi të vlefshme</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Vendosni një email të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Vendosni një adresë Facebook, llogari ose emër faqeje të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Vendosni një emër përdoruesi ose adresë uebi Instagram të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Vendosni një emër përdoruesi ose adresë uebi Twitter të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Vendosni një emër përdoruesi ose adresë uebi VK të vlefshëm</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Vendosni një ID LINE ose adresë uebi të vlefshme</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Shto vend në OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ose, në mënyrë alternative, lini një shënim për komunitetin OpenStreetMap në mënyrë që dikush tjetër të mund të shtojë ose rregullojë një vend këtu.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Shënimi do të dërgohet në OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>A dëshironi t&#x27;ua dërgoni të gjithë përdoruesve?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Sigurohuni që nuk keni futur të dhëna private ose personale.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Redaktorët e OpenStreetMap do të kontrollojnë ndryshimet dhe do t&#x27;ju kontaktojnë nëse kanë ndonjë pyetje.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Ndal</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Duke regjistruar gjurmën</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Prano</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Refuzo</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Të përdoret interneti celular për të shfaqur informacione të detajuara?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Përdor Gjithmonë</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Vetëm Sot</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Mos Përdor Sot</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet Celular</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Interneti celular kërkohet për njoftimet e përditësimit të hartës dhe ngarkimin e ndryshimeve.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Mos Përdor Kurrë</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Pyet Gjithmonë</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Për të shfaqur të dhënat e trafikut, hartat duhet të jenë të përditësuara.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Rrit madhësinë për etiketat e hartës</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Ju lutemi përditësoni Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Të dhënat e trafikut nuk janë të disponueshme</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Aktivizo regjistrimin</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Reagime të Përgjithshme</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Ne përdorim sistemin TTS për udhëzime zanore. Shumë pajisje Android përdorin Google TTS, mund ta shkarkoni ose përditësoni nga Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Për disa gjuhë, do t&#x27;ju duhet të instaloni një sintetizues të të folurit ose një paketë gjuhësore shtesë nga dyqani i aplikacioneve (Google Play, Galaxy Store, App Gallery, FDroid).
+Hapni cilësimet e pajisjes suaj → Gjuha dhe hyrja → Të folurit → Dalja tekst-në-të-folur.
+Këtu mund të menaxhoni cilësimet për sintezën e të folurit (për shembull, shkarkoni paketën gjuhësore për përdorim jashtë linje) dhe zgjidhni një motor tjetër tekst-në-të-folur.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Për më shumë informacion, ju lutemi kontrolloni këtë udhëzues.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translitero në alfabetin latin</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Mëso më shumë</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Përdorni kërkimin, zgjidhni një faqeshënues ose prekni në hartë për të shtuar një pikë nisjeje të rrugës</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Përdorni kërkimin, zgjidhni një faqeshënues ose prekni në hartë për të shtuar një pikë destinacioni</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Menaxho Rrugën</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planifiko</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Hiq Ndalesën</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Shto Ndalesë</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Ruajtur</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Ju lutemi hyni në OpenStreetMap për të ngarkuar automatikisht të gjitha ndryshimet tuaja të hartës. Mësoni më shumë &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;këtu&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Problem me qasjen në ruajtje</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ruajtja e jashtme nuk është e qasshme. Karta SD mund të jetë hequr, dëmtuar ose sistemi i skedarëve është vetëm për lexim. Ju lutemi verifikoni kartën tuaj SD ose na kontaktoni në support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Simulo ruajtje të keqe</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Ju lutemi vendosni një emër të saktë</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listat</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Fshih të gjitha</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Shfaq të gjitha</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Krijo një listë të re</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importo Faqeshënues dhe Gjurmë</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Nuk mund të ndahet për shkak të një gabimi në aplikacion</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Gabim në ndarje</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Nuk mund të ndahet një listë boshe</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Emri nuk mund të jetë bosh</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Ju lutemi vendosni emrin e listës</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Listë e re</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Ky emër është tashmë i zënë</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Ju lutemi zgjidhni një emër tjetër</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Ju lutemi prisni…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Numri i telefonit</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Profili OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restauro</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privatësia</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Politika e privatësisë</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Kushtet e përdorimit</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafiku</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Eisje në natyrë</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Çiklizëm</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Stilet e Hartave dhe Shtresat</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Kjo listë është boshe</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Për të shtuar një faqeshënues, prekni një vend në hartë dhe më pas prekni ikonën e yllit</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Ndrysho ngjyrën e të gjithë faqeshënuesve</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Ndrysho ngjyrën e të gjitha gjurmëve</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…më shumë</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Eksporto KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Eksporto GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Eksporto GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Fshi listen</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Kamerat e shpejtësisë</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Përshkrimi i Vendit</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Shkarkuesi i hartave</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Paralajmëro nëse tejkalohet shpejtësia</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Paralajmëro gjithmonë</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Mos paralajmëro kurrë</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Modaliteti i kursimit të energjisë</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Provoni të ulni përdorimin e energjisë duke sakrifikuar disa funksionalitete.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Kurrë</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Kur bateria është e ulët</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Gjithmonë</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Emrat e faqeshënuesve në hartë</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Nëse ka shumë faqeshënues, shfaqja e emrave të tyre në hartë mund të ngadalësojë aplikacionin.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Shfaq në të djathtë</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Shfaq në fund</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aktivizoni këtë opsion përkohësisht për të regjistruar dhe dërguar manualisht logje diagnostike të detajuara për problemin tuaj duke përdorur &quot;Raporto një problem&quot; në dialogun Ndihmë. Logjet mund të përfshijnë informacione vendndodhjeje.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Mundësitë e rrugëtimit</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Shmang pagesat</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Shmang rrugët e paasfaltuara</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Shmang tragetet</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Shmang autostradat</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Nuk mund të llogaritet rruga</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Rruga nuk mund të gjendej. Kjo mund të shkaktohet nga opsionet tuaja të rrugëtimit ose të dhëna të paplota të OpenStreetMap. Ju lutemi ndryshoni opsionet tuaja të rrugëtimit dhe provoni përsëri.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Përcaktoni rrugët për të shmangur</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Mundësitë e rrugëtimit u aktivizuan</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Rrugë me pagesë</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Rrugë e paasfaltuar</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Kalim me traget</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Po</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Jo</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Po</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Jo</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapaciteti: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Rrjeti: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Keni mbërritur!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Rendit…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Rendit faqeshënuesit</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Sipas parazgjedhjes</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Sipas llojit</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Sipas distancës</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Sipas datës</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Sipas emrit</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Një javë më parë</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Një muaj më parë</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Më shumë se një muaj më parë</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Më shumë se një vit më parë</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Pranë meje</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Të tjera</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Planifikimi i Rrugës Dështoi</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Mbërritja në %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Shkarkoni dhe përditësoni të gjitha hartat përgjatë rrugës së planifikuar për të llogaritur rrugën.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Ju keni ndryshuar hartën e botës! Mos e mbani për vete; tregojuni miqve tuaj dhe redaktojeni së bashku.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Ndaje me miqtë</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Mbyllur tani</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Hapet nesër në %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Hapet %1 në %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Hapet në %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Mbyllet në %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Shto orarin e hapjes</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Fjalëkalimi (minimum 8 karaktere)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Emër përdoruesi ose fjalëkalim i pavlefshëm.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Llogaria OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Ngarkimi i fundit</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Faleminderit</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Emri i Vendit</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefoni</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Ju lutemi vini re</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Gabim në shkarkim</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Zgjidh kategorinë</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popullore</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Të Gjitha Kategoritë</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Shtoni vende të reja në hartë dhe redaktoni ato ekzistuese drejtpërdrejt nga aplikacioni.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Ndrysho vendndodhjen</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Për të shkarkuar, ju duhet më shumë hapësirë. Ju lutemi fshini të dhënat e panevojshme.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Unë përmirësova hartat e Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Komenti i detajuar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Ndryshimet tuaja të sugjeruara të hartës do të dërgohen në komunitetin OpenStreetMap. Ju lutemi përshkruani çdo detaj shtesë që nuk mund të redaktohet në Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Ndodhi një gabim gjatë përcaktimit të vendndodhjes suaj. Kontrolloni që pajisja juaj po punon siç duhet dhe provoni përsëri më vonë.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Shërbimet e vendndodhjes janë të çaktivizuara</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aktivizoni qasjen në gjeolokacion në cilësimet e pajisjes</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Hapni Cilësimet</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Prekni Vendndodhja</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Zgjidhni Ndërsa Përdorni Aplikacionin</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Zgjidhni Privatësia</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Zgjidhni Shërbimet e Vendndodhjes</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Ndizni Shërbimet e Vendndodhjes</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Ose vazhdoni të përdorni Organic Maps pa Vendndodhje</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervo</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Telefono</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Emri i Faqeshënuesit</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Fshi Faqeshënuesin</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Shënimi juaj do të dërgohet në OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…më shumë</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Përditëso</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Të çaktivizohet regjistrimi i rrugës suaj të udhëtuar së fundmi?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Çaktivizo</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Shiko</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps përdor vendndodhjen tuaj në sfond për të regjistruar rrugën tuaj të udhëtuar së fundmi.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Cilësimet e përgjithshme</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Për të shfaqur të dhënat e trafikut, aplikacioni duhet të përditësohet.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Madhësia e skedarit log: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Tërhiqni këtu për të hequr</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Zëvendëso Ndalesën</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Fillo nga</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Ju lutemi hyni në OpenStreetMap për të ngarkuar automatikisht të gjitha ndryshimet tuaja të hartës. Mëso më shumë</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>këtu</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Fshih Ekranin</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 nga %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Duke shkarkuar %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Duke aplikuar %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Ky emër është tepër i gjatë</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>U zbuluan skedarë të rinj</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konverto</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Gabim</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Disa skedarë nuk u konvertuan.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Ndodhi një gabim</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popullore</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Fshih nga harta</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Ndodhi një gabim gjatë ngarkimit të etiketave, ju lutemi provoni përsëri</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Djathtas</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Poshtë</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Le të shkojmë</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destinacioni</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Riqendro</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Rezultatet e kërkimit</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Pastaj</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>A dëshironi të rindërtoni rrugën?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tastiera nuk është e disponueshme gjatë drejtimit të mjetit</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Nuk mund të krijohet një rrugë nga vendndodhja juaj aktuale</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Nuk mund të gjendet rruga për në destinacionin tuaj. Ju lutemi zgjidhni një pikë tjetër fundore</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Nuk ka sinjal GPS. Ju lutemi zhvendosuni në një zonë të hapur</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Nuk mund të krijohet rruga. Ju lutemi specifikoni pika të tjera të rrugës</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Për të krijuar një rrugë, shkarkoni hartat që mungojnë në pajisjen tuaj</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Ndodhi një gabim. Ju lutemi rinisni aplikacionin</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Rruga do të rindërtohet nga vendndodhja juaj aktuale</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Rruga do të konvertohet në një rrugë automobilistike</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Jo të gjithë faqeshënuesit janë shfaqur</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Kaloni në telefon për të parë të gjithë faqeshënuesit</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kamerat e shpejtësisë</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Paralajmërimet e shpejtësisë</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Ju lutemi shkarkoni hartat në aplikacion në pajisjen tuaj celulare</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Dalja %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Rendit sipas parazgjedhjes</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Rendit sipas llojit</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Rendit sipas distancës</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Rendit sipas datës</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Rendit sipas emrit</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Ushqim</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Vende turistike</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Muzetë</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parqe</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Not</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Male</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Kafshë</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotele</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Ndërtesa</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Para</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Dyqane</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkim</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Pompa karburanti</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Mjekësi</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Kërko në listë</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Vende fetare</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Zgjidh listën</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Lundrimi me metro në këtë rajon nuk është ende i disponueshëm</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Nuk u gjet asnjë rrugë metroje</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Ju lutemi zgjidhni një pikë fillimi ose fundi më afër një stacioni metroje</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Vija Konture</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Aktivizimi i vijave të konturit kërkon shkarkimin e të dhënave të hartës për këtë zonë</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Vijat e konturit nuk janë ende të disponueshme në këtë zonë</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ngjitje</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Zbritje</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Lartësia min.</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Lartësia maks.</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Vështirësia</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Koha:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zmadhoni për të eksploruar izolinat</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Duke shkarkuar</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Shkarko hartën e përgjithshme të botës</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Nuk mund të krijohet dosja dhe të lëvizen skedarët në memorien e brendshme të pajisjes ose kartën sd</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Gabim disku</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Dështim i lidhjes</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Shkëputni kabllon USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Mbaje ekranin ndezur</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Kur aktivizohet, ekrani do të jetë gjithmonë i ndezur kur shfaqet harta.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Shfaq në ekranin e kyçjes</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Kur aktivizohet, aplikacioni do të punojë në ekranin e kyçjes edhe kur pajisja është e kyçur.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Gjuha e hartës</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Të dhëna harte nga OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Faleminderit që përdorni hartat tona të ndërtuara nga komuniteti!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Me donacionet dhe mbështetjen tuaj, ne mund të krijojmë hartat më të mira në Botë!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>A ju pëlqen aplikacioni ynë? Ju lutemi dhuroni për të mbështetur zhvillimin! Nuk ju pëlqen ende? Ju lutemi na tregoni pse, dhe ne do ta rregullojmë!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Nëse njihni një zhvillues softuerësh, mund t&#x27;i kërkoni atij ose asaj të zbatojë një veçori që ju nevojitet.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Prekni kudo në hartë për të zgjedhur çdo gjë. Një prekje e gjatë përdoret për të fshehur dhe shfaqur ndërfaqen.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>A e dinit që vendndodhja juaj aktuale në hartë mund të zgjidhet?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Ju mund të ndihmoni në përkthimin e aplikacionit tonë në gjuhën tuaj.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Aplikacioni ynë zhvillohet nga disa entuziastë dhe komuniteti.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Ju mund të rregulloni dhe përmirësoni lehtësisht të dhënat e hartës.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Qëllimi ynë kryesor është të ndërtojmë harta të shpejta, të fokusuara te privatësia dhe të lehta për t&#x27;u përdorur që do t&#x27;i doni.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Tani jeni duke përdorur Organic Maps në ekranin e telefonit</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Tani jeni duke përdorur Organic Maps në ekranin e makinës</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Jeni lidhur me Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Vazhdoni në telefon</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Te ekrani i makinës</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps ka nevojë për qasje në vendndodhje. Kur të jetë e sigurt, kontrolloni njoftimin në telefonin tuaj.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ky aplikacion ka nevojë për lejen tuaj</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps në Android Auto ka nevojë për leje vendndodhjeje për të punuar me efikasitet</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Jepni Lejet</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Në natyrë</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Shfletuesi i uebit nuk është i disponueshëm</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volumi</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Eksporto të gjithë Faqeshënuesit dhe Gjurmët</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Cilësimet e sistemit të sintezës së të folurit</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Cilësimet e Sintezës së Të Folurit nuk u gjetën, a jeni i sigurt që pajisja juaj e mbështet?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Pastroj kërkimin</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zmadho</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zvogëlo</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Lidhja e Menusë</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Shiko Menunë</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Hape në Një Aplikacion Tjetër</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Vetë-shërbim</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Zgjidh opsionin</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Ulëse jashtë</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Për lundrimin më të saktë, rekomandojmë çaktivizimin e modalitetit të kursimit të energjisë në cilësimet e baterisë së telefonit.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Regjistro Gjurmën</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Ndalo Regjistrimin e Gjurmës</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Regjistrimi i Gjurmës</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Ndalo Pa Ruajtur</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Vazhdo Regjistrimin</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Të ruhet në Faqeshënues dhe Gjurmë?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Gjurma është boshe - asgjë për t&#x27;u ruajtur</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Nuk mund të shfaqet dialogu i zgjedhjes së dosjes sepse asnjë aplikacion i përshtatshëm nuk është i instaluar në pajisjen tuaj. Ju lutemi instaloni një aplikacion menaxhimi skedarësh dhe provoni përsëri.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Zgjidh Ngjyrën</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Ndrysho Gjurmën</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Asnjë aplikacion i instaluar që mund të hapë vendndodhjen</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Automatike në lundrim</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Ndiq sistemin</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Ndaj Gjurmën</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Fshi %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Niveli i vështirësisë</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>E lehtë</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Mesatare</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>E vështirë</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Duke përditësuar</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Përditëso hartat e shkarkuara</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Përditësimi i hartave mban informacionin rreth objekteve të përditësuar</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Përditëso (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Përditëso manualisht më vonë</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Fshi Gjurmën</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Jeni i sigurt që dëshironi të fshini këtë gjurmë?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Emri i Gjurmës</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Lëviz</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Gjurmë</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Ndrysho Ngjyrën</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Harta</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>A dëshironi të dërgoni një raport gabimi te zhvilluesit?
+Ne mbështetemi te përdoruesit tanë pasi Organic Maps nuk mbledh asnjë informacion gabimi automatikisht. Faleminderit paraprakisht për mbështetjen e Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktivizo Sinkronizimin iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Sinkronizimi iCloud ëshë një veçori eksperimentale në zhvillim. Sigurohuni që keni bërë një kopje rezervë të të gjithë faqeshënuesve dhe gjurmëve tuaja.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Është i Çaktivizuar</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Ju lutemi aktivizoni iCloud në cilësimet e pajisjes suaj për të përdorur këtë veçori.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktivizo</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Rezervë</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Dështim i sinkronizimit iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Gabim: Dështoi sinkronizimi për shkak të gabimit në lidhje</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Gabim: Dështoi sinkronizimi për shkak se kuota e iCloud u tejkalua</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Gabim: iCloud nuk është i disponueshëm</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Listat e Fshira Së Fundmi</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Pastro</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Fshi të Gjitha</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Rimerr</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Rimerr të Gjitha</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Kontribuoni në OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Shto Vend</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Përditësoni Hartën për të Kontribuar</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Ju duhet të përditësoni hartën %1 në versionin më të fundit para se të mund të kontribuoni në të dhënat OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Pozicioni Im</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Vendet e Mia</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Ruajtje e brendshme private</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Ruajtje e brendshme e ndarë</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Karta SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Ruajtje e jashtme e ndarë</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Kodi Postar</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Pika e Hartës</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Për të shfaqur rrugët, hartat duhet të jenë të përditësuara.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Dalje</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Hyrje</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Harta e metrosë nuk është e disponueshme</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ti</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Rajonet e shkarkuara me ngjyrë vjollcë</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rruga</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Zbulimi i vendndodhjes në sfond është i nevojshëm për të shijuar plotësisht funksionalitetin e aplikacionit. Përdoret për lundrim dhe ruajtjen e gjurmës suaj të udhëtuar së fundmi.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Përcaktimi i vendndodhjes suaj është i nevojshëm për lundrim dhe për ruajtjen e gjurmës suaj të udhëtuar së fundmi.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Hy me fjalëkalim</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Hyni me anë të shfletuesit</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Të përdorura së fundmi</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Ngjyra e faqeshënuesve u ndryshua</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Ngjyra e gjurmëve u ndryshua</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektri</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Lëvizësit</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>E KUQ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>E GJELBËR</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>E KALTËR</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Ngjyra Hex sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rrjetë</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sr/omim.ts
+++ b/qt/translations/sr/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sr">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Одустани</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Обриши</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Преузми мапе</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Преузимање није успело. Додирни за поновни покушај.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Преузимање…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Километри</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Миље</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Касније</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Претрага</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Тражи на мапи</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Тренутно су сви локацијски сервиси на овом уређају или апликацији искључени. Потребно је да их укључите у Подешавањима.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Ограничена тачност</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Да би се осигурала тачна навигација омогућите прецизну локацију у подешавањима.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Прикажи на мапи</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Преузимање није успело</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Покушај поново</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>О апликацији Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Слободна за све, направљена с љубављу</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Без реклама, без праћења, без сакупљања података</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Без непотребне потрошње батерије, ради и без интернета</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Брза, минималистичка, направљена од стране заједнице</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Апликација отвореног кода, направљена од ентузијаста и волонтера.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Подешавања локације</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Затвори</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Ова апликација захтева хардверски-убрзан OpenGL. На жалост, ваш уређај није подржан.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Преузми</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Молим вас откачите USB кабл, или убаците меморијску картицу да бисте користили Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Молим вас, прво ослободите нешто простора на SD картици или на USB меморији да бисте користили апликацију</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Пре него што почнете да користите апликацију, прво преузмите на ваш уређај општу мапу света.
+За то ће бити потребно %1 меморије.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Иди на мапу</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Преузимање %1. Можете
+отићи на мапу.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Преузети %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Ажурирати %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Пауза</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Настави</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 преузимање није успело</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Направи нову листу</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Назив листе маркера</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Маркери</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Маркери и путање</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Назив</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Адреса</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Листа</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Подешавања</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Место за чување мапа</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Изаберите фолдер у ком се чувају мапе.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Преузете мапе</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>слободно %1 од %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Преместити мапу?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Грешка приликом премештања фајлова са мапама</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Ово може да потраје неколико минута.
+Молим вас, сачекајте…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Јединице мере</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Изаберите између километара и миља</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Обустави преузимање</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Оставите рецензију</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Преузми мапу</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Листе маркера</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Где јести</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Намирнице</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Транспорт</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Гориво</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Паркинг</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Куповина</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Секонд-хенд</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Хотел</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Туристичка атракција</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Забава</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Банкомат</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Ноћни живот</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Све за децу</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Банка</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Апотека</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Болница</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Тоалет</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Пошта</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Полиција</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Рециклажа</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Вода</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>За кампер возила</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Напомене</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps маркери су подељени са вама</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Здраво!
+
+У прилогу су моји маркери; молим те да их отвориш у Organic Maps-у. Ако га немаш већ инсталираног, можеш да га преузмеш одавде: https://omaps.app/get?kmz
+
+Уживај у путовању са Organic Maps-ом!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Учитавање маркера</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Маркери су успешно учитани! Можете их проначи на мапи помоћу Менаџера маркера.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Неуспешно учитавање маркера. Могуће је да је фајл оштећен или неисправан.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Апликација не препознаје ову врсту фајла:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Отварање фајла %1 није успело
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Измени</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ваша локација још није одређена</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Извините, подешавање локације за чување мапа је тренутно онемогућено.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Преузимање мапа је у току.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Види моју тренутну локацију у Organic Maps-у! %1 или %2 Још не користиш offline мапе? Преузми их овде: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Хеј, види мој маркер у Organic Maps-у!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Хеј, види моју тренутну локацију на Organic Maps мапи!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Здраво,
+
+Ја сам овде: %1. Кликни на овај %2 или овај линк %3 да би видео то место на мапи.
+
+Хвала.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Подели</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Копирано у клипборд: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Готово</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap подаци: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Да ли сте сигурни да желите да се одјавите са OpenStreetMap налога?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Путање</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Дужина</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Подели моју локацију</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Општа подешавања</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Информације</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Навигација</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Дугмад „+” и „-” на мапи</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Прикажи на мапи</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Ноћни стил приликом навигације у мраку</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Ноћни режим</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Искључено</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Укључено</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Аутоматски</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Приказ перспективе</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D зграде</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D зграде се не приказују у режиму чувања батерије</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Гласовне инструкције</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Најави име улице</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Када је укључено, име улице или излаз на који треба скренути ће бити изговорен.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Језик гласа</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Да бисте преузели глас вишег квалитета, отворите апликацију Подешавања и идите у Приступачност → VoiceOver → Говор → Глас.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Тестирај гласовне инструкције (Текст-у-говор)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Проверите гласноћу или системска подешавања Текста-у-говор ако сада не чујете глас.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Није доступно</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Аутоматско увећавање</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Раздаљина</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Прикажи на мапи</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Мени</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Веб-сајт</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Новости</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Повратне информације</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Оцена апликације</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Помоћ</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Често постављена питања</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Донација</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Већ је донирано</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Подсећати касније</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Подржава Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Подржи пројекат</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Пријавите проблем</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Побољшајте смер стрелице тако што ћете померати телефон у путањи осмице као бисте калибрисали компас.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Померајте телефон у путањи осмице како бисте калибрисали компас и поправили смер стрелице на мапи.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Додирните дуго мапу да бисте поново видели интерфејс</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Ажурирај све</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Одустани од свих</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Преузето</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>На чекању</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Близу мене</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Мапе</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Преузми све</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Преузимање:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Да бисте обрисали мапу, зауставите навигацију.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Могу се креирати само руте које се комплетно налазе у оквиру мапе једног региона.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Преузми мапу</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Покушај поново</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Обриши мапу</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Ажурирај мапу</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play прецизност локације</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Брзо одређивање ваше локације коришћењем Bluetooth-а, WiFi-а, или мобилне мреже</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Преузми све мапе које се налазе на рути</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Да би рута могла да се креира, потребно је да преузимање и ажурирање свих мапа између ваше локације и вашег одредишта.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Нема довољно простора</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Молим вас укључите Локацијске сервисе</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Сачувај</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>креирај</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Црвена</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Жута</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Плава</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Зелена</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Љубичаста</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Наранџаста</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Браон</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Розе</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Тамно љубичаста</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Светло плава</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Цијан</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Теал</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Лимета</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Тамно наранџаста</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Сива</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Плаво сива</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Информације</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps верзија: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Изглед</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Светло</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Тамно</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Светла од зоре до сумрака</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Остало</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Поклоните бесплатне мапе без огласа милионима корисника!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Пријавите или поправите нетачне податке на мапи</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Волонтирајте</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Пратите и контактирајте нас:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Email клијент није подешен. Молимо вас да га подесите или нас контактирајте на %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Грешка приликом слања email-а</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Калибрација компаса</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Расположиве</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Пронађено</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Ажурирано</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Неуспешно</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>маркер</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Када пратите руту, обратите пажњу на:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Услови на путу, саобраћајни прописи и знакови имају приоритет у односу на навигацију;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Мапа може бити нетачна и предложена рута не мора увек бити најоптималнији начин да стигнете на одредиште;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Предложену руту треба да схватите само као предлог;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Будите пажљиви са рутама које пролазе и близини граница: руте које креира наша апликација могу понекад прелазити границе дражава на недозвољеним местима.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Молимо Вас да будете опрезни и безбедни на путу!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Провери GPS сигнал</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Не могу да направим руту. Тренутне GPS координате не могу да се одреде.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Молим Вас да проверите ваш GPS сигнал. Укључивање Wi-Fi-а ће поправити прецизност ваше локације.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Укључи Локацијске сервисе</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Није могуће одредити тренутне GPS координате. Укључи локацијске сервисе ради проналажења руте.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Не могу да пронађем руту</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Не могу да направим руту.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Молим Вас да подесите почетну или одредишну тачку.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Подеси почетну тачку</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Рута није креирана. Не могу да одредим почетну тачку.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Молим вас да изаберете почетну тачку ближе путу.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Подеси одредишну тачку</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Рута није направљена. Не могу да пронађем одредиште.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Молим Вас да изаберете одредишну тачну ближе путу.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Не могу да пронађем успутну тачку.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Молим Вас да подесите успутну тачку.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Системска грешка</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Не могу да направим руту због грешке у апликацији.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Молим Вас, покушајте поново</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Не сада</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Да ли желите да преузмете мапу и направите оптималнију руту која се простире на више од једне мапе?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Преузми додатне мапе и направи бољу руту која се престире преко граница ове мапе.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Преузимање потребних фајлова</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Преузимање или ажурирање свих мапа које се налазе на предвиђеној путањи ради израчунавања руте.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Да бисте почели да претражујете и правите руте, молим Вас да преузмете мапу. Након тога веза са интернетом Вам више неће бити потребна.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Изабери мапу</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Прикажи</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Сакриј</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Категорије</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Историја</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Упс, нема резултата.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Преузмите регион где вршите претрагу, или пробајте да додате име оближњег насеља.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Историја претраге</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Погледајте ваше недавне претраге.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Обриши историју претраге</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Википедија</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Чланак са wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Викимедијина остава</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Ваша локација</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Крени</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Старт</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Одредиште</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Навигација је могућа само од ваше тренутне локације.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Да ли желите да направите руту од ваше тренутне локације?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Даље</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Од</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>До</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Додај време</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Обриши време</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Нон-стоп (24 сата)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Отворено</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Додај нерадно време</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Радно време</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Напредни режим</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Једноставни режим</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Нерадно време</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Примери</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Исправи грешку</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Изаберите локацију</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Молим Вас да детаљно опишете проблем како би OpenStreetMap заједница могла да га поправи.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Или то учините сами на https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Пошаљи</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Проблем</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Ово место не постоји</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Затворено због одржавања</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Дуплирано место</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Аутоматско преузимање мапа</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Сваки дан</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Данас не ради</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Данас</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Отвара се за %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Затвара се за %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Затворено</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Промени радно време</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Немате OpenStreetMap налог?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Региструјте се на OpenStreetMap-у</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Пријавите се</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Нисте пријављени</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Пријава на OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Лозинка</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Заборављена лозинка?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Одјави се</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Измени место</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Додај језик</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Улица</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Кућни број</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Детаљи</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Друштвени медији</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Зграда</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Додај улицу</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Молим Вас, унесите назив улице</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Изаберите језик</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Изаберите улицу</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Кухиња</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Изаберите кухињу</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email или корисничко име</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Додај број телефона</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Спрат</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Спрат: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Све ваше промене на мапи ће бити обрисане заједно са мапом.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Ажурирај мапе</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Да бисте направили руту, потребно је да ажурирате све мапе, а затим да поново планирате руту.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Пронађи мапу</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Молим Вас да проверите да ли је Ваш уређај повезан на интернет.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Нема довољно простора</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Молим Вас да обришете непотребне податке</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Грешка приликом пријаве.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Верификоване промене</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Превуците мапу да поставите крст на локацију места или посла.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Измена</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Додавање</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Назив места</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Као што је написано на локалном језику</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Категорија</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Детаљан опис проблема</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Други проблем</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Додај фирму</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Објекат не може бити на овом месту</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Подаци са OpenStreetMap-а које је креирала заједница до %1. Научите више о томе како да мењате и ажурирате мапу на OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) је пројекат заједнице који има за циљ прављење бесплатне, слободне и отворене мапе. OSM је главни извор података за мапе у Organic Maps-у и функционише на сличан начин као Википедија. Можете додати или променити места и ваше промене постају видљиве милионима корисника широм света.
+Придружите се заједници и помозите да направимо бољу мапу која је доступна свима!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Пријавите се на openstreetmap.org да бисте објавили ваше промене остатку света.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 од %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Преузимање преко мобилне мреже?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Ово може бити значајно скупље у оквиру одређених пакета или у ромингу.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Унесте исправан кућни број</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Број спратова (макс. %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Број спратова не сме да прелази %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Поштански број</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Унесите исправан поштански број</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Напомена за OpenStreetMap волонтере (није обавезна)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Опишите грешке на мапи или ствари које се не могу променити помоћу Organic Maps-а</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Ваше промене су послате у јавну &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; базу података. Молимо Вас да не додајете личне податке или податке заштићене ауторским правима.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Више о OpenStreetMap-у</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Ваша историја уређивања</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Ваши подаци о мапи</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Оператор</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Оператор: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Не можете да пронађете одговарајућу категорију?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps омогућава додавање једноставних категорија за тачке на мапи, што искључује градове, путеве, језера, тлоцрте зграда, итд. Молимо Вас да такве категорије додате директно на &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Прочитајте наше &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;упутство&lt;/a&gt; за детаљне инструкције, корак-по-корак.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Нисте преузели ни једну мапу</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Преузмите мапе да бисте претраживали и користили навигацију без интернета.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Тренутна локација није позната.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>км/ч</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ми/ч</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ч</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>мин</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>д</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>с</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Више</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Измени маркер</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Личне белешке (текст или хтмл)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Коментар…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Брисање свих измена које нису послате?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Обриши</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Брисање додатог места?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Обриши</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Место не постоји</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Молим Вас наведите разлог због чега бриште ово место</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Унесите исправан број телефона</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Унесите исправну веб адресу</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Унесите исправан email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Унесите исправну Facebook веб адресу, налог, или име странице</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Унесите исправно Instagram корисничко име или веб адресу</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Унесите исправно Twitter корисничко име или веб адресу</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Унесите исправно VK корисничко име или веб адресу</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Унесите исправан LINE ID или веб адресу</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Додај место на OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Или, као алтернативу, оставите поруку заједници OpenStreetMap како би неко други могао да дода или исправи неку локацију овде.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Напомена ће бити послата OpenStreetMap-у</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Да ли желите да поделите са свим другим корисницима?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Проверите да нисте унели приватне или личне податке.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap мапери ће проверити промене и контактирати Вас уколико буду имали питања.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Стоп</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Снимање путање</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Прихвати</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Одбиј</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Користи мобилни интернет ради приказа детљних информација?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Увек користи</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Само данас</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Немој данас</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Мобилни интернет</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Мобилни интернет је потребан за обавештења о ажурирању мапе и за слање измена.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Никад не користи</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Увек ме питај</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Да би се приказали подаци о саобраћају, мапа мора да се ажурира.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Увећана слова на мапи</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Молим Вас да ажурирате Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Подаци о саобраћају нису доступни</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Снимање лог фајлова</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Ваше мишљење</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Користимо системски сервис текст-у-говор за гласовне инструкције. Многи Андроид уређаји користе Google Препознавање и синтезу говора, који можете да преузмете или ажурирате путем Google Play продавнице</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>За поједине језике, мораћете да инсталирате синтетизатор говора или језички пакет путем продавнице апликација (Google Play, Galaxy Store, App Gallery, FDroid).
+Отворите Подешавања вашег уређаја → Језик и унос → Говор → Излаз Текста у говор.
+Овде можете да управљате подешавањима за синтезу говора (на пример, да преузмете језички пакет за употребу без интернета) и да изаберете неку другу машину за Текст-у-говор.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>За више информација погледајте ово упутство.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Транслитерација у латиницу</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Сазнај више</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Користите претрагу или кратко додирните мапу да бисте додали почетну тачку руте</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Користите претрагу или кратко додирните мапу да бисте додали одредишну тачку</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Измени руту</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>План</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Уклони међуодредиште</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Међуодредиште</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Сачувано</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Молим Вас да се пријавите на OpenStreetMap да бисте аутоматски послали своје промене на мапи. Сазнајте више о томе &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;овде&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Проблем са приступом меморији</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Екстерна меморија није доступна. SD картица је можда уклоњена, оштећена, или је фајл систем само за читање. Молим Вас, проверите Вашу SD картицу или нас контактирајте на support\@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Симулирај неисправну меморију</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Молим Вас да унесете исправан назив</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Листе</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Сакриј све</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Прикажи све</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n маркер</numerusform>
+<numerusform>%n маркери</numerusform>
+<numerusform>%n маркера</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Креирај нову листу</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Увези маркере и путање</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Дељење није могуће због грешке у апликацији</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Грешка приликом дељења</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Не може се поделити празна листа</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Назив не сме бити празан</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Молим Вас унесите име листе</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Нова листа</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Овај назив већ постоји</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Молим Вас изаберите други назив</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Молим Вас сачекајте…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Број телефона</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap профил</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n фајл је пронађен. Можете да га погледате након конверзије.</numerusform>
+<numerusform>%n фајла је пронађено. Можете да их погледате након конверзије.</numerusform>
+<numerusform>%n фајлова је пронађено. Можете да их погледате након конверзије.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Реконструиши</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n путања</numerusform>
+<numerusform>%n путање</numerusform>
+<numerusform>%n путања</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Приватност</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Политика приватности</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Услови коришћења</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Саобраћај</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Планинарење</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Бициклизам</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Метро</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Стилови мапе и слојеви</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Ова листа је празна</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Да бисте додали маркер, кратко додирните место на мапи, а онда додирните иконицу са звездом</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Промени боју свих обележивача</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Промени боју свих путања</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…више</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Експортуј KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Експортуј GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Експортуј GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Обриши листу</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Прекршајне камере</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Опис места</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Преузимање мапа</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Упозорење на прекорачење брзине</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Увек ме упозори</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Немој да ме упозораваш</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Режим чувања батерије</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Смањује потрошњу електричне енергије искључивањем одређених функционалности.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Никад</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Када је батерија при крају</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Увек</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Имена обележивача на мапи</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ако има превише обележивача, приказивање њихових имена на мапи може успорити апликацију.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Прикажи десно</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Прикажи на дну</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Привремено укључите ову опцију да бисте сачували детаљне дијагностичке логове уколико имате неки проблем. Логове можете да нам пошаљете коришћењем опције &quot;Пријавите проблем&quot; у прозору Помоћ. Напомена: Логови могу да садрже информације о вашој локацији.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Опције рутирања</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Избегавај путарине</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Избегавај неасфалтиране путеве</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Избегавај трајекте</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Избегавај аутопутеве</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Није могуће израчунати руту</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Рута није пронађена. Узрок могу бити опције рутирања или непотпуни OpenStreetMap подаци. Молим Вас да промените ваше опције рутирања и покушате поново.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Изабери путеве за избегавање</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Опције рутирања су укључене</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Путеви са путаринама</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Неасфалтирани путеви</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Линије трајекта</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Да</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Број места: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Мрежа: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Стигли сте!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>ОК</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Сортирање…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Сортирање маркера</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Подразумевано</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>По типу</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>По удаљености</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>По датуму</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>По називу</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Пре недељу дана</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Пре месец дана</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Пре више од месец дана</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Пре више од годину дана</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Близу мене</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Остали</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Планирање руте није успело</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Долазак у: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Преузимање и ажурирање свих мапа уз пројектовану путању ради израчунавања руте.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Направили сте промену на мапи света! Не чувајте је само за себе; реците својим пријатељима и наставите да је мењате заједно.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Подели са пријатељима</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Затворено сада</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Отвара се сутра у %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Отвара се %1 у %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Отвара се у %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Затвара се у %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Додај радно време</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Лозинка (минимум 8 знакова)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Неисправно корисничко име или лозинка.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM налог</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Последње слање</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Хвала</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Назив места</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Телефон</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Обратите пажњу</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Грешка приликом преузимања</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Изаберите категорију</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Популарно</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Све категорије</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Додајте нова места на мапу, или промените постојећа директно из апликације.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Промените локацију</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Да бисте завршили преузимање потребно је више слободног простора. Молим Вас да обришете непотребне податке.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Ја сам поправио/ла мапе у Organic Maps-у</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Детаљан коментар</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Ваши предлози промена на мапи ће бити послати OpenStreetMap заједници. Молим Вас опишите евентуалне додатне детаље који не могу да се промене помоћу Organic Maps-а.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Десила се грешка приликом утврђивања ваше локације. Проверите да ли је ваш уређај исправан и покушајте поново касније.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Локацијски сервиси су искључени</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Омогућите приступ геолокацији у подешавањима вашег уређаја</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Отворите Подешавања</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Додирните опцију Локација</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Изаберите За време коришћенја апликације</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Изаберите Приватност</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Изаберите Локацијски сервиси</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Укључите Локацијске сервисе</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Или наставите да користите Organic Maps без локације</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Резервиши</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Позови</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Назив маркера</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Обриши маркер</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ваша напомена ће бити послана на OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…још</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Ажурирај</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Искључити снимање ваше недавно пређене руте?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Искључи</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Погледај</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps користи у позадини вашу локацију да би сачувао вашу недавно пређену руту.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Општа подешавања</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Да бисте видели податке о саобраћају, морате да ажурирате апликацију.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Величина лог фајла: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Превуците овде за уклањање</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Замени Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Крени од</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Молим вас да се улогујете на OpenStreetMap да бисте аутоматски послали све ваше промене на мапи. Сазнајте више</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>овде</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Сакриј екран</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 од %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Преузимам %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Примењујем %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Изабрано име је предугачко</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Пронађени су нови фајлови</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Конвертуј</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Грешка</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Неки фајлови нису конвертовани.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Десила се грешка</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Популарно</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Сакриј на карти</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Десила се грешка приликом учитавања тагова, покушајте поново</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Десно</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Доња</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Крећемо</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Одредиште</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Центрирај</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Резултати претраге</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Затим</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Да ли желите да поново направим руту?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Тастатура је онемогућена у току вожње</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Није могуће направити руту са ваше тренутне локације</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Није могуће направити руту до изабраног одредишта. Изаберите друго одредиште.</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Нема ГПС сигнала. Померите се на отворен простор</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Није могуће направити руту. Изаберите друге тачке на рути</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Да бисте направили руту, преузмите недостајуће мапе на ваш уређај</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Дошло је до грешке. Молим Вас рестартујте апликацију</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Рута ће бити поново направљена од ваше тренутне локације</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Рута ће бити прилагођена за кретање аутомобилом</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Нису приказани сви маркери</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Пребаците се на телефон да бисте видели све маркере</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Прекршајне камере</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Упозорење прекорачења</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Молим Вас да преузмете мапе у апликацији на Вашем мобилном уређају</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 излаз</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Подразумевано сортирање</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Сортирање по типу</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Сортирање по удаљености</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Сортирање по датуму</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Сортирање по називу</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Храна</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Атракције</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Музеји</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Паркови</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Пливање</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Планине</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Животиње</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Хотели</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Зграде</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Новац</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Продавнице</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Паркинг</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Бензинске станице</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Медицина</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Претражи листу</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Верска места</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Изаберите листу</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Навигација у метроу у овом региону још није доступна</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Није пронађена метро рута</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Молим вас изаберите почетну и крајњу тачку ближе метро станицама</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Изолиније</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Приказивање изолинија захтева преузмање података са мапе за ову област</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Изолиније нису доступне за ову област</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Успон</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Спуст</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Минимална висина</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Максимална висина</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Тежина</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Удаљ.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Време:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Увећајте да бисте видели изолиније</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Преузимање</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Преузми мапу света</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Не могу да направим фолдер и пременстим фајлове на интерну меморију уређаја или на SD картицу</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Грешка са меморијом</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Повезивање није успело</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Откачите USB кабл</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Екран увек укључен</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Када је одабрано, екран ће увек бити укључен док се приказује мапа.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Приказ мапе на закључаном екрану</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Када је одабрано, апликација ће радити и на закључаном екрану, тј. када је уређај закључан.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Језик мапе</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Подаци за мапе су са OpenStreetMap-а</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Хвала што користите мапе које је направила заједница!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Са вашим донацијама и подршком, можемо да направимо најбоље мапе на свету!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Да ли вам се допада наша апликација? Молим Вас да донирате да бисте подржали даљи развој! Још вам се не допада? Молимо Вас да нам јавите зашто, па ћемо да је поправимо!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ако знате неког програмера, можете да га замолите да имплементира функционалност која вам је потребна.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Додирните било где на мапи да бисте изабрали било шта. Дуг додир се користи да се сакрије и прикаже интерфејс.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Да ли сте знали да можете да изаберете вашу тренутну локацију на мапи?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Можете да помогнете да се апликација преведе на ваш језик.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Наша апликација је развијена од стране неколико ентузијаста и заједнице.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Лако можете да поправите или унапредите податке на мапи.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Наш главни циљ је да направимо брзу апликацију за мапе, једноставну за коришћење, оријентисану на приватност, коју ћете волети.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Ви сада користите Organic Maps на екрану телефона</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ви сада користите Organic Maps на екрану аутомобила</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Повезани сте на Андроид Ауто</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Настави на телефону</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Пребаци на екран аутомобила</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps је потребан локацијски приступ. Када је сигурно, проверите обавештење на свом телефону.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ова апликација треба вашу дозволу</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps у Android Auto-у је потребна дозвола за локацију да ефикасно раде</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Одобри дозволе</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>На отвореном</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Веб читач није доступан</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Јачина звука</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Експортуј све маркере и путање</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Системска подешавања синтезе говора</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Синтеза говора није пронађена, да ли сте сигурни да је ваш уређај подржава?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Пролаз за возила</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Обриши претрагу</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Увећај</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Умањи</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Линк менија</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Прикажи мени</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Отвори у другој апликацији</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Самопослуживање</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Изаберите опцију</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Башта</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>За прецизнију навигацију препоручујемо да се искључи режим чувања батерије у Подешавањима везаним за бетерију телефона.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Сними путању</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Заустави снимање путање</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Снимање путање</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Заустави без чувања</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Настави снимање</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Сачувати у маркерима и путањама?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Путања је празна, нема шта да се сачува</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Дијалог за избор фолдера није могуће приказати пошто на уређају није инсталирана одговарајућа апликација. Молим Вас да инсталирате апликацију за управљање фајловима и покушате поново.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Изаберите боју</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Измените путању</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Нема инсталираних апликација које могу да отворе локацију.</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Аутоматски у навигацији</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Прати систем</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Подели стазу</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Избриши %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Тежина</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Лако</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Умерено</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Тешко</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Ажурирање</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Ажурирај преузете мапе</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Ажурирање мапа обезбеђује да су подаци о објектима ажурни</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Ажурирај (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Ручно ажурирај касније</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Обриши путању</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Да ли сте сигурни да желите да обришете ову путању?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Назив путање</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Премести</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Путања</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Промени боју</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Мапа</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Да ли желите да пошаљете пријаву бага програмерима?
+Ослањамо се на кориснике пошто Organic Maps не прикупља податке о грешкама аутоматски. Хвала унапред што подржавате Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Омогући iCloud синхронизацију</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud синхронизација је експеримантална функционалност која је још увек у развоју. Проверите да ли сте направили резервну копију (бекап) свих ваших маркера и путања.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud је искључен</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Молим Вас да укључите iCloud у подешавањима вашег уређаја да бисте користили ову опцију.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Укључи</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Резервна копија</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Неуспешна iCloud синхронизација</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Грешка: синхронизација није успела због грешке приликом повезивања</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Грешка: синхронизација није успела због прекорачења iCloud квоте</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Грешка: iCloud није доступан</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Недавно обрисане листе</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Обриши</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Обриши све</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Поврати</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Поврати све</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Допринос OpenStreetMap-у</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Додај место</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Ажурирајте мапу да бисте допринели</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Морате ажурирати %1 мапу на најновију верзију пре него што можете да допринесете OpenStreetMap подацима</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>МБ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ГБ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Моја позиција</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Моја места</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Интерна приватна меморија</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Интерна дељена меморија</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD картица</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Екстерна дељена меморија</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Поштански број</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Тачка на мапи</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>м</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>км</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ми</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>стопа</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Да би се приказале руте, мапе морају бити ажуриране.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Излаз</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Улаз</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Мапа метроа не постоји</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ви</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Љубичасти преузети региони</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Путања</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Откривање локације у позадини је неопходно да у потпуности уживате у функционалности апликације. Користи се за навигацију и чување недавно путовао стазу.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Одређивање ваше локације је неопходно за навигацију и за чување недавног путовања.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Пријава са лозинком</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Пријава преко прегледача</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Недавно коришћено</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Боја обележивача је промењена</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Боја путања је промењена</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Спектар</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Слајдери</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ЦРВЕНА</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ЗЕЛЕНА</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>ПЛАВА</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB хексадецимална боја #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Решетка</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sv/omim.ts
+++ b/qt/translations/sv/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sv">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Tillbaka</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Ta bort</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Ladda ner kartor</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Nedladdningen misslyckades, tryck för att försöka igen.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Laddar ner…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometer</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mile</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Senare</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Sök</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Sök karta</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Du har inaktiverat alla platstjänster för denna enhet eller app. Vänligen aktivera dem i Inställningar.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Begränsad noggrannhet</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>För att säkerställa korrekt navigering aktiverar du Precise Location i inställningarna.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Visa på kartan</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Nedladdningen misslyckades</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Försök igen</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Om Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Gratis för alla, skapad med kärlek</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Inga annonser, ingen spårning, ingen datainsamling</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Låg batteriförbrukning, fungerar utan uppkoppling</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Snabb, minimalistisk, utvecklad av gemenskapen</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Öppen källkod-app skapad av entusiaster och frivilliga.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Platsinställningar</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Stäng</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Hårdvaruaccelererad OpenGL krävs. Din enhet stöds tyvärr inte.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Ladda ner</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Vänligen koppla ifrån USB-kabeln eller sätt in ett minneskort för att använda Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Vänligen frigör utrymme på SD-kortet/USB-lagringen först för att använda appen</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Innan du börjar, ladda gärna ner den översiktliga världskartan på din enhet.&#32;
+Den behöver %1 lagringsutrymme.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Gå till karta</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Laddar ner %1. Du kan nu
+&#32;fortsätta till kartan.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Ladda ner %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Uppdatera %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pausa</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Fortsätt</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 nedladdningen misslyckades</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Lägg till ny samling</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bokmärkessamlingens namn</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bokmärken</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bokmärken och rutter</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Namn</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adress</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Lista</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Inställningar</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Spara kartor i</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Välj en plats för nedladdade kartor.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Nedladdade kartor</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 av %2 ledigt</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Flytta kartor?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Fel vid flyttning av kartfiler</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Detta kan ta flera minuter.
+Vänligen vänta…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Längdenheter</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Välj mellan mile och kilometer</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Avbryt nedladdning</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Skriv en recension</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Ladda ner karta</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bokmärkessamlingar</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Matmöjligheter</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Matvaror</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Bensin</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parkering</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Handel</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Begagnat</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotell</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sevärdheter</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Underhållning</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankomat</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nöjesliv</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Familjesemester</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Apotek</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Sjukhus</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toalett</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polis</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Återvinning</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Vatten</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>För husbil</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Anteckningar</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bokmärken har delats med dig</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hej!&#32;
+&#32;
+Jag bifogar mina bokmärken, öppna gärna dem med Organic Maps. Om du inte redan har appen installerad, kan du ladda ner den här: https://omaps.app/get?kmz&#32;
+&#32;
+Trevlig resa med Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Läser in bokmärken</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bokmärkena lästes in! Du kan hitta dem på kartan eller i Bokmärkeshanteraren.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Inläsningen av bokmärkena misslyckades. Filen kan vara skadad eller defekt.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Filtypen känns inte igen av appen:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Det gick inte att öppna filen %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Redigera</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Din position har inte fastslagits ännu</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Tyvärr, kartlagring är inaktiverat i inställningar.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Kartan har börjat laddas ner.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hej, kolla på min nuvarande position på Organic Maps! %1 eller %2 Har du inte offline-kartor? Ladda ner här: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hej, kolla min kartnål på Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hej, kolla på min nuvarande position på Organic Maps kartan!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hej,
+
+Jag är här nu: %1. Klicka på länken %2 eller här %3 för att se platsen på kartan.
+
+Tack.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Dela</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-post</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Kopierat till urklipp: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Klar</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap-data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Är du säker på att du vill logga ut från ditt OpenStreetMap-konto?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Rutter</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Längd</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Dela min plats</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Allmänna inställningar</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigering</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Knapparna + och - på kartan</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Visa på kartan</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Nattstil när du navigerar i mörkret</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Nattläge</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Av</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>På</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektivvy</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D-byggnader</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D-byggnader är avstängda i energisparläge</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Röstinstruktioner</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Läs upp gatunamn</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>När det är aktiverat kommer namnet på gatan eller avfarten att svänga in på att läsas upp.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Röstspråk</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>För att hämta en röst med högre kvalitet, öppna appen Inställningar och gå till Hjälpmedel → VoiceOver → Tal → Röst.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Testa röstinstruktioner (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kontrollera volymen eller systemets text-till-tal-inställningar om du inte hör rösten nu.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Inte tillgängligt</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Automatisk zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Avstånd</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Visa på kartan</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Meny</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Webbplats</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Nyheter</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Återkoppling</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Betygsätt appen</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Hjälp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frågor och svar</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donera</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Redan donerat</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Påminn senare</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Stöd Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Stöd projektet</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Upphovsrätt</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Rapportera en bugg</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Förbättra pilens riktning genom att röra telefonen i en åttarörelse för att kalibrera kompassen.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Rör telefonen i en åttarörelse för att kalibrera kompassen och fastställa pilens riktning på kartan.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Tryck länge på kartan för att se gränssnittet</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Uppdatera alla</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Avbryt alla</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Nedladdade</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Köade</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Nära mig</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Kartor</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Ladda ned alla</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Ladda ner:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Avsluta navigering för att radera kartan.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Rutter kan endast skapas om de finns inom en enda kart-region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Ladda ner kartan</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Försök igen</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Radera karta</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Uppdatera karta</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play platstjänster</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Fastställ snabbt din ungefärliga position via Bluetooth, WiFi eller mobilnät</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Ladda ned kartor längs vägen</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Navigering kräver att alla kartor från din position till destinationen är nerladdade och uppdaterade.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>För lite utrymme kvar</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Vänligen aktivera platstjänster</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Spara</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>skapa</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Röd</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Gul</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blå</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Grön</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Lila</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brun</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rosa</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Mörklila</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Ljusblå</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Blågrön</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Smaragdgrön</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Limefärg</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Mörkorange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Grå</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Ljusblå grå</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps-version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Utseende</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Ljust</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Mörkt</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Ljus från gryning till skymning</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Övrigt</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Ge bort gratis kartor utan annonser till miljontals användare!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Rapportera eller korrigera felaktiga kartdata</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Bli volontär</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Följ och kontakta oss:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Emailklienten har inte konfigurerats. Ställ in den eller använd ett annat sätt att kontakta oss på %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Fel när mailet skulle skickas</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kompasskalibrering</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Tillgänglig</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Hittat</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Uppdatera</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Misslyckades</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bokmärke</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>När du följer vägen, kom ihåg att:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>– Vägförhållanden, trafikregler och vägskyltar alltid ska prioriteras över navigeringsråden;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>– Kartan kan vara felaktig och den föreslagna vägen inte alltid är det optimala sättet att ta sig till destinationen på;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>– Föreslagna vägar endast är rekommendationer;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>– Iakttag försiktighet med rutter i gränszoner: rutterna som vår app skapat kan ibland korsa landsgränser på otillåtna platser.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Var uppmärksam och kör säkert på vägarna!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Kontrollera GPS-signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Kan inte skapa rutt. Nuvarande GPS-koordinater går inte att läsa.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Kontrollera din GPS-signal. Aktivera Wi-Fi-anslutning för att förbättra platsprecisionen.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Aktivera platstjänster</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Kan inte läsa nuvarande GPS-koordinater. Aktivera platstjänster för att hitta en rutt.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Kan inte hitta rutt</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Kan inte hitta rutt.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Justera din startpunkt eller destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Justera startpunkt</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Ingen rutt hittades. Hittar inte startpunkt.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Välj en startpunkt närmare en väg.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Justera destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Ingen rutt hittades. Kan inte hitta destinationen.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Välj en destination närmare en väg.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Det går inte att hitta mellanliggande punkt.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Justera din mellanliggande punkt.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Systemfel</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Kan inte hitta rutt pga ett programfel.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Försök igen</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Inte nu</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Vill du ladda ned kartan och hitta en bättre sträcka via fler än en karta?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Ladda ned kartan för att skapa en bättre sträcka utanför den här kartan.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Ladda ned nödvändiga filer</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Ladda ned och uppdatera all kart- och väginformation längs den beräknade sträckan för att hitta en rutt.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>För att börja söka och hitta rutter, ladda ner kartan. Efter det behöver du ingen internetanslutning längre.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Välj karta</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Visa</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Dölj</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategorier</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historik</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Ledsen, jag hittade ingenting.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Ladda ner den region där du söker eller försök att lägga till ett närliggande stads- eller bynamn.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Sökhistorik</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Se senaste sökningar.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Rensa sökhistorik</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Artikel från wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Din plats</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Rutt från</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Rutt till</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigering är enbart möjlig från din nuvarande plats.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Vill du att vi planerar en färdväg från din nuvarande plats?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Nästa</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Från</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Till</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Lägg till schema</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Ta bort schema</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Hela dagen (24 timmar)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Öppet</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Stängt</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Lägg till stängda tider</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Öppettider</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Avancerat läge</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Enkelt läge</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Stängda timmar</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Exempelvärden</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Korrigera fel</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Välj plats</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Beskriv problemet i detalj så att OpenStreetMaps community kan lösa det.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Eller gör det själv på https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Skicka</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Problem</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Platsen existerar inte</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Stängt för underhåll</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicerad plats</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Automatisk nedladdning</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Dagligen</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Dygnet runt</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Stängt idag</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Stängt</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Idag</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Öppnar om %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Stänger om %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Stängt</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Redigera öppettider</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Inget konto hos OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Registrera</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Logga in</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Inte inloggad</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Logga in på OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Lösenord</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Glömt lösenord?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Logga ut</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Ändra platsen</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Lägg till ett språk</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Gata</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Husnummer</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Detaljer</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sociala medier</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Byggnad</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Lägg till en gata</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Ange ett gatunamn</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Välj ett språk</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Välj en gata</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Mat</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Välj mat</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-postadress eller användarnamn</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Lägg till telefon</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Våningsplan</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Nivå: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Alla kartändringar kommer att raderas tillsammans med kartan.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Uppdatera kartor</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>För att hitta en rutt måste du uppdatera alla kartor och sedan försöka igen.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Hitta kartan</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Kontrollera dina inställningar och se till att din enhet är ansluten till internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Otillräckligt minne</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Ta bort onödig data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Inloggningsfel.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verifierade ändringar</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Dra kartan för att placera korset på platsen för platsen eller företaget.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Redigerar</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Lägger till</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Platsens namn</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Som det står skrivet på det lokala språket</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategori</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detaljerad beskrivning av problemet</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Annat problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Lägg till organisation</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Ett objekt kan inte placeras här</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-skapade OpenStreetMap-data från och med %1. Läs mer om hur du redigerar och uppdaterar kartan på OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) är ett community-projekt för att bygga en fri och öppen karta. Det är den huvudsakliga källan till kartdata i Organic Maps och fungerar på samma sätt som Wikipedia. Du kan lägga till eller redigera platser och de blir tillgängliga för miljontals användare över hela världen.
+Gå med i samhället och hjälp till att skapa en bättre karta för alla!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Skapa ett OpenStreetMap-konto eller logga in för att publicera dina kartredigeringar till hela världen.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 av %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Ladda ned med mobildata?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Detta kan vara mycket dyrt med vissa abonnemang och vid roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Ange giltigt husnummer</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Antal våningar (max %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Redigera byggnaden med max %1 våningar</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Postnr</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Ange korrekt postnr</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Meddelande till OpenStreetMap-volontärer (valfritt)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Beskriv fel på kartan eller saker som inte kan redigeras med Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Dina redigeringar laddas upp till den offentliga &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Sv:Om_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt;-databasen. Lägg inte till personlig eller upphovsrättsskyddad information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Mer om OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Din redigeringshistorik</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Anteckningar om dina kartdata</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operatör</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operatör: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Hittar du ingen lämplig kategori?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps tillåter endast att lägga till enkla punktkategorier, det betyder inga städer, vägar, sjöar, byggnadskonturer etc. Lägg till sådana kategorier direkt till &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Kontrollera vår &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; för detaljerade steg-för-steg-instruktioner.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Du har inte laddat ner några kartor</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Ladda ner kartor för att hitta platsen och navigera offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Den nuvarande platsen är okänd.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/tim</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mi/tim</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>tim</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Mer</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Redigera bokmärke</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personlig anteckning (text eller html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Kommentar…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Återställ alla lokala ändringar?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Återställ</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Ta bort en tillagd plats?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Ta bort</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Platsen finns inte</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Vänligen förklara varför platsen raderas</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Ange korrekt telefonnummer</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Ange en giltig webbadress</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Ange en giltig e-postadress</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Ange en giltig Facebook-webbadress, ett giltigt konto eller ett giltigt sidnamn</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Ange ett giltigt Instagram-användarnamn eller en giltig webbadress</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Ange ett giltigt Twitter-användarnamn eller en giltig webbadress</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Ange ett giltigt VK-användarnamn eller en giltig webbadress</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Ange ett giltigt LINE-ID eller en giltig webbadress</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Lägg till plats i OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Eller, alternativt, lämna en anteckning till OpenStreetMap community så att någon annan kan lägga till eller fixa en plats här.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Notering kommer att skickas till OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Vill du skicka det till alla användare?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Var noga med att inte ange privata eller personliga uppgifter.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap-redigerare kommer att kontrollera ändringarna och kontakta dig om de har några frågor.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stopp</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Registrering av spåret</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Acceptera</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Neka</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Använd mobilt nätverk för att visa detaljerad information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Använd alltid</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Endast idag</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Använd inte idag</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobilt internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobilt internet krävs för att visa detaljerad information om platser, som t. ex. fotografier, priser och omdömen.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Använd aldrig</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Fråga alltid</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Kartor måste uppdateras för att visa trafikdata.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Öka teckenstorlek på kartan</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Uppdatera Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Trafikdata är inte tillgänglig</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Aktivera loggning</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Allmän feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Vi använder TTS-system för röstinstruktioner. Flera Android-enheter använder Google TTS. Du kan ladda ned eller uppdatera det på Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>För vissa språk måste du installera en annan talsyntes eller ett annat språkpaket från appbutiken (Google Play Market, Galaxy Store).
+Öppna inställningarna på enheten → Språk och inmatning → Tal → Text till tal-uppspelning.
+Här kan du hantera inställningarna för talsyntes (till exempel, ladda ned språkpaket för användning offline) och välja en annan text till tal-motor.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Kolla in den här guiden för mer information.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Translitterera till latinska alfabetet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Läs mer</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Använd sökfunktionen eller tryck på kartan för att lägga till en startpunkt för rutten</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Använd sökfunktionen eller tryck på kartan för att lägga till en destinationspunkt</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Hantera rutt</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Planera</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Ta bort stoppet</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Lägg till stopp</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Sparade</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Logga in på OpenStreetMap för att automatiskt ladda upp alla dina kartredigeringar. Läs mer &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;här&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Lagringsåtkomstproblem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Extern lagring är inte tillgänglig. SD-kortet kan vara borttaget, skadat eller så är filsystemet skrivskyddat. Kontrollera det och kontakta oss på support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulera dålig lagring</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Ange ett korrekt namn</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listor</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Dölj alla</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Visa alla</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bokmärke</numerusform>
+<numerusform>%n bokmärken</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Skapa ny lista</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Importera bokmärken och spår</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Kunde inte delas på grund av ett applikationsfel</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Delningsfel</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Kan inte dela en tom lista</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Namnet kan inte vara tomt</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Vänligen ange listnamnet</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Ny lista</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Det här namnet är redan taget</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Vänligen välj ett annat namn</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Vänligen vänta…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefonnummer</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profil</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n fil hittades. Du kommer att se den efter omvandlingen.</numerusform>
+<numerusform>%n filer hittades. Du kommer att se dem efter omvandlingen.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Återställa</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n spår</numerusform>
+<numerusform>%n spår</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Integritet</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Integritetspolicy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Allmänna villkor</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafik</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Vandring</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cykling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Tunnelbana</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kartstilar och lager</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Listan är tom</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>För att lägga till bokmärken, tryck på kartan och sedan på stjärnikonen</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Ändra färg på alla bokmärken</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Ändra färg på alla spår</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…mer</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Exportera KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Exportera GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Exportera GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Radera listan</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Hastighetskameror</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Beskrivning av platsen</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kartnedladdning</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Varna vid fortkörning</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Varna alltid</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Varna aldrig</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Energisparläge</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Försök att begränsa strömförbrukningen på bekostnad av vissa funktioner.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Aldrig</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Vid lågt batteri</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Alltid</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bokmärk namn på kartan</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Om det finns för många bokmärken kan det göra appen långsammare att visa namnen på dem på kartan.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Visa till höger</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Visa längst ner</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Aktivera denna funktion för att logga detaljer för diagnostiska ändamål. Detta hjälper utvecklarna att identifiera problem med appen. Slå på funktionen endast på begäran av Organic Maps supporttjänst.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Ruttinställningar</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Undvik avgiftsbelagda vägar</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Undvik oasfalterade vägar</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Undvik färjetrafik</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Undvik motorvägen</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Det går inte att hitta rutt</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Tyvärr kunde vi inte hitta en rutt. Detta kan bero på dina ruttpreferenser eller ofullständigt kartunderlag i OpenStreetMap. Ändra gärna dina val och försök igen.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Definiera oönskade vägar</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Ruttinställningar aktiverade</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Betalväg</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Oasfalterad väg</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Färjetrafik</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ja</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapacitet: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Nätverk: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Du är framme!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sortera…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sortera bokmärken</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Som standard</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Efter typ</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Efter avstånd</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Efter datum</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Efter namn</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>En vecka sedan</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>En månad sedan</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Över en månad sedan</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Över ett år sedan</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Nära mig</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Andra</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Ruttplaneringen misslyckades</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Ankomst: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Du har ändrat världskartan. Dela det med dina vänner och redigera den tillsammans.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Dela med vänner</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Stängt just nu</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Öppnar i morgon på %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Öppnar %1 vid %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Öppnas vid %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Stänger vid %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Lägg till öppettider</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Lösenord (minst 8 tecken)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Fel användarnamn eller lösenord.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM-konto</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Senaste uppladdning</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Tack</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Platsens namn</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Observera</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Nedladdningsfel</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Välj kategori</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Populärt</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Alla kategorier</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Lägg till nya platser på kartan och redigera de befintliga direkt i appen.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Ändra plats</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Du behöver mer utrymme för att ladda ned. Radera onödig data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Jag förbättrade kartorna åt Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detaljerad kommentar</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Dina föreslagna ändringar kommer att skickas till OpenStreetMap-communityt. Beskriv detaljerna som inte kan redigeras i Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Ett fel inträffade när din plats försökte hittas. Kontrollera att din enhet fungerar och försök igen senare.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Platsidentifiering avaktiverad</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aktivera tillgång till geografisk plats i enhetens inställningar</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Öppna inställningar</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tryck på Plats</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Välj Medan appen används</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Välj Sekretess</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Välj Platstjänster</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Aktivera platstjänster</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Eller fortsätt använda Organic Maps utan Plats</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Boka</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Ring</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bokmärkesnamn</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Radera bokmärke</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Din anteckning kommer att skickas till OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…mer</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Uppdatera</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Stäng av inspelningen av din senaste rutt?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Avaktivera</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Kolla in</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps använder din geografiska position i bakgrunden för att spela in din senaste resta rutt.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Allmänna inställningar</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Applikationen måste uppdateras för att trafikdata ska kunna visas.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Loggfilens storlek: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Dra hit för att ta bort</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Byt ut stopp</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Starta från</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Logga in på OpenStreetMap för att automatiskt ladda upp alla dina kartredigeringar. Läs mer</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>här</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Dölj skärm</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 av %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Ladda ned %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Tillämpar %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Det här namnet är för långt</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Nya filer upptäcktes</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Konvertera</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Fel</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Vissa filer konverterades inte.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Ett fel har uppstått</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Populär</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Dölj från karta</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Ett fel uppstod när taggarna laddades, försök igen</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Rätt</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Botten</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Nu åker vi</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Placera i mitten</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Sökresultat</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Sedan</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Vill du räkna om rutten?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Tangentbordet är inte tillgängligt vid körning</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Det gick inte att hitta en rutt från nuvarande plats</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Det går inte att hitta en rutt till målet. Välj en annan</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Ingen GPS-signal. Flytta dig till ett öppet område</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Det går inte att hitta en rutt. Välj andra punkter</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>För att hitta en rutt, ladda ner saknade kartor på din enhet</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Ett fel uppstod. Starta om appen</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Rutten kommer att räknas om från din nuvarande plats</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Rutten kommer att ändras till bil</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Alla bokmärken visas inte</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Växla till telefonen för att se alla bokmärken</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Fartkameror</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Info om fartkameror</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Ladda ner kartor i appen på din enhet</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 utgången</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sortera efter förvald ordning</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sortera efter typ</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sortera efter avstånd</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sortera efter datum</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sortera efter namn</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Mat</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sevärdheter</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museer</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parker</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Simning</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Berg</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Djur</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotell</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Byggnader</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Pengar</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Butiker</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parkeringsplatser</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Bensinstationer</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicin</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Sök i listan</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Heliga platser</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Välj lista</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Tunnelbanenavigering är ännu inte tillgängligt i denna region</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Tunnelbanerutt hittades inte</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Välj ruttens start- eller mål närmare en tunnelbanestation</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Terräng</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Om du vill använda höjdlinjer, uppdatera eller ladda ner en karta över önskat område</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Höjdkurvor är ännu inte tillgängliga i det här området</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Stigning</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Backe</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. höjd</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. höjd</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Svårighet</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Avst.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Tid:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Förstora kartan för att se höjdlinjer</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Nedladdning</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Ladda ner översiktskartan för hela världen</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Det går inte att skapa mappar och flytta filer på den interna enhetens minne eller sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Diskfel</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Anslutningen bröts</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Koppla ur USB-kabel</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Behåll skärmen på</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Vid aktivering kommer skärmen alltid att vara på när kartan visas.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Visa på låsskärmen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>När den är aktiverad fungerar appen på låsskärmen även när enheten är låst.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Kartspråk</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Kartdata från OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/sv/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/sv/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Tack för att du använder våra community-byggda kartor!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Med dina donationer och stöd kan vi skapa de bästa kartorna i världen!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Gillar du vår app? Vänligen donera för att stödja utvecklingen! Gillar du den inte ännu? Meddela oss, så fixar vi det!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Om du känner en mjukvaruutvecklare kan du be honom eller henne att implementera en funktion som du behöver.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tryck var som helst på kartan för att välja något. Tryck länge för att dölja och visa gränssnittet igen.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Vet du att du kan välja din nuvarande plats på kartan?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Du kan hjälpa till att översätta vår app till ditt språk.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Vår app är utvecklad av ett fåtal entusiaster och communityn.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Du kan enkelt fixa och förbättra kartdata.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Vårt huvudmål är att bygga snabba, integritetsfokuserade, lättanvända kartor som du kommer att älska.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Du använder nu Organic Maps på telefonens skärm</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Du använder nu Organic Maps på bilskärmen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Du är ansluten till Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Fortsätt i telefonen</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Till bilens skärm</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps behöver platsåtkomst. När det är säkert kan du kontrollera aviseringen på din telefon.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Denna app behöver ditt tillstånd</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps i Android Auto behöver tillgång till platsinformation för att fungera effektivt</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Tilldela behörigheter</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Vandring</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Webbläsaren är inte tillgänglig</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volym</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Exportera alla bokmärken och spår</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Inställningar för talsyntes</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Inställningar för talsyntes hittades inte, är du säker på att din enhet stöder det?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-thru</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Rensa sökning</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zooma in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zooma ut</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Länk till meny</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Visa meny</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Öppna i en annan app</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Självbetjäning</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Välj alternativ</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Sittplatser utomhus</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>För att få den mest exakta navigeringen rekommenderar vi att du avaktiverar energisparläget i telefonens batteriinställningar.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Spela in spår</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stoppa inspelning av spår</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Inspelning av rutt</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stoppa utan att spara</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Fortsätt spela in</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Spara inspelning i bokmärken och rutter?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Routen är tom - inget att spara</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Det går inte att visa dialogrutan för val av mapp eftersom ingen lämplig app är installerad på din enhet. Installera en filhanteringsapp och försök igen.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Välj färg</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Redigera spår</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Ingen app installerad som kan öppna platsen</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto i navigering</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Följ systemet</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Dela spår</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Radera %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Svårighetsgrad</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Lätt</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Måttlig</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Svår</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Uppdaterar</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Uppdatera dina nedladdade kartor</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Kartuppdatering håller informationen om objekt aktuell</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Uppdatera (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Uppdatera senare manuellt</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Radera spår</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Är du säker på att du vill radera det här spåret?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Spårets namn</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Flytta</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Rutt</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Ändra färg</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Karta</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Vill du skicka en felrapport till utvecklarna?
+Vi förlitar oss på våra användare eftersom organiska kartor inte samlar in någon felinformation automatiskt. Tack på förhand för att du stöder Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Aktivera iCloud-synkronisering</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud-synkronisering är en experimentell funktion under utveckling. Se till att du har gjort en säkerhetskopia av alla dina bokmärken och spår.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud är inaktiverat</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Aktivera iCloud i enhetens inställningar för att kunna använda denna funktion.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Aktivera</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Säkerhetskopiering</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>fel i iCloud-synkroniseringen</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Fel: Synkronisering misslyckades på grund av anslutningsfel</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Fel: Synkronisering misslyckades på grund av att iCloud-kvoten överskreds</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Fel: iCloud är inte tillgängligt</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Nyligen borttagna listor</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Rensa</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Radera alla</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Återställ</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Återställ allt</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Bidra till OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Lägg till plats</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Uppdatera kartan för att bidra</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Du måste uppdatera %1-kartan till den senaste versionen innan du kan bidra till OpenStreetMap-data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Min position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Mina Platser</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internt, privat lagringsutrymme</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internt, delat lagringsutrymme</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-kort</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Externt, delat lagringsutrymme</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postkod</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Kartpunkt</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mile</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>fot</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>För att visa rutter måste kartorna uppdateras.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Avsluta</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Ingång</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Tunnelbanekartan är otillgänglig</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Du</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Lila nedladdade regioner</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rutt</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Att fastställa aktuell position i bakgrunden är nödvändigt för att fullt ut använda funktionaliteten hos appen. Det används när en rutt ska följas och när din senaste resväg skall sparas.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Definitionen av aktuell plats används i vissa funktioner som t.ex. att spåra rutt eller att spara nyligen tillryggalagda rutter.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Logga in med lösenord</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Logga in med hjälp av en webbläsare</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Senast använda</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bokmärkesfärg ändrad</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Spårfärg ändrad</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Skjutreglage</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>RÖD</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>GRÖN</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLÅ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Hex färg #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Rutnät</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/sw/omim.ts
+++ b/qt/translations/sw/omim.ts
@@ -1,0 +1,3926 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="sw">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Rudi nyuma</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Futa</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Futa</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Pakua Ramani</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Upakuaji umeshindikana. Gusa ili kujaribu tena.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Inapakua…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilomita</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Maili</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Baadaye</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Tafuta</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Tafuta Ramani</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Kwa sasa umezima huduma zote za eneo kwa kifaa hiki au programu hii. Tafadhali ziwashe katika Mipangilio.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Usahihi mdogo</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Ili kuhakikisha urambazaji sahihi huwezesha eneo sahihi katika mipangilio.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Onyesha kwenye ramani</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Upakuaji umeshindikana</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Jaribu tena</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Kuhusu Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Bure kwa kila mtu, iliyotengenezwa na upendo</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Hakuna matangazo, hakuna ufuatiliaji, hakuna mkusanyiko wa data</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Hakuna betri kuisha, inafanya kazi nje ya mtandao</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Haraka, minimalist, iliyotengenezwa na jumuiya</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Maombi ya chanzo-wazi iliyoundwa na wanaovutia na wanaojitolea.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Mipangilio ya mahali</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Funga</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Programu inahitaji OpenGL iliyoharakishwa na vifaa. Kwa bahati mbaya, kifaa chako hakijaungwa mkono.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Pakua</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Tafadhali toa kebo ya USB au weka kadi ya kumbukumbu ili kutumia Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Tafadhali toa nafasi kidogo kwenye kadi ya SD/hifadhi ya USB kwanza ili kutumia programu</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Kabla ya kuanza kutumia programu, tafadhali pakua ramani ya muhtasari wa dunia kwenye kifaa chako.  Itatumia %1 ya hifadhi.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Nenda kwenye Ramani</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Inapakua %1. Sasa unaweza kuendelea kwenye ramani.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Pakua %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Sasisha %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Sitisha</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Endelea</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 upakuaji umeshindikana</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Ongeza Orodha Mpya</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Jina la Orodha ya Alamisho</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Alamisho</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Alamisho na Njia</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Jina</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Anwani</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Orodha</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Mipangilio</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Hifadhi ramani kwenye</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Chagua folda ya kupakua ramani.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Ramani zilizopakuliwa</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 bure kati ya %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Hamisha ramani?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Hitilafu katika kuhamisha faili za ramani</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Hii inaweza kuchukua dakika kadhaa. Tafadhali subiri…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Vipimo</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Chagua kati ya maili na kilomita</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Futa Upakuaji</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Acha maoni</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Ndiyo</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Pakua Ramani</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Orodha za Alamisho</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Sehemu ya kula</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Migahawani</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Usafiri</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Mafuta</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Maegesho</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Manunuzi</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Mtumba</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hoteli</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Vivutio</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Burudani</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Shughuli za usiku</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Mapumziko ya familia</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Benki</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Duka la dawa</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospitali</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Choo</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polisi</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Urejelezaji</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Maji</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Kwa RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Maelezo</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps alama za ukurasa zimeshirikiwa nawe</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Habari!
+
+Nimeambatanisha alamisho zangu; tafadhali zifungue kwenye Organic Maps. Ikiwa haujaweka, unaweza kupakua hapa: https://omaps.app/get?kmz
+
+Furahia kusafiri na Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Inapakia alamisho</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Alama za ukurasa zimepakia kwa mafanikio! Unaweza kuzipata kwenye ramani au kwenye skrini ya Meneja wa Alama za ukurasa.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Imeshindwa kupakia alamisho. Faili linaweza kuwa limeharibika au lenye kasoro.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Aina ya faili haitambuliwi na programu:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Imeshindwa kufungua faili %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Hariri</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Mahali pako bado halijabainishwa</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Samahani, mipangilio ya Uhifadhi wa Ramani imezimwa kwa sasa.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Upakuaji wa ramani unaendelea sasa.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Angalia eneo langu la sasa kwenye Organic Maps! %1 au %2 Huna ramani za nje ya mtandao? Pakua hapa: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, angalia alama yangu katika Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, angalia eneo langu la sasa kwenye ramani ya Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Habari,  Kwa sasa niko hapa: %1. Bofya kiungo hiki %2 au hiki %3 ili kuona mahali kwenye ramani.  Asante.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Shiriki</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Barua pepe</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Ime nakiliwa kwenye kibao cha kunakili: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Imekamilika</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Data ya OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Je, una uhakika unataka kuondoka kwenye akaunti yako ya OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Njia</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Urefu</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Shiriki Mahali Pangu</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Mipangilio ya jumla</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Taarifa</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Uelekezi</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Vifungo vya &quot;+&quot; na &quot;-&quot; kwenye ramani</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Onyesha kwenye ramani</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Mtindo wa usiku unapovinjari gizani</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Modo ya Usiku</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Imewezwa</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Wakati</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Mtazamo wa mtazamo</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Majengo ya 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Majengo ya 3D yamezimwa katika hali ya kuokoa nishati</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Tangaza Majina ya Mitaa</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Tangaza Majina ya Mitaa</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Ikiwashwa, jina la barabara au la kutoka ili kuwasha litasemwa kwa sauti.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Lugha ya Sauti</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Ili kupakua sauti ya ubora wa juu, fungua programu ya Mipangilio na uende kwenye Ufikivu → VoiceOver → Matamshi → Sauti.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Jaribu maelekezo ya sauti (TTS, maandishi-kwa-hotuba)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Angalia mipangilio ya sauti au ya mfumo ya kubadilisha maandishi-hadi-hotuba ikiwa husikii sauti sasa.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Haipatikani</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Kuzoom kiotomatiki</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Umbali</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Tazama kwenye ramani</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menyu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Tovuti</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Habari</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Maoni</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Tathmini programu</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Msaada</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Maswali na majibu</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Changia</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Tayari kutoa</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Kumbusha baadaye</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Usaidizi Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Saidia mradi</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Hakimiliki</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Ripoti hitilafu</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Boresha mwelekeo wa mshale kwa kusogeza simu kwa mzunguko wa nane ili kurekebisha kompasi.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Sogeza simu kwa mzunguko wa namba nane ili kurekebisha kompasi na kuweka mwelekeo wa mshale kwenye ramani.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Gusa kwa muda mrefu kwenye ramani tena ili kuona kiolesura</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Sasisha Zote</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Futa Zote</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Iliyopakuliwa</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Imeorodheshwa</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Karibu nami</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Ramani</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Pakua Zote</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Inapakia:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Ili kufuta ramani, tafadhali simamisha urambazaji.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Njia zinaweza kuundwa tu ambazo zimejumuishwa kikamilifu ndani ya ramani ya eneo moja.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Pakua ramani</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Jaribu tena</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Futa Ramani</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Sasisha Ramani</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Huduma za Mahali za Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Tambua kwa haraka kadirio la eneo lako kwa kutumia Bluetooth, WiFi au mtandao wa simu</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Pakua ramani zote katika njia yako</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Ili kuunda njia, tunahitaji kupakua na kusasisha ramani zote kutoka eneo lako hadi eneo lako la mwisho.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Hakuna nafasi ya kutosha</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Tafadhali wezesha Huduma za Mahali</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Hifadhi</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>unda</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Nyekundu</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Ujani</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Bulu</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Kijani</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Zambarau</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Rangi ya machungwa</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Kijivu</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Rangi ya waridi</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Zambarau Iliyoiva</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Buluu Hafifu</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Siani</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Chokaa</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Chungwa Iliyokoza</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Kijivu</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Kijivu Buluu</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Taarifa</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Toleo la Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Muonekano</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Mwangaza</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Giza</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Maudhui mepesi kutoka alfajiri hadi machweo</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Mengine</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Zawadia mamilioni ya watumiaji ramani za bure bila matangazo!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Ripoti au urekebishe data isiyo sahihi ya ramani</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Kujitolea</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Fuata na uwasiliane nasi:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Mteja wa barua pepe haujaanzishwa. Tafadhali usanidi au wasiliana nasi kwa %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Hitilafu katika kutuma barua pepe</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Kalibresheni ya kompasi</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Inapatikana</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Imepatikana</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Sasisha</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Imeshindikana</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>alama ya ukurasa</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Unapofuata njia, tafadhali kumbuka:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Hali za barabara, sheria za trafiki, na alama za barabara daima hupewa kipaumbele kuliko vidokezo vya urambazaji;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Ramani inaweza kuwa isiyo sahihi, na njia iliyopendekezwa inaweza isiokuwa kila mara njia bora zaidi ya kufika kwenye eneo lengwa;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Njia zilizopendekezwa zinapaswa kuchukuliwa tu kama mapendekezo;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Kuwa mwangalifu na njia katika maeneo ya mpaka: njia zinazotengenezwa na programu yetu wakati mwingine zinaweza kuvuka mipaka ya nchi katika maeneo yasiyoidhinishwa.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Tafadhali kuwa macho na salama barabarani!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Angalia ishara ya GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Haiwezekani kuunda njia. Kuratibu za sasa za GPS hazikuweza kutambuliwa.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Tafadhali angalia ishara yako ya GPS. Kuwasha Wi-Fi kutaboresha usahihi wa eneo lako.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Washa huduma za eneo</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Haiwezi kupata kuratibu za GPS za sasa. Washa huduma za eneo ili kuhesabu njia.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Haikuweza kupata njia</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Haiwezekani kuunda njia.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Tafadhali rekebisha mahali pa kuanzia au la kufika.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Rekebisha kituo cha kuanzia</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Njia haikuundwa. Haiwezekani kupata sehemu ya kuanzia.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Tafadhali chagua sehemu ya kuanzia karibu zaidi na barabara.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Rekebisha eneo la kuelekea</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Njia haikuundwa. Haiwezekani kupata eneo la mwisho.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Tafadhali chagua kituo cha mwisho kilicho karibu zaidi na barabara.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Imeshindwa kupata eneo la kati.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Tafadhali badilisha eneo lako la kati.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Hitilafu ya mfumo</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Haiwezekani kuunda njia kutokana na hitilafu ya programu.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Tafadhali jaribu tena</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Sio sasa</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Je, ungependa kupakua ramani na kuunda njia bora zaidi inayojumuisha ramani zaidi ya moja?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Pakua ramani za ziada ili kuunda njia bora inayovuka mipaka ya ramani hii.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Pakua faili zinazohitajika</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Pakua au sasisha ramani zote kando ya njia iliyopangwa ili kuhesabu njia.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Ili kuanza kutafuta na kuunda njia, tafadhali pakua ramani. Baada ya hapo hautahitaji tena muunganisho wa Intaneti.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Chagua Ramani</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Onyesha</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ficha</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Vipengele</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Historia</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Lo, hakuna matokeo yaliyopatikana.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Pakua eneo ambalo unatafuta au jaribu kuongeza jina la mji/kijiji kilicho karibu.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Historia ya Utafutaji</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Tazama utafutaji wako wa hivi karibuni.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Futa historia ya utafutaji</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Makala kutoka wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Mahali Pako</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Anza</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Njia kutoka</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Njia ya</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Uelekezi unapatikana tu kutoka eneo lako la sasa.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Je, unataka kupanga njia kutoka mahali ulipo sasa?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Ifuatayo</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Kutoka</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Kwa</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Ongeza ratiba</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Futa ratiba</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Siku nzima (masaa 24)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Fungua</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Imefungwa</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Ongeza Masaa Yasiyo ya Biashara</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Saa za biashara</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Hali ya Juu</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Modhi Rahisi</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Masaa yasiyo ya biashara</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Mifano ya Thamani</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Sahihisha kosa</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Chagua Mahali</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Tafadhali elezea tatizo kwa undani ili jamii ya OpenStreetMap iweze kulirekebisha.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Au fanya mwenyewe kwenye https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Tuma</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Tatizo</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Mahali hapa hakipo</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Imefungwa kwa ajili ya matengenezo</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Mahali maradufu</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Pakua ramani kiotomatiki</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Kila siku</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Imefungwa leo</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Imefungwa</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Leo</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Inafunguka katika %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Inakaribia kwa %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Imefungwa</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Hariri saa za biashara</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Huna akaunti ya OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Jisajili kwenye OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Ingia</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Hujasajiliwa</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Ingia kwa OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Nenosiri</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Umesahau nenosiri lako?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Toka</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Hariri Mahali</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Ongeza lugha</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Mtaa</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Nambari ya jengo</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Maelezo</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Mitandao ya Kijamii</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Jengo</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Ongeza barabara</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Tafadhali ingiza jina la barabara</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Chagua lugha</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Chagua barabara</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Upishi</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Chagua aina ya chakula</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Barua pepe au jina la mtumiaji</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Ongeza Simu</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Ghorofa</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Kiwango: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Marekebisho yako yote ya ramani yatafutwa pamoja na ramani.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Sasisha Ramani</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Ili kuunda njia, unahitaji kusasisha ramani zote kisha kupanga tena njia.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Tafuta ramani</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Tafadhali hakikisha kifaa chako kimeunganishwa na Intaneti.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Hakuna nafasi ya kutosha</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Tafadhali futa data yoyote isiyo ya lazima</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Hitilafu ya kuingia.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Mabadiliko yaliyothibitishwa</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Buruta ramani ili kuweka msalaba katika eneo la mahali au biashara.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Uhariri</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Kuongeza</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Jina la mahali</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Kama ilivyoandikwa katika lugha ya kienyeji</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategoria</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Maelezo ya kina ya tatizo</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Tatizo tofauti</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Ongeza biashara</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Hakuna kitu kinachoweza kupatikana hapa</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Data ya OpenStreetMap iliyoundwa na jumuiya kufikia %1. Pata maelezo zaidi kuhusu jinsi ya kuhariri na kusasisha ramani katika OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) ni mradi wa jamii wa kuunda ramani huru na wazi. Ni chanzo kikuu cha data za ramani katika Organic Maps na inafanya kazi kwa njia inayofanana na Wikipedia. Unaweza kuongeza au kuhariri maeneo na yanapatikana kwa mamilioni ya watumiaji kote ulimwenguni. Jiunge na jamii na usaidie kutengeneza ramani bora kwa kila mtu!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Fungua akaunti ya OpenStreetMap au ingia ili kuchapisha mabadiliko yako ya ramani kwa ulimwengu.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Pakua kupitia muunganisho wa mtandao wa selula?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Hii inaweza kuwa ghali sana kwa baadhi ya mipango au ikiwa uko kwenye roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Weka nambari halali ya jengo</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Idadi ya ghorofa (kiwango cha juu cha %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Idadi ya ghorofa haipaswi kuzidi %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Msimbo wa posta</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Weka msimbo halali wa posta</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Kumbuka kwa wanaojitolea wa OpenStreetMap (si lazima)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Eleza makosa kwenye ramani au vitu ambavyo haviwezi kuhaririwa kwa kutumiaOrganic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Mabadiliko yako yanapakiwa kwenye hifadhidata ya &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; ya umma. Tafadhali usiongeze maelezo ya kibinafsi au yenye hakimiliki.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Zaidi kuhusu OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Historia yako ya uhariri</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Vidokezo vya data ya ramani yako</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Mwendeshaji</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Mwendeshaji: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Je, huwezi kupata aina inayofaa?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps inakuwezesha kuongeza tu aina rahisi za alama, ikimaanisha hakuna miji, barabara, maziwa, mipaka ya majengo, n.k. Tafadhali ongeza aina hizo moja kwa moja kwenye &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Angalia &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;mwongozo&lt;/a&gt; wetu kwa maelekezo ya kina hatua kwa hatua.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Haujapakua ramani yoyote</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Pakua ramani ili kutafuta na kuvinjari bila muunganisho.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Mahali pa sasa halijulikani.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>maili kwa saa</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>kidogo</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Zaidi</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Hariri alama ya ukurasa</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Vidokezo vya kibinafsi (maandishi au HTML)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Maoni…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Tupa mabadiliko yote ya ndani?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Tupa</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Futa mahali palioongezwa?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Futa</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Mahali hakipo</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Tafadhali eleza sababu ya kufuta mahali hapo</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Weka nambari ya simu halali</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Weka anwani halali ya wavuti</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Weka barua pepe halali</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Weka anwani halali ya Facebook mtandaoni, akaunti, au jina la ukurasa</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Ingiza jina halali la mtumiaji la Instagram au anwani ya wavuti</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Ingiza jina halali la mtumiaji wa Twitter au anwani ya wavuti</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Ingiza jina halali la mtumiaji la VK au anwani ya wavuti</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Weka LINE ID halali au anwani ya wavuti</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Ongeza Mahali kwa OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Au, vinginevyo, acha ujumbe kwa jamii ya OpenStreetMap ili mtu mwingine aweze kuongeza au kurekebisha mahali hapa.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Kumbuka itatumwa kwa OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Je, unataka kuwatuma watumiaji wote?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Hakikisha haukuingiza data yoyote ya faragha au ya kibinafsi.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Wahariri wa OpenStreetMap watakagua mabadiliko na kuwasiliana nawe ikiwa wana maswali yoyote.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Simama</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Kurekodi wimbo</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Kubali</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Kataa</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Tumia intaneti ya simu kuonyesha taarifa za kina?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Tumia Daima</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Leo tu</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Usitumie Leo</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Intaneti ya simu</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Intaneti ya simu inahitajika kwa arifa za masasisho ya ramani na kupakia marekebisho.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Usitumie kamwe</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Daima Uliza</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Ili kuonyesha data za trafiki, ramani lazima zisasishwe.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Ongeza ukubwa wa lebo za ramani</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Tafadhali sasisha Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Takwimu za trafiki hazipatikani</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Wezesha kurekodi</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Maoni Jumla</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Tunatumia maagizo ya sauti ya TTS ya mfumo. Vifaa vingi vya Android vinatumia Google TTS, unaweza kuipakua au kuisasisha kwenye Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Kwa baadhi ya lugha, utahitaji kusakinisha programu nyingine ya kusanidi usemi au kifurushi cha ziada cha lugha kutoka kwenye duka la programu-tumizi (Google Play, Galaxy Store, App Gallery, FDroid).
+Fungua mipangilio ya kifaa chako → Lugha na Ingizo → Usemi → Tokeo la maandishi kuwa usemi.
+Hapa unaweza kusimamia usanidi wa usemi (kwa mfano, kupakua kifurushi cha lugha ili utumie nje ya mtandao) na uchague injini nyingine ya maandishi-kuwa-usemi.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Kwa maelezo zaidi tafadhali tazama mwongozo huu.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Tafsiri kwa lugha ya Kilatini</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Jua mengi zaidi</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Tumia utafutaji au uguse kwenye ramani ili kuongeza mahali pa kuanzia</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Tumia utafutaji au uguse kwenye ramani ili kuongeza mahali unakoenda</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Dhibiti njia ya kufuata</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Panga</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Ondoa eneo la kusimama</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Ongeza eneo la kusimama</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Imehifadhiwa</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Tafadhali ingia kwenye OpenStreetMap ili kupakia kiotomatiki hariri zako zote za ramani. Pata maelezo zaidi &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;hapa&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Tatizo la kufikia hifadhi</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Hifadhi ya nje haipatikani, pengine Kadi ya SD imeondolewa, imeharibika au mfumo wa faili ni wa kusoma pekee. Tafadhali ikague na uwasiliane nasi kwa kutumia support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Onyeshana hifadhi mbaya</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Tafadhali, weka jina sahihi</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Orodha</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ficha zote</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Onyesha zote</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n alamisho</numerusform>
+<numerusform>%n alamisho</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Unda orodha mpya</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Ingiza alamisho na nyimbo</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Haiwezekani kushiriki kutokana na hitilafu ya programu</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Hitilafu ya kushiriki</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Haiwezekani kushiriki orodha tupu</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Jina halikuweza kuwa tupu</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Tafadhali ingiza jina la orodha</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Orodha mpya</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Jina hili tayari limechukuliwa</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Tafadhali chagua jina lingine</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Tafadhali subiri…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Nambari ya simu</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Wasifu wa OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>Faili %n ilipatikana. Utaiona baada ya uongofu.</numerusform>
+<numerusform>Files %n zimepatikana. Utaziona baada ya uongofu.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Rejesha</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>Njia %n</numerusform>
+<numerusform>Njia %n</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Faragha</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Sera ya faragha</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Masharti ya matumizi</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafiki</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Utengenezaji wa njia za kupanda milima</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Baiskeli</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Njia ya chini</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Mitindo ya Ramani na Tabaka</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Orodha hii ni tupu</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Ili kuongeza ramani, gusa mahali kwenye ramani na kisha gusa ikoni ya nyota</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Badilisha rangi ya alamisho zote</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Badilisha rangi ya njia zote</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…zaidi</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Hamisha KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Hamisha GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Hamisha GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Futa Orodha</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Kamera za mwendo-kasi</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Maelezo ya Eneo</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Kipakua Ramani</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Onya kuhusu mwendo kasi</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Daima onya</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Kamwe usionye</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Mtindo wa kuokoa nishati</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Pindi mtindo wa kiotomatiki unapochaguliwa programu tumizi inaanza kuzima sifa za kumaliza betri kulingana na kiwango cha chaji cha sasa cha betri</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Kamwe</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Kiotomatiki</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Upeo wa kuhifadhi nishati</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Majina ya alamisho kwenye ramani</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Ikiwa kuna alamisho nyingi sana, kuonyesha majina yao kwenye ramani kunaweza kupunguza kasi ya programu.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Onyesha upande wa kulia</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Onyesha chini</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Chaguo huwasha data kwa madhumuni ya uchunguzi. Itakuwa muhimu kwa wafanyakazi wetu ambao wanatatua matatizo ya programu. Washa chaguo hili kwa maombi ya mhudumu wa Organic Maps tu.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Machaguo ya njia</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Epuka barabara za ushuru</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Epuka barabara za vumbi</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Epuka vivuko vya feri</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Epuka barabara</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Haiwezi kukokotoa njia</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Bahati mbaya hatukuweza kupata njia labda kwa sababu ya machaguo msingi. Tafadhali badili mipangilio na jaribu tena</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Fafanua njia za kuziepuka</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Machaguo ya njia yamewezeshwa</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Barabara ya kulipia</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Barabara ya vumbi</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Kivuko cha feri</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Ndio</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Hapana</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Ndio</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Hapana</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Uwezo: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Mtandao: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Umefika!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Sawa</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Ainisha…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Ainisha alamisho</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Kwa chaguo-msingi</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Kwa aina</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Kwa umbali</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Kwa tarehe</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Kwa Jina</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Wiki moja iliyopita</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Mwezi mmoja uliopita</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Zaidi ya mwezi mmoja uliopita</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Zaidi ya mwaka mmoja uliopita</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Karibu yangu</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Nyingine</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Uratibu wa njia umeshindikana</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Uwasili katika %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Pakua na sasisha ramani zote kando ya njia iliyotabiriwa ili kuhesabu njia.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Umeibadilisha ramani ya dunia! Usibaki nayo peke yako; waambie marafiki zako na mhariri pamoja.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Shiriki na marafiki</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Imefungwa sasa</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Inafunguliwa kesho saa %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Hufungua %1 katika %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Hufunguka saa %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Inafungwa saa %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Ongeza saa za ufunguzi</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Nenosiri (angalau herufi 8)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Jina la mtumiaji au nenosiri si halali.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Akaunti ya OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Upakiaji wa mwisho</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Asante</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Jina la Mahali</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Simu</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Tafadhali kumbuka</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Hitilafu ya upakuaji</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Chagua kategoria</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Maarufu</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Kategoria Zote</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Ongeza maeneo mapya kwenye ramani, na uhariri yale yaliyopo moja kwa moja kutoka kwenye programu.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Badilisha eneo</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Ili kupakua, unahitaji nafasi zaidi. Tafadhali futa data yoyote isiyo ya lazima.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Niliboresha ramani za &#x27;Organic Maps&#x27;</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Maoni ya kina</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Mabadiliko ya ramani uliyopendekeza yatawasilishwa kwa jamii ya OpenStreetMap. Tafadhali elezea maelezo yoyote ya ziada ambayo hayawezi kuhaririwa katika Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Hitilafu ilitokea wakati wa kubaini eneo lako. Hakikisha kifaa chako kinafanya kazi ipasavyo na jaribu tena baadaye.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Huduma za eneo zimezimwa</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Wezesha upatikanaji wa geolocation katika mipangilio ya kifaa</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Fungua Mipangilio</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Gusa Mahali</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Chagua Wakati wa Kutumia Programu</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Chagua Faragha</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Chagua Huduma za Mahali</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Washa Huduma za Mahali</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Au endelea kutumia Organic Maps bila Mahali</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Kitabu</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Piga simu</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Jina la alama ya ukurasa</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Futa alama ya ukurasa</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Dokezo lako litatumwa kwa OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…zaidi</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Sasisha</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Zima kurekodi njia yako uliyopita hivi karibuni?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Zima</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Angalia</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps inatumia eneo lako kwa nyuma ili kurekodi njia uliyopita hivi karibuni.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Mipangilio ya jumla</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Ili kuonyesha data za trafiki, programu lazima isasishwe.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Ukubwa wa faili ya kumbukumbu: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Vuta hapa ili kuondoa</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Badilisha Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Anzia</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Tafadhali ingia kwenye OpenStreetMap ili kupakia kiotomatiki hariri zako zote za ramani. Pata maelezo zaidi</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>hapa</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ficha skrini</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 kati ya %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Inapakua %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Inatekeleza %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Jina hili ni muda mrefu sana</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Faili mpya zimegunduliwa</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Badilisha</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Hitilafu</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Baadhi ya faili hazibadilishwa.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Kosa limetokea</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Maarufu</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ficha kwenye ramani</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Kosa limetokea wakati wa kupakua vibandiko, tafadhali jaribu tena</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Sahihi</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Chini</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Twende zetu</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Mahali</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Weka kati tena</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Matokeo ya utafutaji</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Kisha</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Je, unataka kuunda upya njia?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Mbao-bonye haipatikani wakati wa kuendesha gari</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Haiwezi kuunda njia kutokea kwenye eneo lako la sasa</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Haiwezi kuunda njia kwenda uendako. Tafadhali chagua sehemu nyingine</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Hakuna ishara ya GPS. Tafadhali sogea katika eneo jingine la wazi</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Haiwezi kuunda njia. Tafadhali taja kituo kingine cha njia</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Kuunda njia, pakua ramani zilizokosekana kwenye kifaa chako</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Hitilafu imetokea. Tafadhali iwashe tena programu</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Njia itaundwa upya kutokea kwenye sehemu yako la sasa</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Njia itaboreshwa kuwa ya gari</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Sio vialamisho vyote vinavyoonyeshwa</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Badili utumie simu ili kuona alamisho zote</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Kam za kasi</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Onyo la kasi</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Tafadhali pakua ramani katika programu tumizi ya Organic Maps kwenye kifaa chako</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Kutoka kwa %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Ainisha kwa chaguo-msingi</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Ainisha kwa aina</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Ainisha kwa umbali</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Ainisha kwa tarehe</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Panga kwa jina</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Chakula</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Vivutio</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Makumbusho</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Hifadhi</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Kuogelea</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Milima</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Wanyama</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hoteli</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Majengo</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Fedha</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Maduka</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Maegesho</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Kituo cha gesi</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Dawa</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Tafuta kwenye orodha</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Sehemu za ibada</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Chagua orodha</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Uabiri wa njia ya chini kwa chini katika mkoa huu haupatikani bado</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Njia ya chini kwa chini haipatikani</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Chagua nyota au alama ya mwisho karibu ya kituo cha njia ya chini kwa chini</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Topografia</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Kuamilisha na kutumia tabaka la nchi tafadhali sasisha au pakua ramani ya eneo hilo</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Mistari ya mwinuko bado haipatikani katika eneo hili</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Upandaji</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Ushukaji</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. mwinuko</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. mwinuko</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Ugumu</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Umbali:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Muda:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Vuta karibu kutalii mistari ya kontua</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Inapakua</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Pakua ramani ya muhtasari wa dunia</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Haiwezekani kuunda folda na kuhamisha faili kwenye kumbukumbu ya ndani ya kifaa au kadi ya SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Hitilafu ya diski</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Kushindwa kwa muunganisho</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Ondoa kebo ya USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Washa skrini</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Ikiwashwa, skrini itakuwa imewashwa wakati wa kuonyesha ramani.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Onyesha kwenye skrini ya kufuli</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Inapowezeshwa, programu itafanya kazi kwenye skrini ya kufuli hata wakati kifaa kimefungwa.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Lugha ya ramani</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Data ya ramani kutoka OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Asante kwa kutumia ramani zetu zilizojengwa na jumuiya!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Kwa michango na usaidizi wako, tunaweza kuunda ramani bora zaidi Duniani!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Je, unapenda programu yetu? Tafadhali toa mchango ili kusaidia maendeleo! Je, huipendi bado? Tafadhali tujulishe, na tutarekebisha!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Ikiwa unajua msanidi programu, unaweza kumwomba kutekeleza kipengele unachohitaji.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Gusa popote kwenye ramani ili kuchagua chochote. Gusa kwa muda mrefu ili kuficha na kuonyesha kiolesura.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Je, unajua kwamba unaweza kuchagua eneo lako la sasa kwenye ramani?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Unaweza kusaidia kutafsiri programu yetu katika lugha yako.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Programu yetu imeundwa na washiriki wachache na jamii.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Unaweza kurekebisha na kuboresha data ya ramani kwa urahisi.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Lengo letu kuu ni kujenga ramani za haraka, zinazozingatia faragha, na rahisi kutumia ambazo utapenda.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Sasa unatumia Organic Maps kwenye skrini ya simu</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Sasa unatumia Organic Maps kwenye skrini ya gari</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Umeunganishwa kwenye Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Endelea kwenye simu</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Kwa skrini ya gari</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps zinahitaji ufikiaji wa eneo. Ikiwa salama, angalia arifa kwenye simu yako.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Programu hii inahitaji idhini yako</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps katika Android Auto zinahitaji ruhusa ya eneo ili kufanya kazi kwa ufanisi</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Toa ruhusa</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Nje</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Kivinjari cha wavuti hakipatikani</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Kiwango</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Hamisha Alamisho na Nyimbo zote</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Mipangilio ya usanisi wa hotuba ya mfumo</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Mipangilio ya Usanisi wa Matamshi haikupatikana, una uhakika kuwa kifaa chako kinaitumia?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Kuendesha-kupitia</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Futa utafutaji</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Vuta karibu</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Kuza nje</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Kiungo cha menyu</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Tazama Menyu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Fungua Katika Programu Nyingine</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Kujihudumia</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Chagua chaguo</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Viti vya nje</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Kwa urambazaji sahihi zaidi, tunapendekeza kuzima hali ya kuokoa nishati katika mipangilio ya betri ya simu.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Rekodi njia</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Acha kurekodi</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Kurekodi njia</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Acha bila kuhifadhi</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Endelea kurekodi</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Ungependa kuhifadhi katika alama na njia?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Njia ni tupu - hakuna cha kuhifadhi</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Haiwezi kuonyesha kidirisha cha kuchagua folda kwa sababu hakuna programu inayofaa iliyosakinishwa kwenye kifaa chako. Tafadhali sakinisha programu ya kidhibiti faili na ujaribu tena</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Chagua Rangi</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Hariri Njia</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Hakuna Programu iliyosakinishwa inayoweza kufungua eneo</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Urambazaji otomatiki</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Fuata mfumo</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Shiriki Njia</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Futa %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Usawa mgumu</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Rahisi</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Wastani</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Ngumu</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Inasasisha</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Sasisha ramani zako ulizopakua</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Kusasisha ramani kunaweka taarifa kuhusu vipengee ikiwa ya hivi sasa zaidi</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Sasisha (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Sasisha mwenyewe baadaye</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Futa Njia</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Je, una uhakika unataka kufuta wimbo huu?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Jina la njia</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Sogeza</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Njia</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Badilisha rangi</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Ramani</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Je, ungependa kutuma ripoti ya hitilafu kwa watengenezaji?
+Tunategemea watumiaji wetu kwani Organic Maps haikusanyi taarifa yoyote ya hitilafu kiotomatiki. Asante mapema kwa kuunga mkono Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Washa Usawazishaji wa iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Usawazishaji wa iCloud ni kipengele cha majaribio kinachoendelezwa. Hakikisha kuwa umefanya nakala rudufu ya alamisho na nyimbo zako zote.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Imezimwa</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Tafadhali wezesha iCloud katika mipangilio ya kifaa chako ili kutumia kipengele hiki.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Wezesha</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Hifadhi nakala</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Imeshindwa kusawazisha iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Hitilafu: Imeshindwa kusawazisha kwa sababu ya hitilafu ya muunganisho</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Hitilafu: Imeshindwa kusawazisha kwa sababu ya mgao wa iCloud uliozidishwa</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Hitilafu: iCloud haipatikani</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Orodha Zilizofutwa Hivi Karibuni</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Futa</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Futa Zote</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Rejesha</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Rejesha yote</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Changia kwenye OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Ongeza mahali</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Sasisha ramani ili kuchangia</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Unahitaji kusasisha ramani ya %1 hadi toleo jipya zaidi kabla ya kuchangia kwenye data ya OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Msimamo Wangu</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Maeneo Yangu</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Hifadhi ya ndani ya faragha</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Hifadhi ya pamoja ya ndani</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Kadi ya SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Hifadhi ya nje iliyoshirikiwa</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Msimbo wa posta</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Alama ya Ramani</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Ili kuonyesha njia, ramani lazima zisasishwe.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Toka</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Kiingilio</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Ramani ya njia ya chini haipatikani</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Wewe</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Maeneo yaliyopakuliwa ya zambarau</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Njia</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Kugundua eneo katika nyuma ni muhimu ili kufurahia kikamilifu utendaji wa programu. Inatumika kwa urambazaji na kuhifadhi njia uliyopita hivi karibuni.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Kutambua eneo lako ni muhimu kwa urambazaji na kuhifadhi njia uliyopita hivi karibuni.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Ingia kwa nenosiri</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Ingia kwa kutumia kivinjari</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Iliyotumiwa Hivi Karibuni</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Rangi ya alamisho imebadilishwa</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Rangi ya njia imebadilishwa</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spectrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Vitelezi</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>NYEKUNDU</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>Kijani</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>BLU</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Rangi ya Hex ya sRGB #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Grid</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/te/omim.ts
+++ b/qt/translations/te/omim.ts
@@ -1,0 +1,3934 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="te">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Back</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Cancel</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Download Maps</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Download has failed. Tap to try again.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Downloading…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometers</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Miles</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Later</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Search</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Search Map</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Limited Accuracy</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>To ensure accurate navigation enable Precise Location in settings.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Show on the map</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Download has failed</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Try Again</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>About Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Free for everyone, made with love</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• No ads, no tracking, no data collection</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• No battery drain, works offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Fast, minimalist, developed by the community</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Open-source application created by enthusiasts and volunteers.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Location Settings</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Close</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Download</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Please disconnect USB cable or insert memory card to use Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Please free up some space on the SD card/USB storage first in order to use the app</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Go to Map</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Downloading %1. You can now
+proceed to the map.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Download %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Update %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Pause</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Continue</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 download has failed</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Add a New List</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Bookmark List Name</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Bookmarks</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Bookmarks and Tracks</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Name</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Address</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>List</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Settings</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Save maps to</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Select the folder to download maps to.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Downloaded maps</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 free of %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Move maps?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Error moving map files</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>This can take several minutes.
+Please wait…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Measurement units</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Choose between miles and kilometers</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Cancel Download</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Leave a Review</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Download Map</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Bookmark Lists</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Where to eat</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Groceries</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Transport</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Gas</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Shopping</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Second Hand</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Hotel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Entertainment</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Nightlife</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Family holiday</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Bank</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Pharmacy</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hospital</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Toilet</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Post</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Police</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Recycling</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Water</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>RV Facilities</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notes</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Organic Maps bookmarks were shared with you</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Loading Bookmarks</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Failed to load bookmarks. The file may be corrupted or defective.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>The file type is not recognized by the app:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Failed to open file %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Edit</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Your location hasn&#x27;t been determined yet</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Sorry, Map Storage settings are currently disabled.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Map download is in progress now.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, check out my pin in Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, check out my current location on the Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Share</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Copied to clipboard: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Done</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap data: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Are you sure you want to log out of your OpenStreetMap account?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Tracks</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Length</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Share My Location</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Information</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigation</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>“+” and “-” buttons on the map</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Display on the map</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Night style when navigating in the dark</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Off</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>On</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Auto</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspective view</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D buildings</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D buildings are disabled in power saving mode</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Voice Instructions</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Announce Street Names</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>When enabled, the name of the street or exit to turn onto will be spoken aloud.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Voice Language</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Test Voice Directions (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Not Available</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Auto zoom</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Distance</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>View on map</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Website</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>News</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Feedback</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Rate the app</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Help</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Frequently Asked Questions</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Donate</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Already donated</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Remind later</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Support Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Support the project</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Copyright</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Report a bug</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Long-tap on the map again to see the interface</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Update All</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Cancel All</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Downloaded</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Queued</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Maps</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Download All</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Downloading:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>To delete map, please stop navigation.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Routes can only be created that are fully contained within a map of a single region.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Download map</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Retry</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Delete Map</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Update Map</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Location Services</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Download all of the maps along your route</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>In order to create a route, we need to download and update all the maps from your location to your destination.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Please enable Location Services</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Save</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>create</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Red</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Yellow</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Blue</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Green</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Purple</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Orange</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Brown</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pink</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Deep Purple</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Light Blue</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cyan</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Teal</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Lime</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Deep Orange</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gray</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Blue Gray</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps version: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Appearance</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Light</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Dark</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>తెల్లవారుజాము నుంచి సంధ్య వరకు లేత</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Other</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Gift free maps with no ads to millions of users!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Report or fix incorrect map data</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Volunteer</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Follow and contact us:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>The email client has not been set up. Please configure it or contact us at %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Error sending email</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Compass calibration</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Available</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Found</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Failed</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>bookmark</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>When following the route, please keep in mind:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Suggested routes should only be understood as recommendations;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Please stay alert and safe on the roads!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Check GPS signal</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Unable to create route. Current GPS coordinates could not be identified.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Enable location services</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Unable to locate current GPS coordinates. Enable location services to calculate route.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Unable to locate route</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Unable to create route.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Please adjust your starting point or destination.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Adjust starting point</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Route was not created. Unable to locate starting point.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Please select a starting point closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Adjust destination</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Route was not created. Unable to locate the destination.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Please select a destination point located closer to a road.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Unable to locate the intermediate point.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Please adjust your intermediate point.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>System error</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Unable to create route due to an application error.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Please try again</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Not Now</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Would you like to download the map and create a more optimal route spanning more than one map?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Download additional maps to create a better route that crosses the boundaries of this map.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Download required files</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Download or update all maps along the projected path to calculate a route.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Select Map</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Show</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Hide</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Categories</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>History</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Oops, no results found.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Download the region where you are searching or try adding a nearby town/village name.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Search History</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>View your recent searches.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Clear Search History</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org నుండి వ్యాసం</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Your Location</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Start</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Route from</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Route to</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigation is only available from your current location.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Do you want to plan a route from your current location?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Next</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>From</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>To</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Add Schedule</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Delete Schedule</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>All Day (24 hours)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Open</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Add Non-Business Hours</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Business Hours</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Advanced Mode</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Simple Mode</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Non-Business Hours</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Example Values</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Correct mistake</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Select Location</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Please describe the problem in detail so that the OpenStreetMap community can fix it.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Or do it yourself at https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Send</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Issue</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>This place does not exist</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Closed for maintenance</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Duplicate place</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Auto-download maps</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Daily</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Closed today</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Today</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Opens in %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Closes in %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Closed</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Edit business hours</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Don&#x27;t have an OpenStreetMap account?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Register at OpenStreetMap</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Login</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Not signed in</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Login to OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Forgot your password?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Log Out</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Edit Place</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Add a language</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Street</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Building number</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Details</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Social Media</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Building</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Add a street</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Please enter a street name</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Choose a language</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Choose a street</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Cuisine</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Select cuisine</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email or username</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Add Phone</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Floor</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Level: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>All of your map edits will be deleted with the map.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Update Maps</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>To create a route, you need to update all maps and then plan the route again.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Find map</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Please make sure your device is connected to the Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Not enough space</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Please delete any unnecessary data</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Login error.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Verified Changes</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Drag the map to place the cross at the location of the place or business.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Editing</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Adding</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Name of the place</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>As it is written in the local language</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Category</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Detailed description of the issue</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Different problem</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Add business</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>No object can be located here</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Create an OpenStreetMap account or log in to publish your map edits to the world.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 of %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Download over a cellular network connection?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>This could be considerably expensive with some plans or if roaming.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Enter a valid building number</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Number of floors (maximum of %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>The number of floors must non exceed %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>ZIP Code</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Enter a valid ZIP code</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Note to OpenStreetMap volunteers (optional)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Describe errors on the map or things that cannot be edited with Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>More about OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Your editing history</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Your map data notes</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Operator</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Operator: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Can&#x27;t find a suitable category?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>You haven&#x27;t downloaded any maps</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Download maps to search and navigate offline.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Current location is unknown.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/h</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>h</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>min</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>d</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>s</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>More</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Edit Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Personal notes (text or html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Comment…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Discard all local changes?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Discard</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Delete added place?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Delete</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Place does not exist</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Please indicate the reason for deleting the place</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Enter a valid phone number</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Enter a valid web address</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Enter a valid email</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Enter a valid Facebook web address, account, or page name</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Enter a valid Instagram username or web address</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Enter a valid Twitter username or web address</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Enter a valid VK username or web address</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Enter a valid LINE ID or web address</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Add Place to OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Note will be sent to OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Do you want to send it to all users?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Make sure you did not enter any private or personal data.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editors will check the changes and contact you if they have any questions.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Stop</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Recording the track</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Accept</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Decline</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Use mobile internet to show detailed information?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Use Always</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Only Today</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Do Not Use Today</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobile Internet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Mobile internet is required for map update notifications and uploading edits.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Never Use</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Always Ask</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>To display traffic data, maps must be updated.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Increase size for map labels</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Please update Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Traffic data is not available</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Enable logging</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>General Feedback</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>For more information please check this guide.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Transliterate into Latin alphabet</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Learn more</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a route starting point</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Use search, select a bookmark, or tap on the map to add a destination point</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Manage Route</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Remove Stop</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Add Stop</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Saved</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Storage access problem</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Emulate bad storage</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Please enter a correct name</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Lists</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Hide all</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Show all</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n bookmark</numerusform>
+<numerusform>%n bookmarks</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Create a new list</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Import Bookmarks and Tracks</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Unable to share due to an application error</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Sharing error</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Cannot share an empty list</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>The name can&#x27;t be empty</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Please enter the list name</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>New list</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>This name is already taken</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Please choose another name</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Please wait…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Phone number</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profile</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n file was found. You can see it after conversion.</numerusform>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Restore</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n track</numerusform>
+<numerusform>%n tracks</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Privacy</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Privacy policy</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Terms of use</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Traffic</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Hiking</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Cycling</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Subway</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Map Styles and Layers</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>This list is empty</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>To add a bookmark, tap a place on the map and then tap the star icon</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Change color of all bookmarks</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Change color of all tracks</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Export KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Export GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Export GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Delete list</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Speed cameras</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Place Description</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Map downloader</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Warn if speeding</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Always warn</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Never warn</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Power saving mode</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Try to reduce power usage at the expense of some functionality.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Never</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>When battery is low</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Always</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Bookmark names on the map</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>If there are too many bookmarks, displaying their names on the map may slow down the app.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Show to the right</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Show at the bottom</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Routing options</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Avoid tolls</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Avoid unpaved roads</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Avoid ferries</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Avoid freeways</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Unable to calculate route</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Define roads to avoid</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Routing options enabled</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Toll road</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Unpaved road</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Ferry crossing</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Yes</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Capacity: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Network: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>You have arrived!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sort…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sort bookmarks</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>By default</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>By type</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>By distance</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>By date</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>By name</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>A week ago</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>A month ago</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>More than a month ago</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>More than a year ago</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Near me</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Others</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Route Planning Failed</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Arrival at %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Download and update all map along the projected path to calculate route.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Share with friends</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Closed now</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Opens tomorrow at %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Opens %1 at %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Opens at %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Closes at %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Add opening hours</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Password (8 characters minimum)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Invalid username or password.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Account</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Last upload</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Thank You</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Place Name</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Phone</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Please note</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Download error</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Select category</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>All Categories</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Add new places to the map, and edit existing ones directly from the app.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Change location</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>To download, you need more space. Please delete any unnecessary data.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>I improved the Organic Maps maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Detailed comment</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>An error occurred while determining your location. Check that your device is working properly and try again later.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Location services are disabled</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Enable access to geolocation in the device settings</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Open Settings</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Tap Location</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Select While Using the App</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Select Privacy</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Select Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Turn on Location Services</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Or continue using Organic Maps without Location</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Book</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Call</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Bookmark Name</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Delete Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Your note will be sent to OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…more</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Disable recording of your recently travelled route?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Disable</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Check out</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps uses your location in the background to record your recently travelled route.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>General settings</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>To display traffic data, the application must be updated.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Log file size: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Drag here to remove</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Replace Stop</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Start from</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>here</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Hide Screen</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 of %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Downloading %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Applying %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>This name is too long</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>New files detected</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Convert</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Some files were not converted.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>An error occurred</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popular</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Hide from map</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>An error occurred while loading tags, please try again</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Right</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Bottom</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Let&#x27;s go</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Destination</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Re-center</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Search results</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Then</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Do you want to rebuild the route?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Keyboard is not available while driving</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Unable to build a route from your current location</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Unable to find a route to your destination. Please choose another end point</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>No GPS signal. Please move to an open area</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Unable to build a route. Please specify other route points</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>To create a route, download missing maps on your device</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>An error occurred. Please restart the application</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>The route will be rebuilt from your current location</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>The route will be converted into an automobile route</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Not all bookmarks are shown</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Switch to the phone to see all bookmarks</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Speedcams</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Speed warnings</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Please download maps in the app on your mobile device</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 exit</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sort by default</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sort by type</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sort by distance</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sort by date</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sort by name</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Food</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Sights</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Museums</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parks</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Swim</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Mountains</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Animals</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Hotels</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Buildings</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Money</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Shops</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Parking</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Gas Stations</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Medicine</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Search in the list</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Religious places</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Select list</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Subway navigation in this region is not available yet</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>No subway route found</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Please choose a start or end point closer to a subway station</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Contour Lines</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Activating contour lines requires downloading map data for this area</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Contour lines are not yet available in this area</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Ascent</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Descent</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. elevation</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. elevation</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Difficulty</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Dist.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Time:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Zoom in to explore isolines</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Downloading</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Download the world overview map</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Unable to create folder and move files on internal device&#x27;s memory or sdcard</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk error</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Connection failure</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Disconnect USB cable</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Keep the screen on</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>When enabled, the screen will always be on when displaying the map.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Show on the lock screen</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>When enabled, the app will work on the lock screen even when the device is locked.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Map language</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Map data from OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/te/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Thank you for using our community-built maps!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>With your donations and support, we can create the best maps in the world!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>If you know a software developer, you can ask him or her to implement a feature that you need.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Did you know that your current location on the map can be selected?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>You can help to translate our app into your language.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Our app is developed by a few enthusiasts and the community.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>You can easily fix and improve the map data.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>You are now using Organic Maps on the phone screen</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>You are now using Organic Maps on the car screen</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>You are connected to Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Continue on the phone</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>To the car screen</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>This app needs your permission</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps in Android Auto needs location permissions to work effectively</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Grant Permissions</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Outdoors</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web browser is not available</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Volume</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Export all Bookmarks and Tracks</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Speech synthesis system settings</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Speech Synthesis settings were not found, are you sure your device supports it?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Drive-through</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Clear the search</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Zoom in</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Zoom out</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menu Link</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>View Menu</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Open in Another App</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self-service</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Select option</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Outdoor seating</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Record Track</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Stop Track Recording</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Track Recording</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Stop Without Saving</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Continue Recording</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Save into Bookmarks and Tracks?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Track is empty - nothing to save</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Choose Color</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Edit Track</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>No app installed that can open the location</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Auto in navigation</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Follow the system</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Share Track</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Delete %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Difficulty level</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Easy</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Moderate</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Hard</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Updating</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Update downloaded maps</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Updating maps keeps the information about objects up to date</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Update (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Manually update later</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Delete Track</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Are you sure you want to delete this track?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Track Name</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Move</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Track</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Change Color</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Map</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Enable iCloud Synchronization</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Is Disabled</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Please enable iCloud in your device&#x27;s settings to use this feature.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Enable</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Backup</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud synchronization failure</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Error: Failed to synchronize due to connection error</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Error: Failed to synchronize due to iCloud quota exceeded</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Error: iCloud is not available</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Recently Deleted Lists</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Clear</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Delete All</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Recover</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Recover All</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Contribute to OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Add Place</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Update the Map to Contribute</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>My Position</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>My Places</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Internal private storage</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Internal shared storage</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD card</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>External shared storage</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Postal Code</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Map Point</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mi</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>To display routes, maps must be updated.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Entrance</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Subway map is unavailable</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>You</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Purple downloaded regions</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Route</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Determining your location is necessary for navigation and for saving your recently traveled track.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Login with password</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Login using Browser</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>ఇటీవల ఉపయోగించినవి</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Bookmarks color changed</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Tracks color changed</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>స్పెక్ట్రమ్</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>స్లైడర్లు</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ఎరుపు</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ఆకుపచ్చ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>నీలం</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB హెక్స్ రంగు #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>గ్రిడ్</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/th/omim.ts
+++ b/qt/translations/th/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="th">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>กลับ</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>ยกเลิก</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>ลบ</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>ดาวน์โหลดแผนที่</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>การดาวน์โหลดล้มเหลว แตะอีกครั้งเพื่อลองใหม่</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>กำลังดาวน์โหลด…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>กิโลเมตร</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>ไมล์</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>ภายหลัง</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>ค้นหา</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>ค้นหาแผนที่</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>ในปัจจุบันนี้มีการปิดการใช้งานการบริการตำแหน่งที่ตั้งสำหรับอุปกรณ์หรือแอปพลิเคชันนี้ โปรดเปิดใช้งานในการตั้งค่า</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>ความแม่นยำ จำกัด</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>เพื่อให้แน่ใจว่าการนำทางที่ถูกต้องเปิดใช้งานตำแหน่งที่แม่นยำในการตั้งค่า</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>แสดงบนแผนที่</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>การดาวน์โหลดล้มเหลว</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>ลองอีกครั้ง</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>เกี่ยวกับ Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>ฟรีสำหรับทุกคนทำด้วยความรัก</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• ไม่มีโฆษณาไม่มีการติดตามไม่มีการรวบรวมข้อมูล</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• ไม่มีแบตเตอรี่หมด ทำงานแบบออฟไลน์</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• รวดเร็ว เรียบง่าย พัฒนาโดยชุมชน</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>แอปพลิเคชันโอเพนซอร์ซที่สร้างขึ้นโดยผู้ที่ชื่นชอบและอาสาสมัคร</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>การตั้งค่าตำแหน่ง</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>ปิด</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>จำเป็นต้องใช้ฮาร์ดแวร์ที่เพิ่มความเร็ว OpenGL โชคไม่ดีที่อุปกรณ์ของคุณไม่รองรับ</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>ดาวน์โหลด</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>โปรดยกเลิกการเชื่อมต่อสาย USB หรือใส่การ์ดหน่วยความจำเพื่อใช้ Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>โปรดเพิ่มพื้นที่บางส่วนบนการ์ด SD /พื้นที่จัดเก็บ USB ก่อนเพื่อใช้แอป</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>ก่อนที่คุณจะเริ่มต้น โปรดให้เราดาวน์โหลดแผนที่โลกลงในอุปกรณ์ของคุณ
+จำเป็นต้องใช้ %1 ของข้อมูล</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>ไปยังแผนที่</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>กำลังดาวน์โหลด %1 ตอนนี้คุณสามารถ
+ดำเนินการต่อไปยังแผนที่</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>ดาวน์โหลด %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>อัปเดต %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>หยุดชั่วคราว</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>ดำเนินการต่อ</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>การดาวน์โหลด %1 ล้มเหลว</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>เพิ่มชุดใหม่</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>ชื่อของชุดบุ๊กมาร์ก</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>บุ๊กมาร์ก</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>บุ๊กมาร์กและการติดตาม</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>ชื่อ</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>ที่อยู่</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>รายการ</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>การตั้งค่า</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>บันทึกแผนที่ไปยัง</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>เลือกสถานที่ที่ต้องการดาวน์โหลดใช้แผนที่</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>แผนที่</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>เหลือว่าง %1 จาก %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>ลบแผนที่?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>เกิดข้อผิดพลาดในการย้ายไฟล์แผนที่</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>นี่อาจจะใช้เวลาสองสามนาที
+โปรดรอ…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>หน่วยการวัด</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>เลือกระหว่างไมล์และกิโลเมตร</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>ยกเลิกการดาวน์โหลด</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>ให้คำวิจารณ์</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>ใช่</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>ดาวน์โหลดแผนที่</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>ชุดของบุ๊กมาร์ก</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>กินร้านไหนดี</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>ซื้อของกินของใช้</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>การขนส่ง</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>ก๊าซ</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>ที่จอดรถ</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>ช็อปปิง</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>มือสอง</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>โรงแรม</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>สถานที่ท่องเที่ยว</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>แหล่งบันเทิง</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>เอทีเอ็ม</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>ไนท์ไลฟ์</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>วันหยุดสำหรับครอบครัว</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>ธนาคาร</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>ร้านขายยา</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>โรงพยาบาล</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>ห้องน้ำ</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>ไปรษณีย์</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>ตำรวจ</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>การรีไซเคิล</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>น้ำ</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>สำหรับ RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>บันทึก</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>แชร์บุ๊กมาร์กของ Organic Maps แล้ว</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>สวัสดีครับ
+
+แนบมาด้วยบุ๊กมาร์กของผม; กรุณาเปิดใน Organic Maps หากคุณยังไม่ได้ติดตั้ง คุณสามารถดาวน์โหลดได้ที่นี่: https://omaps.app/get?kmz
+
+ขอให้สนุกกับการเดินทางด้วย Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>กำลังโหลดบุ๊กมาร์ก</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>โหลดบุ๊กมาร์กสำเร็จแล้ว! คุณสามารถหาพวกมันได้บนแผนที่หรือบนหน้าจอโปรแกรมจัดการบุ๊กมาร์ก</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>การอัปโหลดล้มเหลว ไฟล์อาจเสียหายหรือมีข้อบกพร่อง</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>แอปไม่รู้จักประเภทไฟล์:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>ไม่สามารถเปิดไฟล์ได้ %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>แก้ไข</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>ตำแหน่งที่ตั้งของคุณยังไม่ได้รับการกำหนด</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>ขออภัย ไม่มีการเปิดใช้งานการตั้งค่าพื้นที่จัดเก็บแผนที่ในปัจจุบัน</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>กำลังดำเนินการดาวน์โหลดประเทศในตอนนี้</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>เฮ้อ ตรวจสอบตำแหน่งที่ตั้งปัจจุบันของฉันที่ Organic Maps! %1 หรือ %2 ไม่มีการติดตั้งแผนที่แบบออฟไลน์? ดาวน์โหลดที่นี่: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>เฮ้ ตรวจสอบหมุดของฉันที่ แผนที่ Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>นี่ มาดูตำแหน่งปัจจุบันของฉันที่แผนที่ Organic Maps สิ!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>หวัดดี
+
+ฉันอยู่ที่นี่ตอนนี้: %1. คลิกลิงก์นี้ %2 หรือลิงก์นี้ %3 เพื่อดูสถานที่บนแผนที่
+
+ขอบคุณ</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>แชร์</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>อีเมล</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>คัดลอกไปยังคลิปบอร์ด: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>เสร็จแล้ว</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>ข้อมูล OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบบัญชี OpenStreetMap ของคุณ?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>การติดตาม</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>ระยะเวลา</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>แชร์ตำแหน่งที่ตั้งของฉัน</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>การตั้งค่าทั่วไป</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>ข้อมูล</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>การนำทาง</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>ปุ่ม + และ - บนแผนที่</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>แสดงบนหน้าจอ</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>สไตล์กลางคืนเมื่อนำทางในที่มืด</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>โหมดกลางคืน</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>ปิด</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>เปิด</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>อัตโนมัติ</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>มุมมองเพอร์สเปกทีฟ</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>ตึก 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>สิ่งปลูกสร้าง 3 มิติจะปิดในโหมดประหยัดพลังงาน</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>คำแนะนำด้วยเสียง</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>ประกาศชื่อถนน</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>เมื่อเปิดใช้งาน ชื่อของถนนหรือทางออกที่จะเลี้ยวจะถูกพูดออกมาดัง ๆ</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>ภาษาสำหรับเสียง</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>หากต้องการดาวน์โหลดเสียงคุณภาพสูงขึ้น ให้เปิดแอปการตั้งค่า แล้วไปที่ การช่วยการเข้าถึง → VoiceOver → การพูด → เสียง</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>ทดสอบเส้นทางด้วยเสียง (TTS, การอ่านออกเสียงข้อความ)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>ตรวจสอบระดับเสียงหรือการตั้งค่าการอ่านออกเสียงข้อความของระบบหากคุณไม่ได้ยินเสียงในตอนนี้</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>ไม่สามารถใช้ได้</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>ซูมอัตโนมัติ</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>ระยะห่าง</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>ดูบนแผนที่</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>เมนู</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>เว็บไซต์</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>ข่าว</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>ข้อเสนอแนะ</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>ให้คะแนนแอป</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>ความช่วยเหลือ</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>คำถามและคำตอบ</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>บริจาค</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>บริจาคแล้ว</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>เตือนภายหลัง</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>สนับสนุน Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>สนับสนุนโครงการ</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>ลิขสิทธิ์</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>แจ้งข้อผิดพลาด</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>ปรับปรุงทิศทางลูกศรโดยขยับโทรศัพท์เป็นเลขแปดเพื่อปรับเทียบเข็มทิศ</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>ขยับโทรศัพท์เป็นเลขแปดเพื่อปรับเทียบเข็มทิศและกำหนดทิศทางลูกศรบนแผนที่</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>แตะยาวบนแผนที่อีกครั้งเพื่อดูอินเทอร์เฟซ</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>อัปเดตทั้งหมด</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>ยกเลิกทั้งหมด</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>ดาวน์โหลดแล้ว</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>ต่อแถว</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>ใกล้ฉัน</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>แผนที่</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>ดาวน์โหลดทั้งหมด</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>กำลังดาวน์โหลด:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>เพื่อลบแผนที่ โปรดหยุดใช้การนำทาง</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>สามารถสร้างเส้นทางแบบสมบูรณ์ได้เฉพาะที่มีอยู่ในแผนที่เดียวเท่านั้น</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>ดาวน์โหลดแผนที่</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>ทำซ้ำ</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>ลบแผนที่</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>อัปเดตแผนที่</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>บริการตำแหน่งของ Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>ระบุตำแหน่งโดยประมาณของคุณอย่างรวดเร็วโดยใช้บลูทูธ WiFi หรือเครือข่ายมือถือ</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>ดาวน์โหลดแผนที่ตามเส้นทาง</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>การสร้างเส้นทางจำเป็นต้องใช้แผนที่จากสถานที่ตั้งของคุณไปยังปลายทางที่มีการดาวน์โหลดและอัปเดต</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>มีพื้นที่ไม่เพียงพอ</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>โปรดเปิดการใช้งานการบริการตำแหน่งที่ตั้ง</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>บันทึก</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>สร้าง</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>สีแดง</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>สีเหลือง</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>สีน้ำเงิน</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>สีเขียว</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>สีม่วง</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>สีส้ม</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>สีน้ำตาล</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>สีชมพู</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>สีม่วงเข้ม</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>สีฟ้าอ่อน</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>สีฟ้าอมเขียว</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>สีเขียวนกเป็ดน้ำ</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>สีเขียวอมเหลือง</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>สีส้มเข้ม</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>สีเทา</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>สีฟ้าอมเทา</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>ข้อมูล</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>เวอร์ชัน Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>รูปแบบ</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>สว่าง</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>มืด</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>สว่างตั้งแต่เช้าจรดค่ำ</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>อื่น ๆ</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>มอบแผนที่ฟรีไม่มีโฆษณาให้แก่ผู้ใช้นับล้าน!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>รายงานหรือแก้ไขข้อมูลแผนที่ที่ไม่ถูกต้อง</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>อาสาสมัคร</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>ติดตามและติดต่อเรา:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>อีเมลลูกค้ายังไม่ได้รับการจัดตั้งขึ้น กรุณาตั้งค่าหรือใช้วิธีอื่นที่จะติดต่อเราที่ %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>จดหมายที่ส่งเกิดความผิดพลาด</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>การปรับเทียบเข็มทิศ</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>มีให้ใช้</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>พบ</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>ปรับปรุง</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>ล้มเหลว</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>บุ๊กมาร์ก</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>ขณะกำลังเดินทางตามเส้นทาง โปรดจำไว้ว่า:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— สภาพถนน กฎจราจร และสัญลักษณ์บนถนนย่อมมีความสำคัญกว่าคำแนะนำเพื่อบอกทางเสมอ;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— แผนที่อาจมีความคลาดเคลื่อนและเส้นทางที่แนะนำอาจไม่ใช่เส้นทางที่เหมาะสมที่สุดเสมอไปสำหรับการไปยังที่หมาย;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— เส้นทางที่แนะนำเป็นเพียงคำแนะนำเท่านั้น;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— โปรดระมัดระวังเมื่อใช้เส้นทางในพื้นที่ชายแดน: บางครั้งเส้นทางที่สร้างขึ้นโดยแอปของเรานั้นอาจข้ามผ่านชายแดนประเทศในพื้นที่ที่ไม่ได้รับการอนุญา;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>โปรดมีสติอยู่เสมอและยึดถือความปลอดภัยบนถนน!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>ตรวจสอบสัญญาณ GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>ไม่สามารถสร้างเส้นทางได้ ไม่สามารถระบุพิกัด GPS ปัจจุบันได้</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>กรุณาตรวจสอบสัญญาณ GPS ของคุณ การเปิดใช้ Wi-Fi จะช่วยเพิ่มความแม่นยำในการระบุตำแหน่งของคุณ</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>เปิดใช้บริการหาตำแหน่ง</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้ เปิดใช้บริการหาตำแหน่งเพื่อคำนวณเส้นทาง</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>ไม่สามารถหาเส้นทางได้</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>ไม่สามารถสร้างเส้นทางได้</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>กรุณาปรับจุดเริ่มต้นหรือที่หมายของคุณ</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>ปรับจุดเริ่มต้น</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>ไม่มีการสร้างเส้นทาง ไม่สามารถหาจุดเริ่มต้นได้</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>กรุณาเลือกจุดเริ่มต้นที่ใกล้ถนนมากขึ้น</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>ปรับที่หมาย</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>ไม่มีการสร้างเส้นทาง ไม่สามารถหาที่หมายได้</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>กรุณาเลือกที่หมายที่ใกล้ถนนมากขึ้น</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>ไม่สามารถระบุจุดระหว่างทางได้</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>กรุณาปรับจุดระหว่างทางของคุณ</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>ระบบเกิดข้อผิดพลาด</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>ไม่สามารถสร้างเส้นทางได้เนื่องจากเกิดข้อผิดพลาดของแอปพลิเคชัน</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>กรุณาลองอีกครั้ง</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>ไว้คราวหลัง</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>คุณต้องการดาวน์โหลดแผนที่และสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>ดาวน์โหลดแผนที่เพื่อสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>ดาวน์โหลดไฟล์ที่จำเป็น</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>ดาวน์โหลดและอัปเดตแผนที่กับข้อมูลเส้นทางทั้งหมดตามเส้นทางที่คาดหมายเพื่อคำนวณเส้นทาง</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>เพื่อเริ่มต้นการค้นหาและสร้างเส้นทาง โปรดดาวน์โหลดแผนที่ และคุณจะไม่จำเป็นต้องทำการเชื่อมต่ออินเทอร์เน็ตอีกต่อไป</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>เลือกแผนที่</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>แสดง</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>ซ่อน</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>หมวดหมู่</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>ประวัติ</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>ขออภัย ฉันไม่พบสิ่งใด</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>ดาวน์โหลดภูมิภาคที่คุณกำลังค้นหาหรือลองเพิ่มชื่อเมือง/หมู่บ้านใกล้เคียง</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>ประวัติการค้นหา</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>เข้าถึงคำถามที่ใช้ในการค้นหาเมื่อเร็ว ๆ นี้ได้อย่างรวดเร็ว</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>ล้างการค้นหาประวัติ</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>วิกิพีเดีย</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>บทความจาก wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>วิกิมีเดีย คอมมอนส์</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>ตำแหน่งที่ตั้งของคุณ</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>เริ่มต้น</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>จาก</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>เส้นทางถึง</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>สามารถใช้การนำทางได้เฉพาะจากตำแหน่งที่ตั้งปัจจุบันของคุณเท่านั้น</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>คุณต้องการให้เราาวงแผนเส้นทางจากสถานที่ตั้งปัจจุบันของคุณหรือไม่?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>ถัดไป</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>เวลา</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>น</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>เพิ่มวัน</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>ลบวัน</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>ตลอดวัน (24 ชั่วโมง)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>เปิด</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>ปิด</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>เพิ่มเวลาที่ปิดทำการเพิ่มเติม</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>วันเวลาทำการ</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>โหมดขั้นสูง</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>โหมดแบบง่าย</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>ปิดเวลา</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>ตัวอย่างของค่าที่ตั้งไว้</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>แก้ไขข้อผิดพลาด</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>เลือกสถานที่</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>กรุณาอธิบายปัญหาโดยละเอียดเพื่อที่ชุมชน OpenStreetMap จะสามารถแก้ไขข้อผิดพลาดได้</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>หรือทำด้วยตัวคุณเองที่ https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>ส่ง</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>ปัญหา</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>ไม่มีสถานที่นี้อยู่</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>ปิดปรับปรุง</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>สถานที่ซ้ำ</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>ดาวน์โหลดอัตโนมัติ</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>ทุกวัน</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>ทั้งกลางวันและกลางคืน</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>วันนี้ปิด</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>ปิด</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>วันนี้</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>เปิดใน %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>ปิดใน %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>ปิด</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>แก้ไขชั่วโมงทำการ</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>ไม่มีบัญชีใน OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>ลงทะเบียน</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>ล็อกอิน</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>ยังไม่ได้ลงชื่อเข้าใช้</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>เข้าสู่ระบบ OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>รหัสผ่าน</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>ลืมรหัสผ่าน?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>ออกจากระบบ</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>แก้ไขสถานที่</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>เพิ่มภาษา</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>ถนน</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>บ้านเลขที่</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>รายละเอียด</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>โซเชียลมีเดีย</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>อาคาร</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>เพิ่มถนน</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>กรุณากรอกชื่อถนน</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>เลือกภาษา</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>เลือกถนน</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>ประเภทอาหาร</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>เลือกประเภทอาหาร</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>อีเมลหรือชื่อผู้ใช้</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>เพิ่มโทรศัพท์</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>ชั้น</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>ระดับ: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>การเปลี่ยนแปลงแผนที่ทั้งหมดจะถูกลบไปพร้อมกับแผนที่</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>อัปเดตแผนที่</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>ในการสร้างเส้นทาง คุณต้องอัปเดตแผนที่ทั้งหมดแล้ววางแผนเส้นทางอีกครั้ง</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>ค้นหาแผนที่</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>กรุณาตรวจสอบการตั้งค่าของคุณแล้วทำให้แน่ใจว่าอุปกรณ์ของคุณได้รับการเชื่อมต่ออินเทอร์เน็ต</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>มีพื้นที่ไม่เพียงพอ</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>กรุณาลบข้อมูลที่ไม่จำเป็น</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>ข้อผิดพลาดในการล็อกอิน</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>การเปลี่ยนแปลงที่อนุมัติแล้ว</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>ลากแผนที่เพื่อวางกากบาทที่ตำแหน่งของสถานที่หรือธุรกิจ</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>กำลังแก้ไข</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>กำลังเพิ่ม</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>ชื่อสถานที่</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>ตามที่เขียนเป็นภาษาท้องถิ่น</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>หมวดหมู่</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>คำอธิบายปัญหาอย่างละเอียด</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>ปัญหาอีกอย่างหนึ่ง</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>เพิ่มองค์กร</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>ไม่สามารถตั้งวัตถุได้ที่นี่</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>ข้อมูล OpenStreetMap ที่สร้างโดยชุมชน ณ %1 เรียนรู้เพิ่มเติมเกี่ยวกับวิธีแก้ไขและอัปเดตแผนที่ได้ที่ OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) เป็นโครงการของชุมชนเพื่อสร้างแผนที่ที่เสรีและเปิดกว้าง นี่คือแหล่งข้อมูลแผนที่หลักใน Organic Maps และทำงานคล้ายกับวิกิพีเดีย คุณสามารถเพิ่มหรือแก้ไขสถานที่ต่าง ๆ ได้ และสิ่งที่คุณทำจะพร้อมใช้งานสำหรับผู้ใช้หลายล้านคนทั่วโลก
+เข้าร่วมชุมชนและช่วยสร้างแผนที่ที่ดีขึ้นสำหรับทุกคน!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>สร้างบัญชี OpenStreetMap หรือเข้าสู่ระบบเพื่อเผยแพร่การแก้ไขแผนที่ของคุณไปทั่วโลก</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 จาก %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>ดาวน์โหลดโดยใช้การเชื่อมต่อเครือข่ายมือถือ?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>มันอาจมีราคาสูงมากหากใช้แผนโทรศัพท์บางประเภทหรือหากทำการโรมมิ่ง</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>กรอกบ้านเลขที่ให้ถูกต้อง</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>จำนวนชั้น (มากสุด %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>แก้ไขอาคารที่มีจำนวนชั้นมากกว่า %1</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>รหัสไปรษณีย์</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>กรุณาใส่รหัสไปรษณีย์ที่ถูกต้อง</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>หมายเหตุถึงอาสาสมัคร OpenStreetMap (ไม่บังคับ)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>อธิบายข้อผิดพลาดบนแผนที่หรือสิ่งที่ไม่สามารถแก้ไขได้ด้วยเครื่องมือแก้ไขแผนที่สาธารณะ (Organic Maps)</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>การแก้ไขของคุณจะถูกอัปโหลดไปยังฐานข้อมูล &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; สาธารณะ กรุณาอย่าเพิ่มข้อมูลส่วนบุคคลหรือข้อมูลที่มีลิขสิทธิ์</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>ข้อมูลเพิ่มเติมเกี่ยวกับ OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>ประวัติการแก้ไขของคุณ</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>บันทึกข้อมูลแผนที่ของคุณ</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>ตัวดำเนินการ</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>ตัวดำเนินการ: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>ไม่พบหมวดหมู่ที่เหมาะสมใช่ไหม?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps อนุญาตให้เพิ่มหมวดหมู่จุดแบบง่ายเท่านั้น ซึ่งหมายถึงไม่สามารถเพิ่มเมือง ถนน ทะเลสาบ เส้นขอบอาคาร ฯลฯ ได้ กรุณาเพิ่มหมวดหมู่ดังกล่าวโดยตรงที่ &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; โปรดตรวจสอบ&lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;คู่มือ&lt;/a&gt;ของเราสำหรับคำแนะนำแบบละเอียดทีละขั้นตอน</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>คุณยังไม่ได้ดาวน์โหลดแผนที่</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>ไม่ทราบชื่อของที่ตั้งปัจจุบัน</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>กม./ชม.</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ไมล์/ชม.</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>ชม.</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>น.</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>วัน</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>วิ</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>เพิ่มเติม</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>แก้ไข Bookmark</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>ข้อความส่วนตัว (ข้อความหรือ html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>ข้อคิดเห็น…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>ตั้งค่าการเปลี่ยนแปลงท้องถิ่นทั้งหมด</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>ตั้งค่าใหม่</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>ลบที่ที่เพิ่มออก</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>ลบออก</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>ไม่พบสถานที่นี้</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>กรุณาระบุเหตุผลในการลบสถานที่</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>กรอกหมายเลขโทรศัพท์ที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>กรอกที่อยู่เว็บที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>กรอกอีเมลที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>กรุณากรอกที่อยู่เว็บไซต์ Facebook ที่ถูกต้อง, บัญชีผู้ใช้, หรือชื่อเพจ</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>กรุณากรอกชื่อผู้ใช้ Instagram หรือที่อยู่เว็บไซต์ที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>กรุณากรอกชื่อผู้ใช้ Twitter หรือที่อยู่เว็บไซต์ที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>กรุณาป้อนชื่อผู้ใช้ VK หรือที่อยู่เว็บไซต์ที่ถูกต้อง</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>กรุณากรอก LINE ID หรือที่อยู่เว็บไซต์ที่ถูกต้อง</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>เพิ่มสถานที่ลงใน OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>หรืออีกทางหนึ่ง คุณสามารถฝากข้อความไว้กับชุมชน OpenStreetMap เพื่อให้ผู้อื่นสามารถเพิ่มหรือแก้ไขสถานที่นี้ได้</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>บันทึกจะถูกส่งไปยัง OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>คุณต้องการส่งมันให้ผู้ใช้ทั้งหมดหรือไม่?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>ตรวจสอบว่าคุณไม่ได้กรอกข้อมูลส่วนตัวใด ๆ</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>ผู้แก้ไข OpenStreetMap จะตรวจสอบการเปลี่ยนแปลงและติดต่อคุณหากมีคำถามใดๆ</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>หยุด</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>การบันทึกเส้นทาง</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>ยอมรับ</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>ปฏิเสธ</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>ใช้อินเทอร์เน็ตมือถือแสดงข้อมูลโดยรายละเอียดหรือไม่?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>ใช้เสมอ</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>วันนี้เท่านั้น</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>ไม่ใช้วันนี้</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>อินเทอร์เน็ตมือถือ</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>จำเป็นต้องใช้อินเทอร์เน็ตมือถือในการแสดงข้อมูลโดยรายละเอียดเกี่ยวกับสถานที่ เช่น รูปถ่าย ราคา และรีวิว</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>ไม่ใช้เลย</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>ถามก่อนเสมอ</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>ต้องอัปเดตแผนที่เพื่อแสดงข้อมูลการจราจร</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>เพิ่มขนาดฟอนต์บนแผนที่</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>กรุณาอัปเดต Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>ไม่มีข้อมูลการจราจร</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>เปิดใช้งานการเก็บล็อก</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>ข้อเสนอแนะทั่วไป</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>เราใช้ระบบ TTS สำหรับคำแนะนำด้วยเสียงพูด เครื่องแอนดรอยด์จำนวนมากใช้งาน Google TTS คุณสามารถดาวน์โหลดหรืออัปเดตได้จาก Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>สำหรับบางภาษาคุณจำเป็นต้องติดตั้งตัวสังเคราะห์เสียงหรือชุดภาษาเพิ่มเติมจากแอปสโตร์ (Google Play, Galaxy Store, App Gallery, FDroid)
+เปิดการตั้งค่าของเครื่องคุณ → ภาษาและการป้อนข้อมูล → คำพูด → เอาต์พุตการอ่านออกเสียง
+ที่นี่คุณสามารถจัดการการตั้งค่าสำหรับการสังเคราะห์เสียง (ตัวอย่างเช่น ดาวน์โหลดชุดภาษาสำหรับใช้งานออฟไลน์) และเลือกเครื่องมืออ่านออกเสียงข้อความตัวอื่นได้</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>สำหรับข้อมูลเพิ่มเติม กรุณาเข้าชมคำแนะนำนี้</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>การทับศัพท์เป็นภาษาละติน</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>ศึกษาเพิ่มเติม</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>ใช้การค้นหาหรือแตะบนแผนที่เพื่อเพิ่มจุดเริ่มต้นเส้นทาง</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>ใช้การค้นหาหรือแตะบนแผนที่เพื่อเพิ่มจุดปลายทาง</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>จัดการเส้นทาง</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>วางแผน</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>ลบจุดแวะพัก</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>เพิ่มจุดแวะพัก</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>บันทึกแล้ว</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>กรุณาเข้าสู่ระบบ OpenStreetMap เพื่ออัปโหลดการแก้ไขแผนที่ทั้งหมดของคุณโดยอัตโนมัติ เรียนรู้เพิ่มเติม&lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;ที่นี่&lt;/a&gt;</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>ปัญหาการเข้าถึงที่เก็บข้อมูล</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>ที่เก็บข้อมูลภายนอกไม่พร้อมใช้งาน อาจเป็นเพราะการ์ด SD ถูกถอดออกไป ได้รับความเสียหาย หรือระบบไฟล์ให้เขียนได้อย่างเดียว กรุณาตรวจสอบและติดต่อเราได้ที่ support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>จำลองแบบที่เก็บข้อมูลที่ไม่ดี</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>กรุณาใส่ชื่อที่ถูกต้อง</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>รายการ</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>ซ่อนทั้งหมด</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>แสดงทั้งหมด</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n บุ๊กมาร์ก</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>สร้างรายการใหม่</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>นำเข้าบุ๊กมาร์กและแทร็ก</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>ไม่สามารถแชร์ได้เนื่องจากเกิดข้อผิดพลาดในแอปพลิเคชัน</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>ข้อผิดพลาดในการแชร์</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>ไม่สามารถแชร์รายการที่ว่างเปล่าได้</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>ชื่อต้องไม่ว่างเปล่า</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>โปรดป้อนชื่อรายการ</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>รายการใหม่</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>ชื่อนี้ถูกนำมาใช้แล้ว</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>โปรดเลือกชื่ออื่น</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>โปรดรอสักครู่ …</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>หมายเลขโทรศัพท์</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>โปรไฟล์ OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>พบ %n ไฟล์ คุณจะเห็นพวกเขาหลังจากการแปลง</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>ฟื้นฟู</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n ติดตามต่าง ๆ</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>ความเป็นส่วนตัว</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>นโยบายความเป็นส่วนตัว</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>ข้อกำหนดในการใช้งาน</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>การจราจร</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>การเดินป่า</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>การปั่นจักรยาน</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>รถไฟใต้ดิน</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>รูปแบบและเลเยอร์ของแผนที่</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>รายการนี้ว่างเปล่า</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>เพื่อเพิ่มบุ๊กมาร์ก โปรดแตะที่สถานที่บนแผนที่ แล้วจากนั้นแตะที่ไอคอนรูปดาว</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>เปลี่ยนสีที่คั่นหน้าทั้งหมด</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>เปลี่ยนสีแทร็กทั้งหมด</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…เพิ่มเติม</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>ส่งออก KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>ส่งออก GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>ส่งออก GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>ลบรายการ</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>กล้องตรวจจับความเร็ว</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>รายละเอียดของสถานที่</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>ตัวดาวน์โหลดแผนที่</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>เตือนเรื่องการขับรถเร็ว</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>โหมดประหยัดพลังงาน</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>เมื่อโหมดอัตโนมัตินั้นถูกเลือก แอปพลิเคชันจะเริ่มหยุดการใช้พลังงานจากแบตเตอรีขึ้นอยู่กับจำนวนไฟในแบตเตอรีว่าเหลือเท่าไร</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>ไม่ใช้</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>อัตโนมัติ</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>ประหยัดพลังงานสูงสุด</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>บันทึกชื่อบนแผนที่</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>หากมีบุ๊กมาร์กมากเกินไป การแสดงชื่อของบุ๊กมาร์กบนแผนที่อาจทำให้แอปทำงานช้าลง</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>แสดงทางขวา</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>แสดงที่ด้านล่าง</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>ออปชันเพื่อเปิดการบันทึกประวัติการทำงานเพื่อการวินิจฉัย ประวัติดังกล่าวอาจเป็นประโยชน์กับทีมงานช่วยเหลือของเราที่คอยจัดการกับปัญหาที่เจอระหว่างแอปทำงาน โปรดเปิดออปชันดังกล่าวจากการร้องข้อการสนับสนุนจาก Organic Maps เท่านั้น</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>ทางเลือกเส้นทางขับขี่</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>หลีกเลี่ยงถนนที่เก็บค่าผ่านทาง</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>เลี่ยงถนนดินทั้งหมด</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>เลี่ยงการข้ามฟากด้วยเรือ</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>หลีกเลี่ยงมอเตอร์เวย์</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>ไม่สามารถคำนวณเส้นทาง</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>ขออภัย เราไม่สามารถค้นหาเส้นทาง โดยสาเหตุอาจมาจากทางเลือกที่คุณกำหนดไว้ โปรดเปลี่ยนการตั้งค่าทางเลือกและลองใหม่อีกครั้ง</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>กำหนดถนนที่ต้องการเลี่ยง</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>เปิดใช้การค้นหาเส้นทางขับขี่แล้ว</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>ถนนแบบเสียค่าผ่านทาง</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>ถนนดิน</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>เรือข้ามฟาก</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>ใช่</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>ไม่ใช่</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>ใช่</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>ไม่ใช่</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>ความจุ: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>เครือข่าย: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>คุณมาถึงแล้ว!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>โอเค</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>เรียง…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>เรียงบุ๊กมาร์ก</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>ตามค่าเริ่มต้น</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>ตามประเภท</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>ตามระยะทาง</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>ตามวันที่</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>ตามชื่อ</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>สัปดาห์ที่ผ่านมา</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>เดือนที่ผ่านมา</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>มากกว่าหนึ่งเดือนที่ผ่านมา</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>มากกว่าหนึ่งปีที่ผ่านมา</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>ใกล้ฉัน</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>อื่นๆ</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>การวางแผนเส้นทางล้มเหลว</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>มาถึง: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>คุณได้เปลี่ยนแผนที่โลก อย่าซ่อนมันไว้! บอกเพื่อนคุณ แล้วมาแก้ไขมันไปด้วยกัน</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>แชร์กับเพื่อน</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>ปิดตอนนี้</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>เปิดพรุ่งนี้ที่ %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>เปิด %1 ที่ %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>เปิดที่ %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>ปิดที่ %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>เพิ่มชั่วโมงทำการ</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>รหัสผ่าน (อย่างน้อย 8 ตัวอักษร)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>บัญชี OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>อัปโหลดครั้งสุดท้าย</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>ขอบพระคุณ</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>ชื่อสถานที่</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>โทรศัพท์</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>โปรดทราบ</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>ข้อผิดพลาดในการดาวน์โหลด</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>เลือกหมวดหมู่</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>ยอดนิยม</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>หมวดหมูทั้งหมด</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>เพิ่มสถานที่ใหม่ ๆ ไปยังแผนที่ และแก้ไขสถานที่ที่มีอยู่เดิมจากแอปโดยตรง</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>เปลี่ยนสถานที่ตั้ง</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>ในการดาวน์โหลด คุณต้องมีพื้นที่มากขึ้น กรุณาลบเนื้อหาที่ไม่จำเป็นออกไป</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>ฉันได้ปรับปรุงแผนที่ Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>ข้อคิดเห็นอย่างละเอียด</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>คำแนะนำการเปลี่ยนแปลงของคุณจะถูกส่งไปยังกลุ่ม OpenStreetMap โปรดอธิบายรายละเอียดที่ Organic Maps ไม่สามารถแก้ไขได้</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>มีข้อผิดพลาดเกิดขึ้นในขณะที่กำลังหาที่ตั้งที่คุณอยู่ โปรดตรวจสอบอุปกรณ์ของคุณว่าทำงานถูกต้อง และลองใหม่อีกครั้ง</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>ปิดการใช้งานการระบุตำแหน่งที่ตั้งแล้ว</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>เปิดใช้งานการเข้าถึงตำแหน่งภูมิศาสตร์ในการตั้งค่าอุปกรณ์</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. เปิดการตั้งค่า</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. แตะตำแหน่งที่ตั้ง</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. เลือกในขณะใช้แอป</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. เลือกความเป็นส่วนตัว</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. เลือกบริการระบุตำแหน่ง</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. เปิดบริการระบุตำแหน่ง</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>หรือใช้ต่อที่ Organic Maps โดยไม่ต้องระบุตำแหน่ง</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>จอง</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>โทร</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>ชื่อของ Bookmark</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>ลบ Bookmark</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>บันทึกของคุณจะถูกส่งไปยัง OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…เพิ่มเติม</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>อัปเดต</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>ปิดการใช้งานการบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>ปิดการใช้งาน</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>ตรวจชม</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps ใช้ตำแหน่งทางภูมิศาสตร์ของคุณในพื้นหลังเพื่อบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>การตั้งค่าทั่วไป</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>ในการแสดงข้อมูลการจราจร แอปพลิเคชั่นจะต้องอัปเดตก่อน</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>ขนาดไฟล์บันทึก: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>ลากมาที่นี่เพื่อเอาออก</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>แทนที่หยุด</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>เริ่มจาก</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>กรุณาเข้าสู่ระบบ OpenStreetMap เพื่ออัปโหลดการแก้ไขแผนที่ทั้งหมดของคุณโดยอัตโนมัติ เรียนรู้เพิ่มเติม</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>ที่นี่</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>ซ่อนหน้าจอ</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 จาก %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>กำลังดาวน์โหลด %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>กำลังนำ %1 ไปใช้งาน…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>ชื่อนี้ยาวเกินไป</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>พบไฟล์ใหม่แล้ว</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>แปลง</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>ความผิดพลาด</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>ไฟล์บางไฟล์ไม่ได้รับการแปลง</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>มีข้อผิดพลาดเกิดขึ้น</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>ยอดนิยม</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>ซ่อนจากแผนที่</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>เกิดข้อผิดพลาดขณะโหลดแท็ก โปรดลองใหม่อีกครั้ง</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>ถูกต้อง</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>ด้านล่าง</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>ไปกันเลย</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>จุดหมาย</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>รีเซ็นเตอร์</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>ผลการค้นหา</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>จากนั้น</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>ต้องการสร้างเส้นทางใหม่หรือไม่</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>คีย์บอร์ดไม่สามารถใช้งานได้ขณะขับขี่</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>ไม่สามารถสร้างเส้นทางจากตำแหน่งปัจจุบันของคุณ</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>ไม่สามารถสร้างเส้นทางไปยังจุดหมายของคุณ โปรดเลือกจุดหมายใหม่</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>ไม่มีสัญญาณจีพีเอส โปรดไปในที่โล่งเพื่อหาสัญญาณ</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>ไม่สามารถคำนวณเส้นทาง โปรดระบุตำแหน่งของเส้นทางอื่น</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>เพื่อสร้างเส้นทาง โปรดดาวน์โหลดแผนที่บนอุปกรณ์ของคุณ</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>พบข้อผิดพลาด โปรดปิดและเปิดแอปพลิเคชันใหม่อีกครั้ง</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>เส้นทางจะถูกสร้างอีกครั้งจากตำแหน่งปัจจุบันของคุณ</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>เส้นทางของรถยนต์อาจถูกปรับเปลี่ยน</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>บุ๊กมาร์กไม่แสดงทั้งหมด</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>สลับไปที่โทรศัพท์เพื่อดูบุ๊กมาร์กทั้งหมด</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>จับความเร็ว</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>เตือนความเร็ว</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>โปรดดาวน์โหลดแผนที่ในแอพฯ Organic Maps บนอุปกรณ์ของคุณ</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>ทางออกที่ %1</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>เรียงตามค่าเริ่มต้น</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>เรียงตามประเภท</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>เรียงตามระยะทาง</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>เรียงตามวันที่</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>เรียงตามชื่อ</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>อาหาร</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>ที่ท่องเที่ยว</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>พิพิธภัณฑ์</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>ที่จอดรถ</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>ว่ายน้ำ</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>ภูเขา</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>สวนสัตว์</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>โรงแรม</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>สิ่งปลูกสร้าง</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>เงิน</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>ร้านค้า</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>ที่จอดรถ</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>ปั๊มน้ำมัน/แก๊ส</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>ยา</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>ค้นหาในรายการ</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>สถานที่ทางศาสนา</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>เลือกรายการ</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>ยังไม่สามารถใช้การนำทางรถไฟใต้ดินในภูมิภาคนี้ได้</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>ไม่พบเส้นทางของทางรถไฟใต้ดิน</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>โปรดเลือกจุดเริ่มต้นและสิ้นสุดที่อยู่ใกล้สถานีรถไฟใต้ดิน</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>ความสูง</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>ในการเปิดใช้งานเลเยอร์แผนที่ภูมิประเทศโปรดอัปเดตหรือดาวน์โหลดแผนที่ของบริเวณนั้น</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>เลเยอร์แผนที่ภูมิประเทศยังใช้งานไม่ได้ในพื้นที่นี้</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>การขึ้น</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>การลง</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>ต่ำสุด</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>สูงสุด</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>ลำบาก</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>ระยะทาง</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>เวลา:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>ขยายเข้าเพื่อสำรวจเส้นชั้นความสูง</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>การดาวน์โหลด</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>ดาวน์โหลดแผนที่ภาพรวมของโลก</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>ไม่สามารถสร้างโฟลเดอร์และย้ายไฟล์ในหน่วยความจำภายในหรือ sdcard ได้</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>ข้อผิดพลาดของดิสก์</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>การเชื่อมต่อล้มเหลว</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>ถอดสาย USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>เปิดหน้าจอไว้</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>เมื่อเปิดใช้งาน หน้าจอจะเปิดอยู่เสมอเมื่อแสดงแผนที่</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>แสดงบนหน้าจอล็อก</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>เมื่อเปิดใช้งาน แอปจะทำงานบนหน้าจอล็อกแม้ในขณะที่อุปกรณ์ถูกล็อก</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>ภาษาแผนที่</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>ข้อมูลแผนที่จาก OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>ขอขอบคุณที่ใช้แผนที่ที่สร้างโดยชุมชนของเรา!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>ด้วยการบริจาคและการสนับสนุนของคุณ เราสามารถสร้างแผนที่ที่ดีที่สุดในโลกได้!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>คุณชอบแอพของเราหรือไม่? กรุณาบริจาคเพื่อสนับสนุนการพัฒนา! ยังไม่ชอบมันเหรอ? โปรดแจ้งให้เราทราบ และเราจะแก้ไขมัน!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>หากคุณรู้จักนักพัฒนาซอฟต์แวร์ คุณสามารถขอให้เขาหรือเธอใช้คุณลักษณะที่คุณต้องการได้</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>แตะที่ใดก็ได้บนแผนที่เพื่อเลือกอะไรก็ได้ แตะยาวเพื่อซ่อนและแสดงอินเทอร์เฟซ</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>คุณรู้หรือไม่ว่าคุณสามารถเลือกตำแหน่งปัจจุบันของคุณบนแผนที่ได้?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>คุณสามารถช่วยแปลแอปของเราเป็นภาษาของคุณได้</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>แอพของเราได้รับการพัฒนาโดยผู้ที่ชื่นชอบและชุมชนบางส่วน</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>คุณสามารถแก้ไขและปรับปรุงข้อมูลแผนที่ได้อย่างง่ายดาย</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>เป้าหมายหลักของเราคือการสร้างแผนที่ที่รวดเร็ว เน้นความเป็นส่วนตัว และใช้งานง่ายที่คุณจะหลงรัก</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>ขณะนี้คุณกำลังใช้ Organic Maps บนหน้าจอโทรศัพท์</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>ขณะนี้คุณกำลังใช้ Organic Maps บนหน้าจอรถยนต์</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>คุณเชื่อมต่อกับ Android Auto แล้ว</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>ดำเนินการต่อบนโทรศัพท์</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>ไปที่หน้าจอรถ</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps ต้องการการเข้าถึงตำแหน่ง เมื่อปลอดภัยแล้ว โปรดตรวจสอบการแจ้งเตือนบนโทรศัพท์ของคุณ</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>แอพนี้ต้องได้รับอนุญาตจากคุณ</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps ใน Android Auto ต้องการสิทธิ์การเข้าถึงตำแหน่งเพื่อทำงานอย่างมีประสิทธิภาพ</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>ให้สิทธิ์</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>การเดินป่า</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>เว็บเบราว์เซอร์ไม่พร้อมใช้งาน</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>ระดับเสียง</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>ส่งออกบุ๊กมาร์กและแทร็กทั้งหมด</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>การตั้งค่าการสังเคราะห์เสียงพูดของระบบ</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>ไม่พบการตั้งค่าการสังเคราะห์เสียง คุณแน่ใจหรือไม่ว่าอุปกรณ์ของคุณรองรับ</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>ขับรถผ่าน</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>ล้างการค้นหา</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>ขยายเข้า</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>ซูมออก</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>ลิงค์เมนู</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>ดูเมนู</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>เปิดในแอปอื่น</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>บริการตนเอง</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>เลือกตัวเลือก</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>ที่นั่งกลางแจ้ง</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>เพื่อการนำทางที่แม่นยำที่สุด เราขอแนะนำให้ปิดใช้งานโหมดประหยัดพลังงานในการตั้งค่าแบตเตอรี่ของโทรศัพท์</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>บันทึกเส้นทาง</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>หยุดการบันทึกเส้นทาง</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>บันทึกเส้นทาง</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>หยุดโดยไม่บันทึก</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>ดำเนินการบันทึกต่อ</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>บันทึกการบันทึกลงในบุ๊กมาร์กและการติดตามใช่ไหม</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>เส้นทางว่างเปล่า - ไม่มีอะไรจะบันทึก</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>ไม่สามารถแสดงกล่องโต้ตอบการเลือกโฟลเดอร์ได้เนื่องจากไม่ได้ติดตั้งแอปที่เหมาะสมในอุปกรณ์ของคุณ โปรดติดตั้งแอปตัวจัดการไฟล์แล้วลองอีกครั้ง</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>เลือกสี</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>แก้ไขเส้นทาง</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>ไม่มีการติดตั้งแอปที่สามารถเปิดตำแหน่งได้</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>อัตโนมัติในการนำทาง</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>ตามระบบ</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>แชร์ติดตาม</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>ลบ %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>ระดับความยาก</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>ง่าย</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>ปานกลาง</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>ยาก</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>การอัปเดต</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>อัปเดตแผนที่ที่คุณดาวน์โหลดมา</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>การอัปเดตแผนที่จะคงข้อมูลเกี่ยวกับจุดหมายต่าง ๆ ให้ล่าสุดอยู่เสมอ</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>อัปเดต (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>อัปเดตด้วยตนเองภายหลัง</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>ลบเพลง</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>คุณแน่ใจหรือไม่ว่าต้องการลบแทร็กนี้</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>ชื่อเพลง</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>ย้าย</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>ติดตาม</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>เปลี่ยนสี</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>แผนที่</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>คุณต้องการส่งรายงานข้อผิดพลาดไปยังนักพัฒนาหรือไม่?
+เราไว้วางใจผู้ใช้ของเราเนื่องจาก Organic Maps จะไม่รวบรวมข้อมูลข้อผิดพลาดใด ๆ โดยอัตโนมัติ ขอขอบคุณล่วงหน้าสำหรับการสนับสนุน Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>เปิดใช้งานการซิงโครไนซ์ iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>การซิงโครไนซ์ iCloud เป็นคุณสมบัติทดลองที่อยู่ระหว่างการพัฒนา ตรวจสอบให้แน่ใจว่าคุณได้สำรองข้อมูลบุ๊กมาร์กและแทร็กทั้งหมดของคุณแล้ว</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud ถูกปิดใช้งาน</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>โปรดเปิดใช้งาน iCloud ในการตั้งค่าอุปกรณ์ของคุณเพื่อใช้คุณสมบัตินี้</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>เปิดใช้งาน</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>สำรองข้อมูล</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>การซิงโครไนซ์ iCloud ล้มเหลว</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>ข้อผิดพลาด: ไม่สามารถซิงโครไนซ์ได้เนื่องจากข้อผิดพลาดในการเชื่อมต่อ</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>ข้อผิดพลาด: ไม่สามารถซิงโครไนซ์ได้เนื่องจากเกินโควต้า iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>ข้อผิดพลาด: iCloud ไม่พร้อมใช้งาน</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>รายการที่ถูกลบล่าสุด</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>ล้าง</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>ลบทั้งหมด</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>กู้คืน</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>กู้คืนทั้งหมด</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>มีส่วนร่วมกับ OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>เพิ่มสถานที่</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>อัปเดตแผนที่เพื่อมีส่วนร่วม</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>คุณต้องอัปเดตแผนที่ %1 เป็นเวอร์ชันล่าสุดก่อนจึงจะสามารถมีส่วนร่วมกับข้อมูล OpenStreetMap ได้</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>ตำแหน่งของฉัน</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>สถานที่ของฉัน</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>พื้นที่จัดเก็บข้อมูลส่วนตัวภายใน</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>พื้นที่จัดเก็บข้อมูลที่ใช้ร่วมกันภายใน</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>การ์ด SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>พื้นที่จัดเก็บข้อมูลที่ใช้ร่วมกันภายนอก</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>รหัสไปรษณีย์</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>จุดแผนที่</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>ม.</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>กม.</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ไมล์</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ฟุต</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>เพื่อแสดงเส้นทาง แผนที่ต้องได้รับการอัปเดต</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>ออก</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>ทางเข้า</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>แผนที่รถไฟใต้ดินไม่พร้อมใช้งาน</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>คุณ</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>พื้นที่ดาวน์โหลดสีม่วง</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>เส้นทาง</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>จำเป็นต้องทำการระบุตำแหน่งปัจจุบันในพื้นหลังเพื่อเพลิดเพลินกับการใช้งานแอปอย่างเต็มรูปแบบ มันจะได้รับการใช้เป็นหลักสำหรับตัวเลือกในการติดตามเส้นทางและการบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>มีการใช้การระบุตำแหน่งปัจจุบันในตัวเลือกการเดินทางตามเส้นทางและการบันทึกเส้นทางที่คุณเดินทางล่าสุด</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>เข้าสู่ระบบด้วยรหัสผ่าน</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>เข้าสู่ระบบโดยใช้เบราว์เซอร์</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>ใช้ล่าสุด</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>สีที่คั่นหน้าเปลี่ยนแล้ว</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>สีแทร็กเปลี่ยนแล้ว</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>สเปกตรัม</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>สไลเดอร์</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>สีแดง</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>เขียว</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>สีน้ำเงิน</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>สี sRGB ในรูปแบบ Hex #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>กริด</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/tr/omim.ts
+++ b/qt/translations/tr/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="tr">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Geri</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>İptal</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Sil</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Harita İndir</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>İndirme başarısız. Yeniden denemek için dokun.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>İndiriliyor…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilometre</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Mil</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Sonra</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Ara</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Haritada Ara</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Şu anda bu aygıt veya uygulama için tüm Konum Hizmetleri devre dışı bırakılmış. Lütfen bunu ayarlardan etkinleştirin.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Sınırlı Doğruluk</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Doğru navigasyon sağlamak için ayarlardan Hassas Konum&#x27;u etkinleştirin.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Haritada göster</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>İndirme başarısız oldu</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Yeniden Dene</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Organic Maps Hakkında</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Sevgiyle yapılmış, herkes için ücretsiz harita</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Reklam yok, izleyici yok, veri toplama yok</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Pilinizi tüketmez, çevrim dışı çalışır</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Hızlı, minimalist, toplulukça geliştirilmiş</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Teknoloji tutkunları ve gönüllülerce oluşturulan açık kaynaklı uygulama.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Konum ayarları</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Kapat</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Uygulama, donanım hızlandırmalı OpenGL gerektiriyor. Ne yazık ki aygıtınız desteklenmiyor.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>İndir</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Organic Maps’i kullanabilmek için lütfen USB kablosunun bağlantısını kesin veya hafıza kartı takın</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Uygulamayı kullanabilmek için lütfen SD kart/USB depolama aygıtında biraz alan boşaltın</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Uygulamayı kullanmadan önce lütfen aygıtınıza dünya genel görünüm haritasını indirin.
+Bu, %1 alan kullanacaktır.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Haritaya Git</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>%1 indiriliyor. Şimdi haritaya
+gidebilirsiniz.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>%1 indir?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>%1 güncelle?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Duraklat</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Sürdür</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1 indirme işlemi başarısız oldu</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Yeni Liste Ekle</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Yer İmi Listesi Adı</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Yer İmleri</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Yer İmleri ve İzler</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Adı</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Adres</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Liste</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Ayarlar</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Haritaları şuraya kaydet:</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Haritaların indirileceği yeri seç.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Haritalar</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%2&#x27;ın %1&#x27;ı boş</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Haritalar taşınsın mı?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Harita dosyalarını taşıma hatası</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Bu işlem birkaç dakika sürebilir.
+Lütfen bekleyin…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Ölçü birimleri</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Mil veya kilometre seçimini yap</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>İndirmeyi İptal Et</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Yorum Bırak</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Evet</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Haritayı İndir</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Yer İmi Listeleri</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Nerede yenir</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Market</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Ulaşım</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Benzinlik</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Otopark</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Alışveriş</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>İkinci el</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Otel</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Görülecek yerler</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Eğlence</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Bankamatik</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Gece hayatı</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Aile tatili</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Banka</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Eczane</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Hastane</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>WC</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Posta</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Polis</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Geri dönüşüm</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Su</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Karavan tesisleri</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Notlar</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Seninle paylaşılan Organic Maps yer imleri</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Merhaba!&#32;
+&#32;
+Ektekiler yer imlerim, lütfen bunları Organic Maps&#x27;te açın. Eğer uygulama kurulmamışsa, şu bağlantıyla iOS ve Android aygıtınıza kurabilirsiniz: https://omaps.app/get?kmz
+&#32;
+Organic Maps ile gezintinin tadını çıkarın!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Yer İmleri Yükleniyor</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Yer İmleri başarılıyla yüklendi! Bunları haritada ya da Yer İmleri Yöneticisi ekranında bulabilirsiniz.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Yer İmlerini yükleme işlemi başarısız oldu. Dosya bozuk ya da hatalı olabilir.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Dosya türü uygulamaca tanınmıyor:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Dosya açılamadı %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Düzenle</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Konumunuz henüz belirlenmedi</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Üzgünüz, Harita Depolama ayarları şu anda devre dışı.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Harita indirme işlemi şu anda sürüyor.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Hey, Organic Maps’te geçerli konumumu incele! %1 veya %2 Çevrimdışı haritalar sende yok mu? Buradan indir: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Hey, Organic Maps&#x27;teki imimi incele!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Hey, Organic Maps’te geçerli konumumu incele!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Merhaba,
+
+Şu anda bulunduğum yer: %1. Yeri haritada görmek için %2 veya %3 bağlantısına tıkla.
+
+Teşekkürler.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Paylaş</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>E-posta</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Panoya kopyalandı: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Bitti</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap verileri: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>OpenStreetMap hesabınızdan çıkış yapmak istediğinizden emin misiniz?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>İzler</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Uzunluk</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Konumumu Paylaş</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Genel ayarlar</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Bilgi</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Navigasyon</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Haritadaki + ve - düğmeleri</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Haritada göster</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Karanlıkta navigasyon yaparken gece stili</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Gece Modu</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Kapalı</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Açık</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Kendiliğinden</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Perspektif görünümü</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3B yapılar</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3B yapılar güç tutum kipindeyken kapatılır</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Sesli Yönlendirme</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Sokak Adlarını Söyle</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Etkinleştirildiğinde, dönülecek sokağın veya çıkışın adı sesli olarak söylenecektir.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Ses Dili</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Daha yüksek kaliteli bir ses indirmek için Ayarlar uygulamasını açın ve Erişilebilirlik → VoiceOver → Konuşma → Ses bölümüne gidin.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Sesli Yönlendirmeleri Sına (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Sesi şimdi duymuyorsanız ses düzeyini veya sistem metin okuma ayarlarını denetleyin.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Yok</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Kendiliğinden yaklaştır</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Mesafe</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Haritada görüntüle</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menü</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Web Sitesi</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Haberler</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Geri Bildirim</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Uygulamayı değerlendir</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Yardım</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Sıkça Sorulan Sorular</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Bağış yap</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Zaten bağış yaptım</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Sonra hatırlat</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Organic Maps’i Destekleyin</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Bu projeyi destekleyin</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Telif hakkı</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Hata bildir</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Pusulayı kalibre etmek için telefonu sekiz biçiminde oynatarak ok yönünü iyileştirin.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Pusulayı kalibre etmek ve haritadaki ok yönünü düzeltmek için telefonu sekiz biçiminde oynatın.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Arayüzü görmek için haritaya uzun basın</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Tümünü Güncelle</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Tümünü İptal Et</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>İndirilenler</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Sırada</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Yakınlarımda</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Haritalar</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Tümünü İndir</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>İndiriliyor:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Haritayı silmek için lütfen navigasyonu durdurun.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Rotalar yalnızca tümüyle tek bir bölgenin haritası içinde oluşturulabilir.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Haritayı indir</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Yeniden Dene</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Haritayı Sil</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Haritayı Güncelle</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play Konum Hizmetleri</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Bluetooth, WiFi veya mobil ağ üzerinden yaklaşık konumunuzu hızlıca belirleyin</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Rota üzerindeki tüm haritaları indir</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Rota oluşturabilmemiz için bulunduğunuz yerden hedefinize dek tüm haritaları indirmemiz ve güncellememiz gerekiyor.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Yeterli alan yok</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Lütfen konum hizmetlerini etkinleştirin</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Kaydet</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>oluştur</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Kırmızı</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Sarı</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Mavi</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Yeşil</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Mor</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Turuncu</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Kahverengi</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Pembe</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Koyu Mor</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Açık Mavi</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Cam Göbeği</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Deniz Mavisi</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Çim Rengi</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Koyu Turuncu</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Gri</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Mavi Gri</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Bilgi</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps sürümü: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Görünüm</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Açık</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Koyu</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Şafaktan gün batımına kadar açık</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Diğer</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Milyonlarca kullanıcıya reklamsız ve ücretsiz haritalar hediye edin!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Haritadaki hataları bildir ya da düzelt</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Gönüllü ol</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Bizi izle ve iletişime geç:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>E-posta istemcisi henüz kurulmamış. Lütfen e-posta istemcisini yapılandırın veya bize %1 adresinden ulaşmak için başka bir yöntem deneyin</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>E-Posta gönderme hatası</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Pusula kalibrasyonu</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Var</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Bulundu</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Güncelle</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Başarısız</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>yer i̇mi</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Rotanızı izlerken şunları lütfen unutmayın:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Yol koşulları, trafik kuralları ve trafik işaretleri her zaman navigasyon önerilerinden önceliklidir;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Harita doğru olmayabilir, önerilen rota da hedefinize ulaşmak için en uygun yol olmayabilir;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Önerilen rotalar yalnızca öneri olarak kabul edilmelidir;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Sınır bölgelerinde rotalar konusunda dikkatli olun: uygulamamızca oluşturulan rotalar bazen izin verilmeyen yerlerdeki ülke sınırlarından geçebilir.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Lütfen yolda özenli ve güvenli olun!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>GPS sinyalini denetle</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Rota oluşturulamıyor. Şu anki GPS koordinatları tanımlanamadı.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Lütfen GPS sinyalinizi denetleyin. Wi-Fi&#x27;ı etkinleştirmek konum doğruluğunu artırır.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Konum hizmetlerini etkinleştir</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Şu anki GPS koordinatları belirlenemiyor. Rota hesaplamak için konum hizmetlerini etkinleştirin.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Rota belirlenemiyor</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Rota oluşturulamıyor.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Lütfen başlangıç noktanızı veya hedefinizi ayarlayın.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Başlangıç noktasını ayarla</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Rota oluşturulamadı. Başlangıç noktası belirlenemiyor.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Lütfen yola daha yakın bir başlangıç noktası seçin.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Hedefinizi ayarlayın</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Rota oluşturulamadı. Hedef belirlenemiyor.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Lütfen yola daha yakın hedef noktası seçin.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Ara nokta bulunamadı.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Lütfen ara noktanızı ayarlayın.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Sistem hatası</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Uygulama hatası nedeniyle rota oluşturulamadı.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Lütfen yeniden deneyin</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Şimdi Değil</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Haritayı indirerek birden çok haritaya uzanan daha uygun bir rota oluşturmak ister misiniz?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Bu haritanın bir bölümünden geçen daha uygun rota oluşturmak için harita indir.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Gerekli dosyaları indir</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Planlanan yoldaki tüm harita ve rota bilgilerini indirip güncelleyerek rotayı hesaplayın.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Aramak ve rota oluşturmaya başlamak için lütfen haritayı indirin. İndirdikten sonra internet bağlantısına gerek kalmayacak.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Haritayı Seçin</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Göster</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Gizle</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Kategoriler</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Geçmiş</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Tüh, sonuç bulunamadı.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Arama yapmak istediğiniz bölgenin haritasını indirin veya yakındaki bir yerleşim yeri adını eklemeyi deneyin.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Arama Geçmişi</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Son aramalarınızı görüntüleyin.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Arama Geçmişini Temizle</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Vikipedi</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>wikipedia.org&#x27;dan makale</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Konumunuz</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Başla</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Başlangıç</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Varış yeri</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Navigasyon yalnızca şu anki konumunuzdan kullanılabilir.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Şu anki konumunuzdan rota planlamamızı ister misiniz?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Sonraki</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Açılış</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Kapanış</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Plan Ekle</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Planı Sil</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Tüm Gün (24 saat)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Açık</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Kapalı</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Kapalı olduğu saatleri ekle</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Açık olduğu saatler</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Gelişmiş Kip</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Basit Kip</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Kapalı olduğu saatler</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Örnek Değerler</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Hatayı düzelt</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Konum Seç</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>OpenStreetMap topluluğunun hatayı düzeltmesi için lütfen sorunu ayrıntılı açıklayın.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Veya bunu https://www.openstreetmap.org/ adresinden kendiniz yapın</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Gönder</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Sorun</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Yer yok</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Bakım için kapalı</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Kopyalanmış yer</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Haritaları kendiliğinden indir</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Her gün</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>7/24</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Bugün kapalı</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Kapalı</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Bugün</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>%1 sonra açılıyor</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>%1 sonra kapanıyor</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Kapalı</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Çalışma saatlerini düzenle</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>OpenStreetMap hesabınız yok mu?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>OpenStreetMap&#x27;e kaydol</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Oturum aç</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Giriş yapılmadı</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>OpenStreetMap&#x27;e giriş yap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Şifre</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Şifrenizi mi unuttunuz?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Oturumu kapat</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Yeri Düzenle</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Dil ekle</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Sokak</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Bina numarası</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Ayrıntılar</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Sosyal Medya</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Bina</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Sokak ekle</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Lütfen bir sokak adı girin</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Dil seç</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Sokak seç</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Mutfak</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Mutfak Seç</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>E-posta veya kullanıcı adı</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Telefon Ekle</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Kat</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Kat sayısı: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Harita ile birlikte tüm harita değişiklikleri de silinecektir.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Haritaları güncelle</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Rota oluşturmak için tüm haritaları güncellemeli ve rotayı yeniden planlamalısınız.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Harita bul</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Lütfen aygıtınızın internete bağlandığından emin olun.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Yeterli alan yok</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Lütfen gereksiz verileri silin</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Giriş hatası.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Doğrulanan Düzenleme</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Çarpı imini mekân veya işletmenin konumuna yerleştirmek için haritayı sürükleyin.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Düzenleme</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Ekleme</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Yerin adı</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Yerel dilde yazıldığı gibi</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Kategori</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Sorunun ayrıntılı açıklaması</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Farklı bir sorun</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Kuruluş ekle</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Buraya bir nesne konumlandırılamıyor</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>%1 tarihine ait topluluk tarafından oluşturulmuş OpenStreetMap verilerini kullanıyorsunuz. OpenStreetMap.org adresinden haritayı nasıl düzenleyebileceğiniz hakkında bilgi edinebilirsiniz</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM), özgür ve açık harita oluşturmayı amaçlayan topluluk projesidir. OSM, Organic Maps&#x27;teki harita verisinin ana kaynağıdır ve Vikipedi&#x27;ye benzer çalışır. Yerler ekleyebilir ya da düzenleyebilirsiniz ve bunlar tüm dünyadaki milyonlarca kullanıcıca erişilebilir.
+Topluluğa katılın ve herkes için daha iyi harita oluşturmaya yardımcı olun!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Harita düzenlemelerinizi herkese ulaştırmak için OpenStreetMap hesabı oluşturun veya oturum açın.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1/%2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Hücresel bir ağ bağlantısı kullanarak indirilsin mi?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Bu işlem, bazı planlarda veya dolaşımda oldukça pahalı olabilir.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Geçerli bir bina numarası girin</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Kat sayısı (en çok %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Kat sayısı %1&#x27;i geçmemelidir</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Posta Kodu</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Geçerli posta kodu gir</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap gönüllülerine not (isteğe bağlı)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Organic Maps ile haritadaki hataları veya düzenlenemeyen öğeleri açıklayın</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Düzenlemeleriniz halka açık &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Tr:About&quot;&gt;OpenStreetMap&lt;/a&gt; veri tabanına yüklenir. Lütfen kişisel ya da telif hakkıyla korunan bilgi eklemeyin.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>OpenStreetMap ile ilgili ek bilgi</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Düzenleme geçmişiniz</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Harita veri notlarınız</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>İşletici</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>İşletici: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Uygun kategori bulamıyor musunuz?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps yalnızca basit nokta kategorilerini eklemeyi sağlar. Yani kasaba, yol, göl, bina vb. çizgi/alan verisi ekleme desteği yoktur. Lütfen bu tür kategorileri doğrudan &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; üzerinden ekleyin. Adım adım ayrıntılı yönergeler için &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;yönergemize&lt;/a&gt; göz atabilirsiniz.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Hiç harita indirmediniz</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Çevrim dışı olarak adres bulmak ve gezinmek için haritaları indirin.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Geçerli konum bilinmiyor.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/sa</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>saatte mil</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>sa</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>dk</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>g</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>sn</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Diğer</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Yer İmini Düzenle</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Kişisel notlar (metin veya html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Yorum…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Tüm yerel değişiklikler sıfırlansın mı?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Sıfırla</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Eklenen yer kaldırılsın mı?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Kaldır</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Bu yer yok</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Lütfen bu yerin silinmesinin nedenini belirtin</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Geçerli bir telefon numarası girin</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Geçerli bir web adresi girin</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Geçerli bir e-posta girin</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Geçerli bir Facebook web adresi, hesap veya sayfa adı girin</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Geçerli bir İnstagram web adresi veya hesap adı girin</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Geçerli bir Twitter web adresi veya kullanıcı adı girin</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Geçerli bir VK web adresi veya hesap adı girin</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Geçerli bir LINE web adresi veya LINE ID&#x27;si girin</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>OpenStreetMap&#x27;e Yer Ekle</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Ya da OpenStreetMap topluluğuna not bırakabilirsiniz, böylece biri burayı düzeltebilir ya da yenisini ekleyebilir.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Not OpenStreetMap&#x27;e gönderilecek</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Bunu tüm kullanıcılara göndermek ister misiniz?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Herhangi bir kişisel bilgi girmediğinizden emin olun.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap editörleri değişikliklerinizi denetleyecek ve bir soruları olursa sizinle iletişime geçecek.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Dur</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>İz kaydediliyor</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Kabul Et</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Reddet</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Ayrıntılı bilgileri görüntülemek için mobil internet kullanılsın mı?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Her Zaman Kullan</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Yalnızca Bugün</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Bugün Kullanma</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Mobil İnternet</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Harita güncelleme bildirimleri ve yapılan düzenlemelerin yüklenmesi için mobil internet gereklidir.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Asla Kullanma</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Her Zaman Sor</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Trafik verilerini görüntülemek için haritaların güncellenmesi gerekiyor.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Haritadaki yazı tipi boyutunu artır</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Lütfen Organic Maps&#x27;i güncelleyin</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Trafik verileri kullanılamıyor</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Günlüğü etkinleştir</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Genel Geri Bildirim</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Sesli yönlendirme için TTS sistemini kullanıyoruz. Çoğu Android aygıt, Google TTS&#x27;yi kullanıyor. Uygulamayı, Google Play&#x27;den indirebilir veya güncelleyebilirsiniz</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Bazı diller için uygulama mağazasından (Google Play, Galaxy Store, App Gallery, FDroid) başka konuşma sentezleyici ya da ek dil paketi kurmanız gerekebilir.
+Aygıt ayarları → Dil ve Giriş → Konuşma → Metin Okuma seçeneğini açın.
+Buradan konuşma sentezi ayarlarını yönetebilir (örneğin, çevrim dışı kullanım için dil paketini karşıdan yükleyebilir) ve başka metin okuma motorunu seçebilirsiniz.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Daha fazla bilgi için lütfen bu kılavuzu inceleyin.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Latin alfabesine çevir</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Daha fazla bilgi edinin</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Rota başlangıç noktası eklemek için aramayı kullanın, yer imi seçin ya da haritaya dokunun</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Hedef noktası eklemek için aramayı kullanın, yer imi seçin ya da haritaya dokunun</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Rotayı yönet</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Plan</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Durağı Kaldır</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Ara nokta ekle</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Kaydedildi</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Tüm harita düzenlemelerinizi kendiliğinden yüklemek için lütfen OpenStreetMap&#x27;e giriş yapın. Daha çok bilgi &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;buradadır&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Depolama alanı erişim sorunu</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Dış depolamaya erişilemiyor. Büyük olasılıkla SD Kart çıkarılmış, hasarlı ya da dosya sistemi salt okunur. Lütfen denetleyin veya support@organicmaps.app adresinden bizimle iletişime geçin</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Bozuk depolama alanını taklit et</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Lütfen doğru ad girin</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Listeler</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Tümünü gizle</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Tümünü göster</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n yer imi</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Yeni liste oluştur</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Yer İmlerini ve İzleri İçe Aktar</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Uygulama hatası nedeniyle paylaşılamıyor</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Paylaşım hatası</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Boş liste paylaşılamaz</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Ad boş olamaz</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Lütfen liste adını girin</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Yeni liste</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Bu ad zaten alınmış</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Lütfen başka ad seçin</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Lütfen bekleyin…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Telefon numarası</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap profili</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n dosya bulundu. Dönüştürmeden sonra onları görebilirsiniz.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Geri al</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n iz</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Gizlilik</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Gizlilik politikası</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Kullanım koşulları</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Trafik</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Yürüyüş</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Bisiklet</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Metro</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Harita Stilleri ve Katmanlar</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Bu liste boş</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Yer imi eklemek için önce haritadaki bir yere sonrasında ise yıldız simgesine dokunun</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Tüm yer imlerinin rengini değiştir</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Tüm izlerin rengini değiştir</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…daha fazla</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>KMZ Olarak Dışa Aktar</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>GPX Olarak Dışa Aktar</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>GeoJSON Olarak Dışa Aktar</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Listeyi sil</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Hız kameraları</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Yer Açıklaması</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Harita indirici</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Hız sınırını aşma riski varsa uyar</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Her zaman uyar</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Hiçbir zaman uyarma</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Güç tutum kipi</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Kimi işlevler pahasına olsa da güç kullanımını düşürmeyi dener.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Asla</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Pil düşükken</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Her zaman</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Haritadaki yer imi adları</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Eğer çok yer imi varsa, adlarını haritada göstermek uygulamayı yavaşlatabilir.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Sağa doğru göster</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Altta göster</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Bu seçenek tanılama amacıyla günlüğe kaydetmeyi açar. Ekibimizin uygulamayla ilgili sorunları gidermesine yardımcı olabilir. Sorununuzla ilgili ayrıntılı günlükleri kaydetmek ve bize göndermek için bu seçeneği geçici olarak etkinleştirin.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Yönlendirme seçenekleri</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Ücretli yollardan kaçın</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Asfaltsız yollardan kaçın</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Vapurdan kaçın</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Otobandan kaçın</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Rota hesaplanamıyor</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Rota bulunamadı. Bunun nedeni, belirlediğiniz seçenekler ya da eksik OpenStreetMap verisi olabilir. Lütfen rota seçeneklerinizi değiştirin ve yeniden deneyin.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Kaçınılması gereken yolları tanımlayın</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Sürüş seçenekleri etkinleştirildi</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Paralı yol</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Asfaltsız yol</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Vapur geçişi</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Evet</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Hayır</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Var</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Yok</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Kapasite: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Ağ: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Vardınız!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Tamam</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sırala…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Yer imlerini sırala</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Varsayılana göre</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Türe göre</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Mesafeye göre</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Tarihe göre</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>İsme göre</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Bir hafta önce</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Bir ay önce</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Bir aydan daha önce</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Bir yıldan daha önce</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Bana yakınlarda</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Diğerleri</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Rota Planlaması Başarısız</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Varış: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Dünya haritasını değiştirdiniz. Bunu gizlemeyin! Arkadaşlarınıza anlatın ve birlikte düzenleyin.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Arkadaşlarınla paylaş</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Şu anda kapalı</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Açılış yarın %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Açılış %1 %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Açılış %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Kapanış %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Açılış saatlerini ekle</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Parola (en az 8 karakter)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Geçersiz kullanıcı adı ya da parola.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM Hesabı</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Son yükleme</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Teşekkür ederiz</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Yerin Adı</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Telefon</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Lütfen dikkat</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>İndirme hatası</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Kategori seç</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Popüler</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Tüm kategoriler</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Doğrudan uygulamadan haritaya yeni yerler ekleyin ve var olan yerleri düzenleyin.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Konumu değiştir</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>İndirmek için daha çok alan gerekiyor. Lütfen gereksiz verileri silin.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Organic Maps&#x27;in haritasını düzenledim</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Ayrıntılı yorum</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Önerdiğiniz değişiklikler OpenStreetMap topluluğuna gönderilecek. Organic Maps’te düzenlenemeyen ayrıntıları açıklayın.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Konumunuz aranırken bir hata oluştu. Aygıtınızın düzgün çalışıp çalışmadığını denetleyin ve daha sonra yeniden deneyin.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Konum hizmetleri devre dışı bırakıldı</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Aygıt ayarlarında coğrafi konuma erişim izni verin</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Ayarları Açın</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Konuma Dokunun</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. &quot;Uygulamayı Kullanırken&quot;i Seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Gizlilik&#x27;i seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Konum Servisleri&#x27;ni seçin</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Konum Servislerini Açın</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Veya Konum olmadan Organic Maps kullanmaya devam edin</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Rezervasyon</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Ara</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Yer İmi Adı</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Yer İmini Sil</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Notunuz OpenStreetMap&#x27;e gönderilecektir</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…daha fazla</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Yenile</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>En son seyahat edilen rotanızı kaydetmeyi devre dışı bırakmak istiyor musunuz?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Devre Dışı Bırak</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>İncele</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps, en son seyahat ettiğiniz rotayı kaydetmek için arka planda coğrafi konumunuzu kullanır.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Genel ayarlar</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Trafik verilerini görüntülemek için uygulamanın güncellenmesi gerekiyor.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Günlük dosyası boyutu: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Kaldırmak için buraya sürükleyin</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Durağı Değiştir</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Buradan başla</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Tüm harita düzenlemelerinizi otomatik olarak yüklemek için lütfen OpenStreetMap&#x27;e giriş yapın. Daha fazla bilgi</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>burada</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ekranı Gizle</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>%1 indiriliyor…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>%1 uygulanıyor…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Bu ad çok uzun</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Yeni dosyalar algılandı</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Dönüştür</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Hata</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Bazı dosyalar dönüştürülmedi.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Bir hata oluştu</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Popüler</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Haritadan gizle</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Etiketler yüklenirken bir hata oluştu, lütfen yeniden deneyin</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Sağ</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Alt</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Haydi gidelim</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Hedef</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Yeniden ortala</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Arama sonuçları</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Sonra</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Yeniden bir rota oluşturmak ister misiniz?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Klavye sürüş sırasında kullanılamaz</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Geçerli konumunuzdan rota oluşturulamıyor</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Hedefinize rota oluşturulamıyor. Lütfen başka bir nokta seçin</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>GPS sinyali yok. Lütfen açık bir alana geçin</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Rota oluşturulamıyor. Lütfen başka bir rota noktası belirtin</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Rota oluşturmak için eksik haritaları aygıtınıza indirin</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Hata oluştu. Lütfen uygulamayı yeniden başlatın</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Rota, geçerli konumunuzdan yeniden oluşturulacak</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Rota, bir araba sürüş rotasına dönüştürülecek</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Tüm yer imleri gösterilmiyor</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Tüm yer imlerini görmek için telefona geçin</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Hız kameraları</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Hız uyarıları</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Lütfen telefonunuzdaki Organic Maps&#x27;ten haritaları indirin</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 çıkış</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Varsayılana göre sırala</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Türe göre sırala</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Mesafeye göre sırala</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Tarihe göre sırala</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>İsme göre sırala</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Yiyecek</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Görülecek yerler</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Müzeler</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Parklar</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Yüzme</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Dağlar</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Hayvanlar</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Oteller</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Binalar</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Para</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Mağazalar</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Otoparklar</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Benzin istasyonları</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>İlaç</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Listede ara</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Dini yerler</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Liste seç</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Metro navigasyonu henüz bu bölgede kullanılamaz</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Metro rotası bulunamadı</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Metro istasyonuna en yakın rotanın başlangıç veya bitiş noktasını seçin</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>İzohipsler</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Arazi katmanını etkinleştirmek ve kullanmak için lütfen haritayı güncelleyin veya indirin</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>İzohipsler henüz bu bölgede kullanılamaz</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Tırmanış</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>İniş</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. yükselti</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Maks. yükselti</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Zorluk</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Mesafe:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Süre:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>İzohipsleri görmek için haritayı büyütün</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>İndiriliyor</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Dünya genel görünüm haritasını indir</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Aygıtın iç belleğinde ya da SD kartta klasör oluşturulamıyor ve dosyalar taşınamıyor</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Disk hatası</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Bağlantı hatası</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>USB kablosunu çıkarın</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Ekranı açık tut</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Etkinleştirildiğinde, harita görüntülenirken ekran her zaman açık olacaktır.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Kilit ekranında göster</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Etkinleştirildiğinde, aygıt kilitli olsa da uygulama kilit ekranında çalışacaktır.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Harita dili</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Harita verileri OpenStreetMap&#x27;ten</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsTR</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmapstr</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/tr/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/tr/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Tr:About</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Toplulukça oluşturulan haritalarımızı kullandığınız için teşekkür ederiz!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Bağışlarınız ve desteğinizle dünyanın en iyi haritalar uygulamasını oluşturabiliriz!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Uygulamamızı beğendiniz mi? Geliştirmemizi desteklemek için lütfen bağış yapın! Henüz beğenmediniz mi? Lütfen beğenmediğiniz şeyleri bize bildirin, düzelteceğiz!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Yazılım geliştirici tanıyorsanız, ondan gereksindiğiniz bir özelliği uygulamaya eklemesini isteyebilirsiniz.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Herhangi bir şeyi seçmek için haritaya dokunun. Uzun dokunarak arayüz gizlenip gösterilebilir.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Haritada şu anki konumunuzu seçebileceğinizi biliyor musunuz?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Uygulamamızın kendi dilinize çevrilmesine yardımcı olabilirsiniz.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Uygulamamız birkaç teknoloji tutkunu ve toplulukça geliştirilmiştir.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Harita verilerini kolayca düzeltebilir ve iyileştirebilirsiniz.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Temel amacımız hızlı, gizlilik odaklı, kullanımı kolay, seveceğiniz bir harita uygulaması oluşturmaktır.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Artık Organic Maps&#x27;i telefon ekranında kullanıyorsunuz</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Şu anda araç ekranında Organic Maps kullanıyorsunuz</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Android Auto&#x27;ya bağlandınız</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Telefonda sürdür</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Arabada göster</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps konum erişimine gereksinir. Güvenliyken, telefonunuzdaki bildirime bakın.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Bu uygulama izninize gereksiniyor</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto&#x27;daki Organic Maps etkin çalışmak için konum iznine gereksiniyor</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>İzinleri Verin</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Açık Hava</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Web tarayıcısı yok</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Ses</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Tüm Yer İmlerini ve İzleri Dışa Aktar</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Konuşma sentezleme ile ilgili sistem ayarları</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Konuşma Sentezi ayarları bulunamadı, aygıtınızın bunu desteklediğine emin misiniz?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Arabaya servis</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Aramayı temizleyin</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Yakınlaştır</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Uzaklaştır</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Menü Bağlantısı</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Menüyü Görüntüle</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Başka Uygulamada Aç</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Self servis</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Seçeneği seçin</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Açık oturma alanı</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>En doğru navigasyon için telefonunuzun pil ayarlarından güç tutum kipini devre dışı bırakmanızı öneririz.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>İzi Kaydet</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>İz Kaydını Durdur</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Rota Kaydı</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Kaydetmeden Durdur</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Kaydı Sürdür</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Yer İmleri ve İzlere kaydedilsin mi?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>İz boş - kaydedilecek bir şey yok</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Aygıtınızda gerekli uygulama kurulmadığından klasör seçim menüsü görüntülenemiyor. Lütfen dosya yönetici uygulaması kurun ve yeniden deneyin.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Renk Seç</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>İzi Düzenle</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Konumu açabilecek kurulu uygulama yok</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Navigasyonda kendiliğinden</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Sistemi takip et</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>İz Paylaş</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>%1 Silinsin Mi?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Zorluk seviyesi</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Kolay</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Orta</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Zor</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Güncelleniyor</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>İndirdiğiniz haritaları güncelleyin</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Haritaları güncellemek, objelerle ilgili bilgilerin güncel kalmasını sağlar</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Güncelle (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Daha sonra elle güncelle</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>İzi Sil</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Bu izi silmek istediğinizden emin misiniz?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>İz Adı</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Taşı</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>İz</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Renk Değiştir</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Harita</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Geliştiricilere bir hata raporu göndermek ister misiniz?
+Organic Maps otomatik olarak herhangi bir hata bilgisi toplamadığı için bu konuda kullanıcılarımıza güveniyoruz. Organic Maps&#x27;i desteklediğiniz için şimdiden teşekkür ederiz!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>iCloud Senkronizasyonunu Etkinleştir</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud eşzamanlaması geliştirme aşamasındaki deneysel bir özelliktir. Tüm yer imleri ve izlerinizi yedeklediğinizden emin olun.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud Devre Dışı</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Bu özelliği kullanmak için lütfen aygıtınızın ayarlarında iCloud&#x27;u etkinleştirin.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Etkinleştir</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Yedekle</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud senkronizasyon hatası</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Hata oluştu: Bağlantı hatası nedeniyle senkronizasyon başarısız oldu</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Hata: iCloud depolama alanı dolu olduğu için senkronize edilemedi</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Hata: iCloud kullanılamıyor</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Son Silinen Listeler</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Temizle</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Tümünü Sil</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Kurtar</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Tümünü Kurtar</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>OpenStreetMap’e Katkıda Bulun</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Yer Ekle</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Katkıda bulunmak için haritayı güncelle</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>%1 haritasını en son sürüme güncellemeniz gerekir; böylece OpenStreetMap verilerine katkıda bulunabilirsiniz</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Konumum</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Yerlerim</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Dahili özel depolama</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Dahili paylaşılan depolama</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD kart</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Harici paylaşılan depolama</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Posta kodu</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Harita Noktası</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>mil</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>fit</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Rotaları görüntülemek için haritalar güncellenmelidir.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Çık</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Giriş</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Metro haritası yok</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Sen</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Mor indirilen bölgeler</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Rota</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Uygulamanın tüm özelliklerinden yararlanmak için arka planda konumunuzu belirlemek gereklidir. Rota izleme ve son seyahat edilen yolu kaydetmek için kullanılır.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Mevcut konumunuzun tayini rota takibi ve en son seyahat edilen yolu kaydetme seçeneklerinde kullanılır.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Şifre ile giriş yapın</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Tarayıcı kullanarak giriş yapın</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Son Kullanılanlar</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Yer imi rengi değiştirildi</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>İz rengi değiştirildi</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Spektrum</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Sürgüler</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>KIRMIZI</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>YEŞİL</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>MAVİ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB Onaltılı Renk #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Izgara</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/uk/omim.ts
+++ b/qt/translations/uk/omim.ts
@@ -1,0 +1,3937 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="uk">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Скасувати</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Видалити</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Завантажити мапи</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Помилка завантаження. Натисніть, щоб повторити спробу.</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Завантажується…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Кілометри</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Милі</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Не зараз</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Пошук</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Пошук на мапі</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Геолокація вимкнена в налаштуваннях пристрою. Будь ласка, увімкніть її для зручного використання програми.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Обмежена точність</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Щоб забезпечити точну навігацію, увімкніть у налаштуваннях функцію Точне місцезнаходження.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Показати на мапі</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Помилка завантаження</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Спробуйте ще раз</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Про Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Безкоштовно для всіх, зроблене з любов&#x27;ю</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Без реклами, без трекінгу, без стеження</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Не розряджає батарею, працює в автономному режимі</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Швидкий, мінімалістичний, розроблений спільнотою</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Програма з відкритим кодом, створена ентузіастами та волонтерами.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Налаштування місцеположення</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Закрити</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Для роботи програми необхідний апаратно прискорений OpenGL. На жаль, ваш пристрій не підтримується.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Завантажити</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Будь ласка, від&#x27;єднайте USB-кабель або вставте карту пам&#x27;яті, щоб скористатися програмою Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Недостатньо вільного місця на SD карті / в пам&#x27;яті пристрою для використання програми</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Перш ніж почати користуватися додатком, завантажте оглядову мапу світу на свій пристрій.
+Вона використовуватиме %1 пам’яті.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Перейти на мапу</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Поки завантажується %1
+ви можете користуватися програмою.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Завантажити %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Оновити %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Призупинити</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Продовжити</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>Не вдалося завантажити %1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Додати список</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Назва списка міток</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Мітки</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Мітки та маршрути</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Ім&#x27;я</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Адреса</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Список</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Налаштування</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Зберігати мапи до</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Виберіть місце, куди повинні бути завантажені мапи.</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Завантаженні мапи</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 вільно з %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Перемістити мапи?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Помилка переміщення файлів мапи</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Це може зайняти кілька хвилин.
+Будь ласка, зачекайте…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Одиниці виміру</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Використовувати милі чи кілометри</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Відмінити завантаження</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Написати відгук</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Завантажити мапу</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Списки міток</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Де поїсти</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Продукти</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Транспорт</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Заправка</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Парковка</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Шопінг</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Секонд-хенд</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Готель</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Пам’ятні місця</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Розваги</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>Банкомат</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Нічне життя</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Відпочинок з дітьми</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Банк</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Аптека</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Лікарня</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Туалет</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Пошта</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Поліція</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Переробка відходів</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Вода</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Для автобудинків</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Примітка</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>З вами поділилися мітками Organic Maps</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Привіт!
+
+Додаю мої мітки; відкрийте їх у Organic Maps. Якщо застосунок не встановлено, ви можете завантажити його тут: https://omaps.app/get?kmz
+
+Насолоджуйтесь подорожами з Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Завантаження міток</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Мітки успішно завантажені! Ви можете знайти їх на мапі або у ваших збережених мітках.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Не вдалося завантажити мітки. Файл може бути пошкодженим або несправним.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Тип файлу не розпізнається програмою:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Не вдалося відкрити файл %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Редагувати</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Ваше місце розташування не визначено</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Вибачте, налаштування папки з мапами зараз недоступні.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Зараз відбувається завантаження країни.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Перегляньте моє поточне місцезнаходження в Organic Maps! %1 або %2 Не маєте офлайн мап? Завантажте їх тут: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Поглянь на мою мітку на мапі Organic Maps!</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Поглянь на моє поточне розташування на мапі Organic Maps!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Привіт,
+
+Я зараз тут: %1. Натисни на це посилання %2 або на це посилання %3 щоб побачити місце на мапі.
+
+Дякую.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Поділитись</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Ел. пошта</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Скопійовано в буфер обміну: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Готово</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Дані OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Ви впевнені, що хочете вийти зі свого облікового запису OpenStreetMap?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Треки</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Довжина</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Поділитися моїм місцезнаходженням</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Загальні налаштування</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Інформація</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Навігація</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Кнопки «+» і «-» на мапі</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Відображення на екрані</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Нічний стиль під час навігації в темряві</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Нічний режим</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Вимкнуто</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Увімкнуто</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Автоматично</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Перспективний вид</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Будівлі у 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D будівлі вимкнені в режимі енергозбереження</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Голосові інструкції</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Проговорювати назви вулиць</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Якщо ввімкнено, назва вулиці або виїзду, на яку потрібно повернути, буде вимовлена вголос.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Мова підказок</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Щоб завантажити голос вищої якості, відкрийте програму Параметри та перейдіть у Доступність → VoiceOver → Мовлення → Голос.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Тестування голосових підказок (TTS, Text-To-Speech)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Якщо ви не чуєте голос, перевірте гучність або налаштування системи перетворення тексту на мовлення.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Не доступні</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Автозум</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Відстань</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Подивитись на мапі</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Меню</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Вебсайт</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Новини</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Відгук</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Оцінити застосунок</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Допомога</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Питання та відповіді</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Підтримати грошима</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Вже пожертвувано</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Нагадати пізніше</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Підтримати Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Підтримайте проект</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Копірайт</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Сповістити про помилку</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Покращіть напрямок стрілки, повернувши телефон вісімкою, щоб відкалібрувати компас.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Рухайте телефон вісімкою, щоб відкалібрувати компас і зафіксувати напрямок стрілки на мапі.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Ще раз потримайте палець на мапі, щоб побачити інтерфейс</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Оновити всі</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Скасувати всі</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Завантажено</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>В черзі</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Поблизу</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Мапи</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Завантажити всі</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Завантажується:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Щоб видалити мапу, будь ласка, зупините навігацію.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Маршрут бути прокладений всередині мапи тільки одного регіону.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Завантажити мапу</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Повторити</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Видалити мапу</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Оновити мапу</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Служби визначення місцезнаходження Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Швидке визначення приблизного місця розташування за допомогою Bluetooth, WiFi або мобільної мережі</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Завантажити мапи вздовж маршруту</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Для створення маршруту необхідно щоб всі мапи, починаючи від вашого місцезнаходження і до пункту призначення, були завантажені та оновлені.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Недостатньо місця</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Будь ласка, увімкніть геолокацію</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Зберегти</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>створити</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Червоний</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Жовтий</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Синій</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Зелений</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Пурпуровий</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Помаранчевий</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Коричневий</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Рожевий</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Темно-пурпуровий</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Блакитний</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Синьо-зелений</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Смарагдовий</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Лайм</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Темно-помаранчевий</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Сірий</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Сіро-блакитний</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Інфо</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Версія Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Вигляд</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Світлий</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Темний</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Світла від світанку до заходу сонця</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Інша</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Подаруйте мільйонам користувачів безкоштовні мапи без реклами!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Повідомляйте або виправляйте невірні картографічні дані</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Стати волонтером</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Підписуйтесь та зв&#x27;язуйтесь з нами:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Поштовий клієнт не налаштований. Налаштуйте його або скористайтеся іншими способами зв&#x27;язку. Наша адреса – %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Помилка при відправленні листа</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Калібрування компаса</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Доступні</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Знайдено</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Оновити</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Помилка</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>мітка</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Під час руху за маршрутом пам&#x27;ятайте:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Дорожня обстановка, правила дорожнього руху і знаки пріоритетніші, ніж поради програми;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Мапа може бути неточною, а запропонований маршрут не завжди оптимальний;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Запропоновані маршрути — лише рекомендації;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Дотримуйтеся обережності з маршрутами у прикордонних зонах: маршрути, створені нашою програмою, іноді можуть перетинати кордони країн у несанкціонованих місцях.</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Будьте уважні на дорогах і бережіть себе!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Перевірте сигнал GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Маршрут не побудовано. Поточну геопозицію не визначено.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Будь ласка, перевірте сигнал GPS. Для покращання точності геопозиції увімкніть Wi-Fi.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Увімкніть режим визначення геопозиції</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Поточну геопозицію не визначено. Для побудови маршруту увімкніть режим визначення геопозиції.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Маршрут не знайдено</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Не вдалося побудувати маршрут.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Будь ласка, змініть початкову або кінцеву точку маршруту.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Змініть початкову точку маршруту</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Маршрут не побудовано. Не визначено початкову точку маршруту.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Будь ласка, виберіть початкову точку маршруту ближче до дороги.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Змініть кінцеву точку маршруту</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Маршрут не побудовано. Не визначено кінцеву точку маршруту.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Будь ласка, виберіть кінцеву точку маршруту ближче до дороги.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Не вдалося знайти місцерозташування проміжної точки.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Будь ласка, вкажіть місцерозташування проміжної точки вручну.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Системна помилка</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Не вдалося прокласти маршрут через помилки програми.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Спробуйте знову</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Не зараз</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Бажаєте завантажити мапу та побудувати оптимальний маршрут через декілька регіонів?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Для побудови більш оптимального маршруту з перетином межі потрібно завантажити мапу.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Завантажте необхідні файли</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Оновіть або завантажте всі мапи та дані для побудови маршруту.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Завантажте мапу, щоб шукати об&#x27;єкти та прокладати маршрути без доступу до інтернету.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Обрати мапу</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Показати</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Приховати</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Категорії</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Історія</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>На жаль, нічого не знайдено.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Завантажте регіон пошуку або спробуйте вказати назву найближчого міста чи села.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Історія пошуку</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Швидкий доступ до нещодавніх результатів пошуку.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Очистити історію пошуку</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Вікіпедія</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Стаття з wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Вікісховище</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Ваше місцезнаходження</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Почати рух</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Звідси</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Сюди</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Маршрут можна прокласти лише з поточного місцезнаходження.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Хочете спланувати маршрут із поточного місцезнаходження?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Далі</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>З</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>До</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Додати розклад</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Видалити розклад</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Увесь день (24 години)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Відчинено</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Зачинено</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Додати перерву</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Години роботи</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Розширений режим</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Простий режим</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Перерва</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Приклади значень</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Виправте помилку</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Виберіть місце розташування</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Будь ласка, докладно опишіть проблему, щоб спільнота OpenStreetMap виправила помилку.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Або зробіть це самостійно на сайті https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Надіслати</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Проблема</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Місця не існує</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Зачинено на ремонт</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Дублікат місця</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Автоматичне завантаження</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Щоденно</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>Цілодобово</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Сьогодні не працює</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Зачинено</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Сьогодні</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Відкривається через %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Зачиняється через %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Зачинено</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Редагувати години роботи</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Не зареєстровані в OpenStreetMap?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Зареєструватися</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Увійти</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Вхід не виконано</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Увійдіть до OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Забули пароль?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Вийти</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Редагувати місце</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Додати мову</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Вулиця</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Номер будинку</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Детальніше</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Соціальні мережі</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Будівля</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Додати вулицю</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Введіть назву вулиці</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Вибрати мову</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Вибрати вулицю</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Кухня</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Вибрати кухню</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Ел. пошта або ім&#x27;я користувача</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Додати телефон</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Поверх</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Поверх: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Разом з мапою будуть видалені й внесені Вами правки на цій мапі.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Оновити мапи</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Для побудови маршруту необхідно оновити усі мапи та побудувати маршрут заново.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Знайти мапу</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Будь ласка, перевірте свої налаштування і переконайтеся, що ваш пристрій підлючено до Інтернету.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Недостатньо місця</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Видаліть непотрібні дані</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Виникла помилка при авторизації.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Виправлення, що ураховані</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Перетягніть мапу, щоб розмістити хрестик на розташуванні об&#x27;єкту або бізнесу.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Редагування</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Додавання</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Назва місця</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Місцевою мовою</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Категорія</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Детальний опис проблеми</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Інші проблема</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Додати організацію</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Об&#x27;єкт не може перебувати в цьому місцезнаходженні</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Дані OpenStreetMap, створені спільнотою, станом на %1. Дізнайтеся більше про те, як редагувати та оновлювати мапу на OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) - це громадський проект зі створення вільної та відкритої мапи. Це основне джерело картографічних даних в Organic Maps і працює подібно до Вікіпедії. Ви можете додавати або редагувати місця, і вони стають доступними мільйонам користувачів по всьому світу.
+Приєднуйтесь до спільноти і допоможіть зробити мапу кращою для всіх!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Створіть обліковий запис OpenStreetMap або увійдіть до нього, щоб опублікувати свої редагування мапи для всього світу.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 з %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Завантажити за допомогою мобільної мережі?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Це може бути задорого за деякими планами або за умовами роумінгу.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Введіть правильний номер будинку</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Кількість поверхів (максимум %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Редагуйте будівлі висотою максимум %1 поверхів</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Поштовий індекс</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Введіть коректний поштовий індекс</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Примітка для волонтерів OpenStreetMap (необов&#x27;язково)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Опишіть помилки на мапі або те, що не можна редагувати за допомогою Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Ваші правки завантажуються до публічної бази даних &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Uk:Про_проект&quot;&gt;OpenStreetMap&lt;/a&gt;. Будь ласка, не додавайте особисту або захищену авторським правом інформацію.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Більше про OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Ваша історія редагувань</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Ваші нотатки на мапі</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Оператор</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Оператор: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Не можете знайти відповідну категорію?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps дозволяють додавати до мапи лише прості типи об&#x27;єктів, тобто без міст, доріг, озер та контурів будівель. Будь ласка, додайте такі категорії на сайті &lt;a href=&quot;https://www.openstreetmap.org/&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Ми також рекомендуємо ознайомитися із &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing/&quot;&gt;детальними інструкціями та іншими додатками для редагування мапи&lt;/a&gt;.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Ви не маєте завантажених мап</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без інтернету.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Місцезнаходження не знайдено.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>км/год</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>ми/год</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>год</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>хв</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>д</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>с</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Ще</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Редагувати мітку</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Примітка (текст чи html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Коментар…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Скинути всі локальні виправлення?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Скинути</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Видалити доданий об&#x27;єкт?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Видалити</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Місце не існує</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Будь ласка, вкажіть причину видалення</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Введіть правильний номер телефону</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Введіть вірну адресу веб-сайту</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Введіть вірну адресу електронної пошти</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Введіть вірну веб-адресу Facebook сторінки або і&#x27;мя користувача</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Введіть вірну веб-адресу Instagram сторінки або і&#x27;мя користувача</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Введіть вірну веб-адресу Twitter сторінки або і&#x27;мя користувача</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Введіть вірну веб-адресу VK сторінки або і&#x27;мя користувача</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Введіть вірну веб-адресу LINE сторінки або LINE ID</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Додати місце на OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Або ж залиште повідомлення спільноті OpenStreetMap, щоби хтось інший міг додати або виправити місце тут.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Примітка буде надіслана до OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Надіслати усім користувачам?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Переконайтеся, що ви не ввели особисті дані.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Редактори OpenStreetMap перевірять зміни та зв’яжуться з вами, якщо у них виникнуть запитання.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Стоп</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Запис треку</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Прийняти</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Відхилити</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Використовувати мобільні дані для перегляду докладної інформації?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Завжди</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Тільки сьогодні</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>За винятком сьогодні</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Мобільні дані</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Використання мобільних даних необхідно для сповіщень про оновлення мапи та для відображення докладної інформації про місця та мітки.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Ніколи</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Завжди питати</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Для відображення інформації про трафік необхідно оновити мапи.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Збільшити розмір шрифту на мапі</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Будь ласка, встановіть оновлення Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Дані про трафік недоступні</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Включити логіювання</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Загальний відгук</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Для озвучування голосових інструкцій ми використовуємо систему TTS. Більшість Android-пристроїв підтримують систему Google TTS. Для завантаження або оновлення перейдіть до магазину Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Для деяких мов вам знадобиться встановити інший додаток для синтезу мовлення або додатковий мовний пакет з магазину додатків (Google Play, Galaxy Store, App Gallery, FDroid).
+Відкрийте налаштування пристрою → Мови та введення → Мовлення → Синтез мовлення.
+Тут ви можете здійснювати управління налаштуваннями синтезу мовлення (наприклад, завантажити мовний пакет для використання офлайн) або вибрати інший програмний рушій для синтезу мовлення.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Додаткову інформацію див. у цьому керівництві.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Транслітерувати латиницею</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Докладніше</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Скористайтеся пошуком, виберіть мітку, або торкніться мапи, щоб додати початкову точку маршруту</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Скористайтеся пошуком, виберіть мітку, або торкніться мапи, щоб додати пункт призначення</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Редагування маршруту</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Маршрут</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Видалити зупинку</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Додати зупинку</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Збережено</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Будь ласка увійдіть в акаунт OpenStreetMap.org, щоб автоматично публікувати зміни до мапи. Подробиці за &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;посиланням&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Не вдалося отримати доступ до сховища</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Зовнішнє сховище не доступно. Ймовірно, SD-картку пам&#x27;яті було вилучено, пошкоджено, або система файлів доступна тільки для читання. Перевірте та зв&#x27;яжіться з нами, написавши на поштову адресу support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Емулювати проблемне сховище</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Будь ласка, введіть коректне ім&#x27;я</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Списки</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Приховати всі</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Показати всі</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n мітка</numerusform>
+<numerusform>%n мітки</numerusform>
+<numerusform>%n міток</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Створити новий список</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Імпорт міток та треків</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Неможливо поділитися через помилку програми</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Помилка обміну</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Неможливо поділитися пустим списком</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Ім&#x27;я не може бути порожнім</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Будь ласка, введіть назву списку</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Новий список</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Це ім&#x27;я вже зайнято</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Виберіть інше ім&#x27;я</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Будь ласка, зачекайте…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Номер телефону</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Профіль OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n файл був знайдений. Ви побачите його після перетворення.</numerusform>
+<numerusform>%n файли було знайдено. Ви побачите їх після перетворення.</numerusform>
+<numerusform>%n файлів було знайдено. Ви побачите їх після перетворення.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Відновити</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n маршрут</numerusform>
+<numerusform>%n маршрути</numerusform>
+<numerusform>%n маршрутів</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Приватність</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Політика конфіденційності</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Умови використання</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Затор</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Піші прогулянки</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Велоспорт</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Метрополітен</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Стилі та шари мапи</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Список порожній</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Щоб додати нову мітку, натисніть на значок зірочки в картці об’єкта</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Змінити колір усіх міток</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Змінити колір усіх треків</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…ще</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Експорт KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Експорт GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Експорт GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Видалити список</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Камери швидкості</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Опис місця</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Завантаження мап</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Попереджати якщо швидкість перевищена</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Завжди попереджати</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Ніколи не попереджати</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Режим енергозбереження</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Спроба зменшити енергоспоживання коштом деяких функцій.</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Ніколи</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Автоматично</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Максимальне енергозбереження</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Назви міток на мапі</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Якщо міток забагато, відображення їхніх назв на мапі може уповільнити роботу програми.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Показати праворуч</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Показати внизу</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Дана опція вмикається для логування дій з метою діагностики. Це допомагає команді виявити проблеми з додатком. Тимчасово включайте цю настройку тільки для відправки детальної інформації про знайдену вами проблему в додатку через кнопку &quot;Сповістити про помилку&quot;.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Налаштування об’їзду</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Уникати платних доріг</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Уникати ґрунтових доріг</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Уникати поромів</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Уникати автострад</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Неможливо побудувати маршрут</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Не вдалося знайти маршрут. Це може бути пов&#x27;язано з вашими параметрами прокладання маршруту або неповними даними OpenStreetMap. Змініть параметри і спробуйте ще раз.</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Налаштувати шляхи об’їзду</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Увімкнено налаштування об’їзду</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Платна дорога</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Ґрунтова дорога</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Поромна переправа</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Ні</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Ні</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Місткість: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Мережа: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Ви прибули!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ок</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Сортувати…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Сортувати мітки</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>За замовчуванням</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>За типом</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>За відстанню</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>За датою</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>За назвою</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Тиждень тому</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Місяць тому</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Понад місяць тому</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Понад рік тому</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Поруч зі мною</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Інші</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Збій планування маршруту</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Прибуття в %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Щоб прокласти маршрут, завантажте або оновіть усі потрібні мапи.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Ви змінили мапу світу на краще! Поділіться цим із друзями та редагуйте разом.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Поділитися з друзями</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Зараз закрито</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Відкриття завтра о %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Відчиняється в %1 о %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Відкриття о %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Закривається о %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Додати графік роботи</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Пароль (мінімум 8 символів)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Невірне ім&#x27;я користувача або пароль.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Обліковий запис OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Останнє відправлення</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Дякуємо</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Назва</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Телефон</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Будь ласка, зверніть увагу</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Помилка завантаження</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Оберіть категорію</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Популярні</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Усі категорії</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Додавайте нові місця на мапу та редагуйте існуючі просто в застосунку.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Змініть розташування</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Для завантаження бракує вільного місця. Будь ласка, звільніть місце на пристрої.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Я покращив мапи Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Детальний коментар</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Зміни, що ви запропонували, буде відправлено до OpenStreetMap. Опишіть подробиці про об&#x27;єкт, які не можна редагувати в Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Не вдалося визначити місцезнаходження через невідому помилку. Перевірте налаштування пристрою та спробуйте ще раз пізніше.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Ідентифікацію місцезнаходження відключено</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Дозвольте доступ до геолокації в параметрах пристрою</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Відкрийте «Налаштування»</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Натисніть «Місцезнаходження»</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Оберіть &quot;Під час роботи програми&quot;</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Виберіть Конфіденційність</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Виберіть Служби визначення місцезнаходження</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Увімкніть служби визначення місцезнаходження</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Або продовжуйте використовувати Organic Maps без відстеження місцезнаходження</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Забронювати</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Виклик</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Назва мітки</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Видалити мітку</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Вашу замітку буде надіслано в OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…більше</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Оновити</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Вимкнути запис нещодавно пройденого шляху?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Вимкнути</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Подивись,</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps використовує вашу геопозицію у фоновому режимі для запису нещодавно пройденого шляху.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Загальні налаштування</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Оновіть застосунок, щоб бачити дані про трафік.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Розмір файлу журналу: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Перетягніть сюди, щоб видалити</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Замінити зупинку</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Почати з</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Будь ласка, увійдіть до акаунта OpenStreetMap.org, щоб автоматично публікувати зміни на мапі. Подробиці за</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>посиланням</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Приховати екран</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 з %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Завантаження %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Застосування %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Це ім&#x27;я задовге</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Виявлено нові файли</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Конвертувати</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Помилка</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Деякі файли не конвертувалися.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Виникла помилка</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Популярні</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Приховати на мапі</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Під час завантаження теґів сталася помилка, будь ласка, спробуйте ще раз</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Праворуч</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Вниз</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Поїхали</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Ціль</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Відцентрувати</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Результати пошуку</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Далі</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Бажаєте перебудувати маршрут?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Клавіатура недоступна під час руху</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Неможливо побудувати маршрут від поточного місця розташування</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Неможливо побудувати маршрут до кінцевої точки. Оберіть іншу</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Немає сигналу GPS. Перейдіть на відкриту місцевість</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Неможливо побудувати маршрут. Оберіть інші точки маршруту</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Щоб побудувати маршрут, завантажте відсутні мапи на своєму пристрої</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Виникла помилка. Перезапустіть додаток</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Маршрут буде перебудовано від вашого поточного місця розташування</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Маршрут буде змінено на автомобільний</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Відображаються не всі мітки</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Перейдіть на телефон, щоб побачити всі мітки</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Камери</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Інфо о камерах</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Завантажте мапи в додатку Organic Maps на своєму пристрої</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>%1 з’їзд</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Сортувати за промовчанням</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Сортувати за типом</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Сортувати за відстанню</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Сортувати за датою</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Сортувати за ім&#x27;ям</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Їжа</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Пам’ятки</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Музеї</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Парки</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Плавання</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Гори</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Тварини</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Готелі</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Будівлі</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Гроші</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Магазини</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Парковки</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Заправки</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Медицина</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Пошук у списку</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Святі місця</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Обрати список</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Навігація на метро ще недоступна в цьому регіоні</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Жодного маршруту метро не знайдено</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Виберіть початкову чи кінцеву точку маршруту ближче до станції метро</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Висоти</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Щоб скористатися лініями висот, оновіть чи завантажте мапу потрібної місцевості</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Лінії висот ще недоступні в цьому регіоні</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Підйом</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Спуск</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Мін. висота</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Макс. висота</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Складність</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Відст.:</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Шлях:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Збільште мапу, щоб побачити ізолінії</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Завантаження</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Завантажити оглядову мапу світу</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Неможливо створити папку та перемістити файли до внутрішньої памʼяті або SD карти</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Помилка диска</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Помилка підключення</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Від&#x27;єднайте кабель USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Тримайте екран увімкненим</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Якщо увімкнено, екран завжди буде увімкнений під час відображення мапи.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Показувати на заблокованому екрані</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Якщо ввімкнено, вам не потрібно щоразу розблоковувати пристрій під час роботи програми.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Мова мапи</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Картографічні дані з OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/uk/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/uk/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Uk:Про_проект</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Дякуємо, що користуєтесь нашими мапами, створеними спільнотою!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Завдяки вашим пожертвам і підтримці ми зможемо створити найкращі мапи світу!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Вам подобається наш додаток? Підтримайте його розвиток грошима! Поки ще не подобається? Будь ласка, повідомте нам, чому, і ми це виправимо!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Якщо у вас є знайомий розробник програмного забезпечення, ви можете попросити його реалізувати потрібну вам функцію.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Торкніться будь-якого місця на мапі, щоб вибрати щось. Тривале натискання приховує та відображає інтерфейс.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>А ви знали, що своє місцезнаходження на мапі можна вибрати?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Ви можете допомогти перекласти наш додаток на вашу мову.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Наша програма розроблена кількома ентузіастами та спільнотою.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Ви можете легко виправити та покращити дані мапи.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Наша головна мета – створити швидкі, конфіденційні та прості у використанні мапи, які вам сподобаються.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Зараз ви використовуєте Organic Maps на екрані телефону</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Ви використовуєте Organic Maps на екрані автомобіля</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Ви підключені до Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Продовжуйте в телефоні</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>На екран автомобіля</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Для роботи Organic Maps потрібен доступ до місцезнаходження. Коли це буде безпечно, перевірте сповіщення на телефоні.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ця програма потребує вашого дозволу</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Для ефективної роботи Organic Maps в Android Auto потрібні дозвіли на розташування</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Надавати дозволи</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Активний відпочинок</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Веб-браузер недоступний</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Гучність</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Експортувати всі мітки та треки</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Системні налаштування синтезу мови</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Налаштування синтезу мовлення не знайдено, ви впевнені, що ваш пристрій його підтримує?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>З віконцем для водіїв</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Очистити пошук</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Збільшити</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Зменшити</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Посилання на меню</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Переглянути меню</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Відкрити в іншому застосунку</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Самообслуговування</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Виберіть варіант</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Сидіння на відкритому повітрі</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Для найбільш точної навігації ми рекомендуємо вимкнути режим енергозбереження в налаштуваннях батареї телефону.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Записати трек</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Зупинити запис треку</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Запис треку</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Зупинити без збереження</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Продовжити запис</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Зберегти в мітки та треки?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Трек порожній - нічого зберігати</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Неможливо відобразити діалогове вікно вибору теки, оскільки на вашому пристрої не встановлено відповідний застосунок. Встановіть файловий менеджер і спробуйте ще раз.</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Виберіть колір</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Редагувати трек</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Не встановлено застосунок, який може відкрити розташування</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Авто в навігації</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Як у системі</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Поділитися треком</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Видалити %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Рівень складності</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Простий</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Помірний</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Складний</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Оновлення</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Оновити завантажені мапи</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Оновлення мап дозволяє підтримувати інформацію про об&#x27;єкти в актуальному стані</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Оновити (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Оновити вручну пізніше</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Видалити трек</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Ви дійсно хочете видалити цей трек?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Назва треку</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Перемістити</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Трек</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Змінити колір</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Мапа</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Бажаєте надіслати розробникам звіт про помилку?
+Ми покладаємося на наших користувачів, оскільки Organic Maps не збирає інформацію про помилки автоматично. Заздалегідь дякуємо за підтримку Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Увімкнути синхронізацію з iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Синхронізація з iCloud - це експериментальна функція, яка перебуває на стадії розробки. Переконайтеся, що ви зробили резервну копію всіх ваших міток і треків.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud вимкнено</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Щоб скористатися цією функцією, увімкніть iCloud у налаштуваннях вашого пристрою.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Увімкнути</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Резервне копіювання</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Збій синхронізації iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Помилка: Не вдалося синхронізувати через помилку з&#x27;єднання</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Помилка: Не вдалося синхронізувати через перевищення квоти iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Помилка: iCloud недоступний</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Нещодавно видалене</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Очистити</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Видалити все</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Відновити</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Відновити все</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Долучитися до OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Додати місце</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Оновіть мапу, щоб долучитися</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Ви повинні оновити мапу %1 до останньої версії, перш ніж зможете вносити зміни до даних OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>МБ</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>ГБ</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Моє місцезнаходження</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Мої Мітки</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Внутрішнє приватне сховище</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Внутрішнє спільне сховище</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD-карта</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Зовнішнє спільне сховище</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>Wi-Fi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Поштовий індекс</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Точка на мапі</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>м</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>км</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>ми</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>фут</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Оновіть мапи для відображення маршрутів.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Вихід</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Вхід</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Мапа метрополітену недоступна</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Ви</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Фіолетові завантажені регіони</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Маршрут</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Визначення місцезнаходження у фоновому режимі необхідно для повноцінного користування додатком. Воно використовується під час руху по маршруту та для збереження шляху, що було нещодавно пройдено.</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Ваше місцезнаходження використовується для навігації та запису пройденого шляху.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Вхід за допомогою пароля</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Вхід через браузер</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Нещодавно використані</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Колір міток змінено</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Колір треків змінено</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Спектр</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Повзунки</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ЧЕРВОНИЙ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>ЗЕЛЕНИЙ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>СИНІЙ</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Шістнадцятковий колір у форматі sRGB №</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Сітка</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/vi/omim.ts
+++ b/qt/translations/vi/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="vi">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>Quay lại</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>Huỷ bỏ</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>Xóa</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>Tải xuống Bản đồ</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>Tải xuống thất bại, hãy chạm lại để thử một lần nữa</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>Đang tải xuống…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>Kilômét</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>Dặm</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>Để sau</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>Tìm kiếm</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>Tìm kiếm Bản đồ</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>Bạn hiện đang tắt tất cả Dịch vụ Định vị cho thiết bị hoặc ứng dụng này. Bạn vui lòng bật lại chúng trong Thiết lập.</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>Độ chính xác hạn chế</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>Để đảm bảo điều hướng chính xác, bật vị trí chính xác trong cài đặt.</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>Hiển thị trên bản đồ</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>Tải xuống đã thất bại</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>Thử lại</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>Giới thiệu về Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>Miễn phí cho mọi người, được làm bằng tình yêu</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• Không có quảng cáo, không theo dõi, không thu thập dữ liệu</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• Không hao pin, hoạt động offline</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• Nhanh chóng, tối giản, được phát triển bởi cộng đồng</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>Ứng dụng nguồn mở được tạo bởi những người đam mê và tình nguyện viên.</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>Cài đặt vị trí</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>Đóng</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>Cần có OpenGL được tăng tốc phần cứng. Thật không may, thiết bị của bạn không được hỗ trợ.</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>Tải xuống</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>Bạn vui lòng tháo cáp USB hoặc lắp thẻ nhớ vào để sử dụng Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>Bạn vui lòng giải phóng dung lượng trên ổ lưu trữ thẻ SD/USB để có thể sử dụng ứng dụng</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>Trước khi bạn bắt đầu, hãy để chúng tôi tải bản đồ thế giới vào thiết bị của bạn.
+Bản đồ này cần %1 dữ liệu.</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>Đến Bản đồ</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>Đang tải xuống %1. Bây giờ bạn đã có thể
+vào bản đồ.</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>Tải xuống %1?</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>Cập nhật %1?</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>Tạm dừng</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>Tiếp tục</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>Thêm Bộ Mới</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>Đánh dấu Tên Bộ</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>Đánh dấu</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>Đánh dấu và dấu vết</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>Tên</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>Địa chỉ</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>Danh sách</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>Thiết lập</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>Lưu bản đồ vào</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>Chọn vị trí nơi bản đồ sẽ được tải về</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>Bản đồ</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>%1 trống trong tổng số %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>Di chuyển bản đồ?</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>Lỗi khi di chuyển tệp bản đồ</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>Việc này có thể mất vài phút.
+Vui lòng đợi…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>Đơn vị đo</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>Chọn giữa dặm và kilômét</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>Huỷ bỏ Tải xuống</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>Để lại Đánh giá</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>Có</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>Tải xuống Bản đồ</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>Đánh dấu Bộ</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>Ăn ở đâu</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>Cửa hàng tạp hóa</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>Giao thông</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>Khí đốt</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>Đỗ xe</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>Đi mua sắm</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>Đồ cũ</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>Khách sạn</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>Điểm tham quan</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>Giải trí</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>ATM</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>Cuộc sống về đêm</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>Kỳ nghỉ gia đình</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>Ngân hàng</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>Hiệu thuốc</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>Bệnh viện</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>Nhà vệ sinh</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>Bưu điện</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>Cảnh sát</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>Tái chế rác thải</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>Nước</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>Đối với RV</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>Ghi chú</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>Điểm đánh dấu Organic Maps được chia sẻ</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>Xin chào!
+
+Đính kèm là các dấu trang của tôi; vui lòng mở chúng trong Organic Maps. Nếu bạn chưa cài đặt ứng dụng này, bạn có thể tải xuống tại đây: https://omaps.app/get?kmz
+
+Chúc bạn có những chuyến đi thú vị cùng Organic Maps!</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>Tải Điểm đánh dấu</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>Đã tải điểm đánh dấu thành công! Bạn có thể tìm chúng trên bản đồ hoặc màn hình Trình quản lý Điểm đánh dấu.</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>Không tải lên được điểm đánh dấu. Tập tin có thể bị hỏng hoặc lỗi.</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>Loại tệp không được ứng dụng nhận dạng:
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>Không thể mở tập tin %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>Sửa</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>Chưa xác định được vị trí của bạn</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>Rất tiếc, cài đặt Lưu trữ Bản đồ hiện đã bị tắt.</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>Hiện đang tải xuống quốc gia.</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>Này, hãy xem vị trí hiện tại của tôi tại Organic Maps! %1 hoặc %2 Bạn không có bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>Này, hãy xem ghim của tôi tại Organic Maps map</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>Này, hãy xem vị trí hiện tại của tôi tại Organic Maps map!</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>Chào,
+
+Tôi hiện đang ở đây: %1. Hãy nhấn vào liên kết này %2 hoặc liên kết này %3 để xem địa điểm trên bản đồ.
+
+Cám ơn.</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>Chia sẻ</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>Email</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>Đã sao chép vào Bảng tạm: %1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>Xong</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>Dữ liệu OpenStreetMap: %1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>Bạn có chắc chắn muốn đăng xuất khỏi tài khoản OpenStreetMap của mình không?</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>Dấu vết</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>Độ dài</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>Chia sẻ Vị trí của tôi</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>Cài đặt chung</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>Thông tin</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>Điều hướng</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>Nút + và - trên bản đồ</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>Hiển thị trên màn hình</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>Chế độ ban đêm khi điều hướng trong điều kiện thiếu sáng</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>Chế độ ban đêm</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>Tắt</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>Bật</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>Tự động</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>Góc nhìn phối cảnh</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>Nhà cửa 3D</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>Tòa nhà 3D bị tắt ở chế độ tiết kiệm năng lượng</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>Hướng dẫn bằng Giọng nói</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>Thông báo tên đường</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>Nếu bật, sẽ đọc to tên đường hoặc lối ra để rẽ vào.</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>Ngôn ngữ Giọng nói</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>Để tải giọng nói chất lượng cao hơn, hãy mở ứng dụng Cài đặt và vào Trợ năng → VoiceOver → Lời nói → Giọng nói.</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>Kiểm tra chỉ đường bằng giọng nói (TTS, chuyển văn bản thành giọng nói)</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>Kiểm tra cài đặt âm lượng hoặc chuyển văn bản sang giọng nói của hệ thống nếu bây giờ bạn không nghe thấy giọng nói.</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>Không có sẵn</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>Ống dòm tự động</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>Khoảng cách</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>Xem trên bản đồ</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>Menu</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>Trang web</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>Tin tức</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>Phản hồi</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>Cho điểm ứng dụng</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>Trợ giúp</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>Câu hỏi và trả lời</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>Quyên tặng</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>Đã quyên góp</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>Nhắc sau</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>Hỗ trợ Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>Hỗ trợ dự án</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>Bản quyền</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>Báo cáo lỗi</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>Cải thiện hướng mũi tên bằng cách di chuyển điện thoại theo chuyển động hình số tám để hiệu chỉnh la bàn.</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>Di chuyển điện thoại theo chuyển động hình số tám để hiệu chỉnh la bàn và cố định hướng mũi tên trên bản đồ.</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>Nhấn và giữ lại vào bản đồ để xem giao diện</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>Cập nhật tất cả</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>Hủy tất cả</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>Đã tải xuống</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>Đã xếp hàng chờ</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>Gần tôi</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>Bản đồ</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>Tải xuống tất cả</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>Đang tải về:</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>Để xóa bản đồ, vui lòng dừng điều hướng.</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>Tuyến đường chỉ có thể được tạo hoàn toàn được chứa trong một bản đồ.</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>Tải về bản đồ</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>Lặp lại</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>Xóa Bản đồ</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>Cập nhật Bản đồ</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Dịch vụ vị trí của Google Play</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>Nhanh chóng xác định vị trí gần đúng của bạn bằng Bluetooth, WiFi hoặc mạng di động</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>Tải xuống bản đồ theo tuyến đường</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>Tạo một tuyến đường đòi hỏi tất cả các bản đồ từ vị trí của bạn đến điểm đến phải được tải xuống và cập nhật.</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>Không đủ không gian</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>Bạn vui lòng bật Dịch vụ Định vị</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>Lưu</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>tạo</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>Đỏ</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>Vàng</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>Xanh dương</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>Xanh lục</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>Tím</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>Cam</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>Nâu</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>Hồng</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>Tía thẫm</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>Xanh da trời</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>Xanh lơ</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>Lục bảo</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>Màu xanh chanh</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>Cam đậm</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>Xám</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>Xám xanh da trời</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>Thông tin</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Phiên bản Organic Maps: %1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>Giao diện</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>Sáng</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>Tối</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>Sáng từ bình minh đến hoàng hôn</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>Khác</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>Tặng bản đồ miễn phí không có quảng cáo cho hàng triệu người dùng!</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>Báo cáo hoặc sửa dữ liệu bản đồ không chính xác</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>Tình nguyện</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>Theo dõi và liên hệ với chúng tôi:</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>Trình khách email này chưa được thiết lập. Bạn vui lòng cấu hình nó hoặc sử dụng một cách khác để liên hệ với chúng tôi tại %1</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>Lỗi gửi thư</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>Chuẩn hóa la bàn</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>Đã có</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>Đã tìm thấy</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>Cập nhật</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>Thất bại</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>yer i̇mi</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>Khi đi theo tuyến đường, hãy lưu ý:</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— Điều kiện đường, luật giao thông và biển báo đường bộ luôn được ưu tiên hơn lời khuyên định hướng;</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— Bản đồ có thể không chính xác và tuyến đường được đề xuất có thể không luôn là cách tối ưu nhất để đi đến đích;</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— Các tuyến đường được đề nghị chỉ nên được coi là các khuyến nghị;</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— Chú ý khi thể dục theo những con đường gần đường biên giới: những con đường do ứng dụng của chúng tôi tạo ra đôi khi có khả năng vượt ra khỏi biên giới vào những địa điểm không được phép;</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>Hãy cảnh giác và giữ an toàn trên đường!</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>Kiểm tra tín hiệu GPS</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>Không thể tạo tuyến đường. Không xác định được tọa độ GPS hiện tại.</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>Hãy kiểm tra tín hiệu GPS của bạn. Việc kích hoạt Wi-Fi sẽ cải thiện độ chính xác vị trí của bạn.</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>Bật các dịch vụ định vị</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>Không thể xác định vị trí tọa độ GPS hiện tại. Bật các dịch vụ định vị để tính toán tuyến đường.</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>Không thể xác định tuyến đường</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>Không thể tạo tuyến đường.</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>Hãy điều chỉnh điểm bắt đầu hoặc điểm đến của bạn.</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>Điều chỉnh điểm bắt đầu</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>Tuyến đường chưa được tạo. Không thể xác định vị trí điểm bắt đầu.</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>Hãy chọn điểm bắt đầu gần với một con đường hơn.</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>Điều chỉnh điểm đến</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>Tuyến đường chưa được tạo. Không thể xác định vị trí điểm đến.</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>Hãy chọn điểm đến gần với một con đường hơn.</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>Không thể định vị điểm trung gian.</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>Vui lòng điều chỉnh điểm trung gian của bạn.</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>Lỗi hệ thống</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>Không thể tạo tuyến đường do lỗi ứng dụng.</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>Vui lòng thử lại</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>Lúc khác</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>Bạn có muốn tải về bản đồ và tạo một tuyến đường tối ưu hơn kéo dài trên nhiều hơn một bản đồ?</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>Tải về bản đồ để tạo tuyến đường tối ưu hơn mà đi qua cạnh của bản đồ này.</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>Tải xuống các tệp yêu cầu</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>Tải về và cập nhật tất cả các bản đồ và các thông tin tuyến đường dọc theo lộ trình dự kiến để tính toán tuyến đường.</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>Để bắt đầu tìm kiếm và tạo đường đi, vui lòng tải về bản đồ, và bạn sẽ không cần đến kết nối Internet nữa.</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>Chọn bản đồ</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>Hiện</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>Ẩn</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>Thể loại</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>Lịch sử</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>Xin lỗi, tôi không tìm thấy kết quả nào.</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>Tải xuống khu vực bạn đang tìm kiếm hoặc thử thêm tên thị trấn/làng gần đó.</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>Lịch sử tìm kiếm</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>Truy cập nhanh chóng đến câu hỏi tìm kiếm gần đây.</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>Xóa Lịch sử Tìm kiếm</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>Wikipedia</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>Bài viết từ wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>Wikimedia Commons</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>Vị trí của bạn</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>Bắt đầu</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>Từ</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>Tuyến đến</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>Chức năng tìm đường chỉ có sẵn từ vị trí hiện tại của bạn.</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>Bạn có muốn chúng tôi vạch đường từ vị trí hiện tại của bạn không?</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>Tiếp theo</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>Từ</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>Đến</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>Thêm lịch biểu</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>Xóa lịch biểu</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>Cả ngày (24 giờ)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>Mở cửa</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>Đóng cửa</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>Thêm giờ đóng cửa</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>Giờ mở cửa</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>Chế độ nâng cao</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>Chế độ đơn giản</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>Giờ đóng cửa</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>Giá trị ví dụ</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>Sửa lỗi</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>Chọn vị trí</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>Xin mô tả chi tiết vấn đề để cộng đồng OpenStreetMap có thể sửa lỗi đó.</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>Hoặc bạn có thể tự sửa tại https://www.openstreetmap.org/</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>Gửi</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>Vấn đề</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>Địa điểm này không tồn tại</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>Tạm dừng để bảo trì</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>Địa điểm trùng lặp</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>Tự động tải về</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>Hàng ngày</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>ngày và đêm</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>Nghỉ hôm nay</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>Ngày nghỉ</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>Hôm nay</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>Mở trong %1</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>Đóng trong %1</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>Đã đóng</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>Sửa giờ làm việc</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>Bạn chưa có tài khoản tại OpenStreetMap ư?</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>Đăng ký</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>Đăng nhập</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>Chưa đăng nhập</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>Đăng nhập vào OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>Mật khẩu</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>Quên mật khẩu?</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>Đăng xuất</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>Chỉnh sửa địa điểm</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>Thêm ngôn ngữ</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>Đường</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>Số nhà</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>Chi tiết</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>Truyền thông xã hội</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>Xây dựng</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>Thêm con đường</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>Vui lòng nhập tên đường</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>Đã chọn ngôn ngữ</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>Đã chọn con đường</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>Ẩm thực</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>Chọn Ẩm thực</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>Email hoặc tên người dùng</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>Thêm số điện thoại</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>Tầng</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>Cấp độ: %1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>Tất cả những thay đổi của bản đồ sẽ bị xóa cùng với bản đồ đó.</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>Cập nhật các bản đồ</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>Để tạo một tuyến đường, bạn cần cập nhật tất cả các bản đồ và sau đó lập lại tuyến đường.</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>Tìm bản đồ</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>Xin kiểm tra các thiết lập và đảm bảo thiết bị của bạn có kết nối Internet.</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>Không đủ dung lượng</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>Xin xóa dữ liệu không cần thiết</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>Lỗi đăng nhập.</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>Các thay đổi đã được xác thực</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>Kéo bản đồ để đặt dấu thập vào vị trí của địa điểm hoặc doanh nghiệp.</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>Chỉnh sửa</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>Nhập</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>Tên địa điểm</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>Vì nó được viết bằng ngôn ngữ địa phương</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>Thể loại</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>Mô tả chi tiết của vấn đề</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>Một vấn đề khác</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>Thêm tổ chức</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>Một đối tượng không thể đặt được ở đây</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>Dữ liệu OpenStreetMap do cộng đồng tạo ra kể từ %1. Tìm hiểu thêm về cách chỉnh sửa và cập nhật bản đồ tại OpenStreetMap.org</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) là một dự án cộng đồng nhằm xây dựng bản đồ miễn phí và mở. Đây là nguồn dữ liệu bản đồ chính trên Organic Maps và hoạt động tương tự như Wikipedia. Bạn có thể thêm hoặc chỉnh sửa các địa điểm và chúng sẽ được cung cấp cho hàng triệu người dùng trên toàn thế giới.
+Hãy tham gia cộng đồng và cùng góp phần tạo ra bản đồ tốt hơn cho mọi người!</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>Tạo tài khoản OpenStreetMap hoặc đăng nhập để xuất bản các chỉnh sửa bản đồ của bạn với thế giới.</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 trên %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>Tải xuống qua kết nối mạng di động?</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>Như vậy sẽ rất đắt tiền với một số gói dữ liệu hoặc khi chuyển vùng.</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>Nhập số nhà chính xác</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>Số tầng (tối đa %1)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>Sửa tòa nhà có tối đa %1 tầng</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>Mã ZIP</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>Nhập Mã ZIP chính xác</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>Lưu ý dành cho tình nguyện viên OpenStreetMap (tùy chọn)</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>Mô tả các lỗi trên bản đồ hoặc các mục không thể chỉnh sửa bằng Organic Maps</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>Các chỉnh sửa của bạn sẽ được tải lên cơ sở dữ liệu &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; công khai. Vui lòng không thêm thông tin cá nhân hoặc có bản quyền.</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>Thông tin bổ sung về OpenStreetMap</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>Lịch sử chỉnh sửa của bạn</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>Ghi chú dữ liệu bản đồ của bạn</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>Toán tử</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>Toán tử: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>Không thể tìm thấy một danh mục phù hợp?</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps chỉ cho phép thêm các loại điểm đơn giản, tức là không bao gồm các thị trấn, đường, hồ, đường viền tòa nhà, v.v. Vui lòng thêm các loại này trực tiếp vào &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Hãy tham khảo &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;hướng dẫn&lt;/a&gt; của chúng tôi để biết các bước thực hiện chi tiết.</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>Bạn chưa tải về bất kỳ bản đồ nào</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>Chưa biết địa điểm hiện tại.</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>km/giờ</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>mph</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>giờ</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>phút</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>ngày</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>giây</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>Bổ sung</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>Sửa Dấu Trang</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>Ghi chú cá nhân (văn bản hoặc html)</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>Nhận xét…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>Cài đặt lại tất cả thay đổi cục bộ?</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>Cài đặt lại</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>Xóa một địa điểm đã thêm?</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>Xóa</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>Địa điểm không tồn tại</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>Vui lòng cho biết lý do xóa địa điểm</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>Nhập chính xác số điện thoại</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>Nhập địa chỉ trang web hợp lệ</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>Nhập email hợp lệ</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>Nhập địa chỉ web, tài khoản hoặc tên trang Facebook hợp lệ</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>Nhập tên người dùng Instagram hoặc địa chỉ web hợp lệ</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>Nhập tên người dùng Twitter hoặc địa chỉ web hợp lệ</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>Nhập tên người dùng VK hoặc địa chỉ web hợp lệ</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>Nhập ID LINE hoặc địa chỉ web hợp lệ</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>Thêm địa điểm vào OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>Hoặc, bạn có thể để lại lời nhắn cho cộng đồng OpenStreetMap để người khác có thể thêm hoặc sửa địa điểm này.</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>Ghi chú sẽ được gửi đến OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>Bạn có muốn gửi cho toàn bộ người dùng?</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>Chắc chắn rằng bạn không nhập bất kỳ thông tin cá nhân nào.</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>Các biên tập viên của OpenStreetMap sẽ kiểm tra các thay đổi và liên hệ với bạn nếu họ có bất kỳ câu hỏi nào.</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>Dừng</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>Ghi lại hành trình</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>Chấp nhận</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>Từ chối</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>Sử dụng mạng Internet di động để hiển thị thông tin chi tiết?</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>Luôn Sử dụng</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>Chỉ Hôm nay</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>Không Sử dụng Hôm nay</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>Internet Di động</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>Internet di động là cần thiết để hiển thị thông tin chi tiết về các nơi, ví dụ như ảnh chụp, giá cả và đánh giá.</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>Không bao giờ sử dụng</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>Luôn Hỏi</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>Để hiển thị dữ liệu giao thông, cần cập nhật bản đồ.</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>Tăng kích cỡ phông chữ trên bản đồ</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>Vui lòng cập nhật Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>Dữ liệu giao thông không khả dụng</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>Bật nhật ký</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>Phản hồi chung</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>Chúng tôi sử dụng TTS hệ thống để hướng dẫn bằng giọng nói. Rất nhiều thiết bị Android sử dụng Google TTS, bạn có thể tải về hoặc cập nhật nó từ Google Play</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>Đối với một số ngôn ngữ, bạn sẽ cần cài đặt một trình tổng hợp lời nói khác hoặc một gói ngôn ngữ bổ sung từ cửa hàng ứng dụng (Google Play, Galaxy Store, App Gallery, FDroid).
+Mở cài đặt của thiết bị → Ngôn ngữ và nhập liệu → Lời nói → Đầu ra văn bản sang lời nói.
+Tại đây bạn có thể quản lý các cài đặt tổng hợp lời nói (ví dụ, tải về các gói ngôn ngữ để sử dụng ngoại tuyến) và chọn một công cụ chuyển đổi văn bản sang lời nói khác.</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>Để biết thêm thông tin, vui lòng kiểm tra bài hướng dẫn này.</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>Chuyển ngữ sang chữ Latinh</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>Tìm hiểu thêm</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>Sử dụng tìm kiếm hoặc nhấn vào bản đồ để thêm điểm bắt đầu tuyến đường</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>Sử dụng tìm kiếm hoặc nhấn vào bản đồ để thêm điểm đến</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>Quản lý lộ trình</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>Kế hoạch</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>Xóa điểm dừng</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>Thêm điểm dừng</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>Đã lưu</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>Vui lòng đăng nhập vào OpenStreetMap để tự động tải lên tất cả các chỉnh sửa bản đồ của bạn. Tìm hiểu thêm &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;tại đây&lt;/a&gt;.</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>Vấn đề truy cập ổ lưu trữ</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>Ổ lưu trữ bên ngoài không khả dụng, có thể Thẻ SD đã bị tháo, bị hỏng hoặc hệ thống tập tin được thiết lập chỉ đọc. Hãy kiểm tra và liên hệ với chúng tôi qua support@organicmaps.app</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>Giả lập ổ lưu trữ hỏng</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>Vui lòng nhập một tên chính xác</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>Danh sách</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>Ẩn tất cả</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>Hiển thị tất cả</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n dấu trang</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>Tạo danh sách mới</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>Nhập dấu trang và bản nhạc</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>Không thể chia sẻ do lỗi ứng dụng</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>Lỗi chia sẻ</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>Không thể chia sẻ một danh sách trống</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>Tên không được để trống</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>Vui lòng nhập tên danh sách</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>Danh sách mới</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>Tên này đã được sử dụng</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>Vui lòng chọn một tên khác</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>Vui lòng chờ…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>Số điện thoại</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>Hồ sơ OpenStreetMap</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>%n files were found. You can see them after conversion.</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>Khôi phục</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n các chặng đường</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>Sự riêng tư</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>Chính sách bảo mật</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>Điều khoảng sử dụng</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>Giao thông</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>Đi bộ đường dài</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>Đạp xe</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>Xe điện ngầm</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>Kiểu và lớp bản đồ</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>Danh sách trống</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>Để thêm dấu trang, hãy nhấn vào một địa điểm trên bản đồ và sau đó nhấn vào biểu tượng dấu sao</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>Thay đổi màu của tất cả dấu trang</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>Thay đổi màu cho tất cả các tuyến đường</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…thêm</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>Xuất KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>Xuất GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>Xuất GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>Xóa danh sách</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>Tăn tốc độ máy ảnh</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>Mô tả Địa điểm</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>Trình tải xuống bản đồ</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>Cảnh báo về việc chạy quá tốc độ</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>Luôn cảnh báo</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>Không bao giờ cảnh báo</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>Chế độ tiết kiệm năng lượng</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>Nếu chế độ tiết kiệm năng lượng được bật, ứng dụng sẽ tắt các chức năng tiêu thụ năng lượng tùy thuộc vào mức pin hiện tại của điện thoại</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>Không bao giờ</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>Tự động</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>Tiết kiệm năng lượng tối đa</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>Tên dấu trang trên bản đồ</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>Nếu có quá nhiều dấu trang, việc hiển thị tên của chúng trên bản đồ có thể làm chậm ứng dụng.</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>Hiển thị ở bên phải</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>Hiển thị ở phía dưới</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>Tùy chọn này được kích hoạt để ghi nhật ký đăng nhập cho mục đích chẩn đoán. Điều này sẽ giúp nhóm chúng tôi làm rõ các vấn đề liên quan đến ứng dụng. Hãy bật tùy chọn này chỉ khi nào có yêu cầu hỗ trợ từ Organic Maps.</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>Thiết lập đi vòng</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>Tránh đường thu phí</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>Tránh đường đất</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>Tránh bến phà</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>Tránh xa lộ</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>Không thể tạo tuyến đường</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>Rất tiếc, chúng không thể tạo tuyến đường với những tùy chọn đã chọn. Hãy thay đổi thiết lập và thử lại</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>Thiết lập đường đi vòng</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>Thiết lập đường đi tránh đã được bật</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>Đường trả phí</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>Đường đất</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>Bến phà</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>Có</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>Không</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>Có</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>Không</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>Công suất: %1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>Mạng: %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>Bạn đã tới nơi!</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>Ok</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>Sắp xếp…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>Sắp xếp dấu trang</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>Theo mặc định</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>Theo kiểu</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>Theo khoảng cách</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>Theo ngày</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>Theo Tên</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>Tuần trước</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>Tháng trước</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>Hơn một tháng trước</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>Hơn một năm trước</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>Ở gần tôi</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>Khác</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>Không thể Lập Lộ trình</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>Đến: %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>Bạn đã thay đổi bản đồ thế giới. Đừng giấu điều đó! Hãy cho các bạn khác biết và cùng nhau chỉnh sửa.</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>Chia sẻ với bạn bè</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>Hiện đã đóng</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>Mở cửa vào ngày mai tại %1</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>Mở %1 tại %2</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>Mở tại %1</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>Đóng cửa lúc %1</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>Thêm giờ làm việc</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>Mật khẩu (tối thiểu 8 ký tự)</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>Sai Tên người dùng hoặc Mật khẩu.</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>Tài khoản OSM</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>Tải lên mới nhất</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>Cảm ơn bạn</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>Tên địa điểm</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>Điện thoại</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>Xin lưu ý</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>Lỗi tải xuống</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>Chọn thể loại</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>Phổ biến</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>Mọi thể loại</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>Nhập các địa điểm mới vào bản đồ, và trực tiếp chỉnh sửa những địa điểm hiện có trên ứng dụng.</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>Thay đổi địa điểm</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>Để tải xuống, bạn cần thêm dung lượng. Xin xóa mọi dữ liệu không cần thiết.</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>Tôi đã cải thiện các bản đồ Organic Maps</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>Nhận xét chi tiết</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>Những thay đổi đề nghị của bạn sẽ được gửi đến cộng đồng OpenStreetMap. Mô tả các chi tiết không thể sửa trong Organic Maps.</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>Có lỗi khi tìm kiếm địa điểm của bạn. Đảm bảo rằng thiết bị của bạn hoạt động tốt và thử lại sau.</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>Chức năng nhận biết địa điểm bị tắt</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>Bật truy cập định vị địa lý trong thiết lập thiết bị</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. Mở Thiết lập</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. Chạm mục Địa điểm</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. Chọn Khi Đang Dùng Ứng dụng</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. Chọn Quyền riêng tư</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. Chọn Dịch vụ định vị</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. Bật Dịch vụ định vị</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>Hoặc tiếp tục sử dụng Organic Maps mà không cần định vị</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>Đặt trước</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>Gọi</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>Tên Dấu Trang</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>Xóa Dấu Trang</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>Ghi chú của bạn sẽ được gửi tới OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…thêm</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>Cập nhật</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>Tắt ghi lại tuyến đường đã đi gần đây của bạn?</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>Tắt</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>Xem</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps sử dụng định vị của bạn trong ứng dụng chạy nền để ghi lại tuyến đường đã đi gần đây của bạn.</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>Thiết lập chung</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>Để hiển thị dữ liệu giao thông, ứng dụng cần phải được cập nhật.</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>Kích thước tệp nhật ký: %1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>Kéo vào đây để xóa</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>Thay thế điểm dừng</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>Bắt đầu từ</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>Vui lòng đăng nhập vào OpenStreetMap để tự động tải lên tất cả các chỉnh sửa bản đồ của bạn. Tìm hiểu thêm</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>tại đây</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>Ẩn Màn hình</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>Tải về %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>Áp dụng %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>Tên này quá dài</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>Đã phát hiện tệp mới</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>Chuyển đổi</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>Lỗi</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>Một số tệp không được chuyển đổi.</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>Đã xảy ra lỗi</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>Phổ biến</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>Ẩn từ bản đồ</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>Đã xảy ra lỗi khi tải thẻ, vui lòng thử lại</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>Bên phải</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>Phía dưới</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>Đi nào</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>Mục đích</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>Định tâm</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>Kết quả tìm kiếm</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>Sau đó</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>Bạn có muốn tạo lại tuyến không?</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>Bàn phím không khả dụng trong thời gian di chuyển</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>Không thể tạo tuyến đường từ địa điểm hiển tại</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>Không thể tạo tuyến đường tới điểm kết cuối. Hãy chọn điểm khác</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>Không có tín hiệu GPS. Hãy đến vị trí có không gian mở</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>Không thể tạo tuyến đường. Hãy chọn những điểm khác cho tuyến đường</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>Để tạo tuyến đường, hãy tải xuống các bản đồ còn thiếu về thiết bị</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>Đã xảy ra lỗi. Khởi động lại ứng dụng</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>Tuyến đường sẽ được tạo lại từ vị trí hiện tại của bạn</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>Tuyến đường sẽ được thay đổi thành tuyến dành cho xe ô tô</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>Không phải tất cả dấu trang đều được hiển thị</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>Chuyển sang điện thoại để xem tất cả dấu trang</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>Camera bắn tốc độ</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>Cảnh báo tốc độ</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>Vui lòng tải xuống bản đồ trong ứng dụng Organic Maps trên thiết bị của bạn</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>Lối ra %1 của vòng xuyến</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>Sắp xếp theo mặc định</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>Sắp xếp theo kiểu</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>Sắp xếp theo khoảng cách</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>Sắp xếp theo ngày</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>Sắp xếp theo tên</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>Đồ ăn</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>Danh lam thắng cảnh</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>Bảo tàng</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>Công viên</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>Bơi lội</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>Núi non</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>Động vật</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>Khách sạn</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>Tòa nhà</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>Tiền</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>Cửa hàng</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>Bãi đậu xe</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>Trạm xăng dầu</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>Y tế</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>Tìm trong danh sách</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>Những nơi tôn nghiêm</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>Chọn danh sách</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>Điều hướng đến Metro hiện chưa khả dụng cho khu vực này</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>Không tìm thấy tuyến Metro</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>Hãy chọn điểm đầu hoặc điểm cuối của tuyến gần với bến Metro</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>Độ cao</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>Để sử dụng các đường chỉ độ cao, hãy cập nhật hoặc tải xuống bản đồ của khu vực bạn mong muốn</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>Đường hiển thị độ cao hiện chưa khả dụng tại khu vực này</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>Đi lên</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>Đi xuống</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>Min. độ cao</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>Max. độ cao</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>Độ khó</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>Khoảng cách</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>Giờ:</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>Phóng bản đồ để nhìn rõ đường đồng mức</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>Tải xuống</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>Tải xuống bản đồ tổng quan thế giới</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>Không thể tạo thư mục và di chuyển tệp trên bộ nhớ trong của thiết bị hoặc thẻ SD</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>Lỗi đĩa</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>Lỗi kết nối</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>Ngắt kết nối cáp USB</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>Giữ màn hình luôn bật</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>Khi được bật, màn hình sẽ luôn sáng khi hiển thị bản đồ.</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>Hiển thị trên màn hình khóa</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>Khi được bật, ứng dụng sẽ hoạt động trên màn hình khóa ngay cả khi thiết bị đang bị khóa.</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>Ngôn ngữ bản đồ</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>Dữ liệu bản đồ từ OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/faq/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>Cảm ơn bạn đã sử dụng bản đồ do cộng đồng xây dựng của chúng tôi!</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>Với sự đóng góp và hỗ trợ của bạn, chúng tôi có thể tạo ra những bản đồ tốt nhất trên Thế giới!</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>Bạn có thích ứng dụng của chúng tôi không? Hãy quyên góp để hỗ trợ sự phát triển! Bạn chưa thích nó? Vui lòng cho chúng tôi biết và chúng tôi sẽ khắc phục nó!</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>Nếu bạn biết một nhà phát triển phần mềm, bạn có thể yêu cầu họ triển khai một tính năng mà bạn cần.</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>Nhấn vào bất cứ nơi nào trên bản đồ để chọn bất cứ thứ gì. Nhấn và giữ để ẩn và hiển thị lại giao diện.</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>Bạn có biết rằng bạn có thể chọn vị trí hiện tại của mình trên bản đồ không?</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>Bạn có thể giúp dịch ứng dụng của chúng tôi sang ngôn ngữ của bạn.</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>Ứng dụng của chúng tôi được phát triển bởi một số người đam mê và cộng đồng.</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>Bạn có thể dễ dàng sửa chữa và cải thiện dữ liệu bản đồ.</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>Mục tiêu chính của chúng tôi là xây dựng các bản đồ nhanh chóng, tập trung vào quyền riêng tư, dễ sử dụng mà bạn sẽ yêu thích.</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>Bạn hiện đang sử dụng Organic Maps trên màn hình điện thoại</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>Bạn hiện đang sử dụng Organic Maps trên màn hình xe hơi</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>Bạn đã kết nối với Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>Tiếp tục trên điện thoại</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>Đến màn hình ô tô</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps cần quyền truy cập vị trí. Khi an toàn, hãy kiểm tra thông báo trên điện thoại của bạn.</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>Ứng dụng này cần sự cho phép của bạn</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Organic Maps trên Android Auto cần quyền truy cập vị trí để hoạt động hiệu quả</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>Cấp quyền</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>Đi bộ đường dài</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>Trình duyệt web không khả dụng</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>Âm lượng</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>Xuất tất cả Dấu trang và Bản nhạc</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>Cài đặt tổng hợp giọng nói của hệ thống</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>Không tìm thấy cài đặt Tổng hợp giọng nói, bạn có chắc thiết bị của mình hỗ trợ nó không?</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>Lái xe qua</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>Xóa tìm kiếm</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>Phóng to</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>Thu nhỏ</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>Liên kết thực đơn</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>Xem thực đơn</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>Mở trong ứng dụng khác</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>Tự phục vụ</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>Chọn tùy chọn</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>Chỗ ngồi ngoài trời</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>Để điều hướng chính xác nhất, chúng tôi khuyên bạn nên tắt chế độ tiết kiệm năng lượng trong cài đặt pin của điện thoại.</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>Ghi âm đường đi</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>Dừng ghi âm đường đi</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>Ghi âm hành trình</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>Dừng mà không lưu</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>Tiếp tục ghi âm</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>Lưu bản ghi vào đánh dấu và dấu vết?</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>Tuyến đường trống - không có gì để lưu</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>Không thể hiển thị hộp thoại chọn thư mục vì không có ứng dụng phù hợp nào được cài đặt trên thiết bị của bạn. Vui lòng cài đặt ứng dụng quản lý tệp và thử lại</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>Chọn màu</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>Chỉnh sửa tuyến đường</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>Không có ứng dụng nào được cài đặt có thể mở vị trí</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>Tự động điều hướng</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>Theo hệ thống</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>Chia sẻ lộ trình</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>Xóa %1?</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>Mức độ phức tạp</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>Dễ</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>Trung bình</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>Khó</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>Cập nhật</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>Cập nhật các bản đồ đã tải về của bạn</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>Cập nhật bản đồ để cập nhật thông tin về các đối tượng trên đó</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>Cập nhật (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>Cập nhật thủ công sau</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>Xóa lộ trình</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>Bạn có chắc chắn muốn xóa bản nhạc này không?</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>Tên bài hát</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>Di chuyển</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>Dấu chân</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>Thay đổi màu sắc</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>Bản đồ</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>Bạn có muốn gửi báo cáo lỗi cho nhà phát triển không?
+Chúng tôi dựa vào người dùng của mình vì Bản đồ không phải trả tiền không tự động thu thập bất kỳ thông tin lỗi nào. Cảm ơn bạn trước vì đã ủng hộ Organic Maps!</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>Kích hoạt đồng bộ hóa iCloud</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>Đồng bộ hóa iCloud là một tính năng thử nghiệm đang được phát triển. Đảm bảo rằng bạn đã tạo bản sao lưu tất cả dấu trang và bản nhạc của mình.</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud bị vô hiệu hóa</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>Vui lòng bật iCloud trong cài đặt thiết bị của bạn để sử dụng tính năng này.</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>Cho phép</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>Hỗ trợ</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>Lỗi đồng bộ hóa iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>Lỗi: Không đồng bộ được do lỗi kết nối</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>Lỗi: Không thể đồng bộ hóa do vượt quá hạn ngạch iCloud</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>Lỗi: iCloud không khả dụng</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>Danh sách đã xóa gần đây</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>Xóa</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>Xóa hết</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>Khôi phục</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>Khôi phục tất cả</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>Đóng góp cho OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>Thêm địa điểm</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>Cập nhật bản đồ để đóng góp</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>Bạn cần cập nhật bản đồ %1 lên phiên bản mới nhất trước khi có thể đóng góp cho dữ liệu OpenStreetMap</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>Vị trí của Tôi</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>Các Địa chỉ của Tôi</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>Bộ nhớ riêng tư nội bộ</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>Bộ nhớ chung nội bộ</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>Thẻ SD</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>Bộ nhớ ngoài dùng chung</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>WiFi</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>Mã bưu chính</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>Điểm bản đồ</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>m</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>km</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>dặm</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>ft</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>Để hiển thị các tuyến đường, bản đồ phải được cập nhật.</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>Lối ra</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>Lối vào</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>Bản đồ tàu điện ngầm không khả dụng</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>Bạn</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>Vùng đã tải về màu tím</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>Tuyến đường</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>Xác định vị trí hiện tại ở trạng thái nền là cần thiết để tận hưởng đầy đủ chức năng của ứng dụng. Nó được sử dụng trong các tùy chọn để đi theo tuyến đường và lưu đường đi gần đây của bạn</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>Xác định vị trí hiện tại được sử dụng trong các tùy chọn theo tuyến đường và lưu đường đi gần đây của bạn.</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>Đăng nhập bằng mật khẩu</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>Đăng nhập bằng trình duyệt</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>Đã sử dụng gần đây</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>Màu dấu trang đã thay đổi</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>Màu tuyến đường đã thay đổi</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>Quang phổ</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>Thanh trượt</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>ĐỎ</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>XANH LÁ</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>XANH</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>Màu sRGB dạng hex #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>Lưới</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/zh-Hans/omim.ts
+++ b/qt/translations/zh-Hans/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="zh-Hans">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>返回</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>取消</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>删除</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>下载地图</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>下载失败，请点击重试。</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>正在下载…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>公里</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>英里</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>以后再说</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>搜索</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>搜索地图</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>您当前已禁用此设备或应用程序的所有位置服务，请在设置中启用。</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>精度有限</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>为确保导航准确，请在设置中启用 &quot;精确定位&quot;。</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>在地图上显示</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>下载失败</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>再试一次</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>关于 Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>对每个人都免费，用爱制成</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• 没有广告，不会跟踪您，更不会收集您的数据</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• 无需耗费太多电量，可离线工作</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• 快速且简约，由社区开发</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>由爱好者和志愿者开发的开源应用程序。</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>位置设置</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>关闭</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>该应用程序需要硬件加速的 OpenGL。很遗憾，您的设备不受支持。</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>下载</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>请拔除 USB 线或插入 SD 卡以使用 Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>请先释放一些 SD 卡 / USB 存储空间以使用本应用</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>在您开始使用此应用程序之前，请下载全球地图到您的设备。
+它将使用 %1 的存储空间。</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>前往地图</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>正在下载%1。您现在可以
+继续查看地图。</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>下载%1的地图吗？</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>更新%1的地图吗？</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>暂停</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>继续</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1的地图下载失败</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>添加新的书签列表</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>书签列表名称</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>书签</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>书签和轨迹</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>名字</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>地址</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>列表</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>设置</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>将地图保存到</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>选择下载地图的文件夹。</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>已下载的地图</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>剩余 %1 / 总计 %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>移动地图？</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>移动地图文件时出错</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>这可能需要几分钟的时间。
+请稍候…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>测量单位</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>选择公里或英里</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>取消下载</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>发表评论</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>下载地图</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>书签列表</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>在哪儿吃</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>食品</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>交通</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>加油站</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>停车场</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>购物</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>二手货</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>酒店</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>旅游景点</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>娱乐</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>自动取款机</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>夜生活</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>亲子休闲</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>银行</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>药店</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>医院</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>厕所</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>邮局</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>警察局</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>回收</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>水</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>房车设施</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>注释</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>已与您分享 Organic Maps 书签</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>您好！
+
+附件是我的书签，请在 Organic Maps 中打开。如果您没有安装 Organic Maps，可以在这里下载: https://omaps.app/get?kmz
+
+祝您使用 Organic Maps 旅行愉快！</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>正在加载书签</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>书签载入成功！您可以在地图或书签管理页面中找到它们。</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>书签载入失败，文件可能已损坏或不完整。</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>应用程序无法识别该文件类型：
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>无法打开文件 %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>编辑</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>您的位置尚未确定</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>很抱歉，地图存储设置目前已停用。</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>地图下载进行中。</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>嘿，在 Organic Maps 上查看我目前的位置吧！请打开 %1 或 %2 链接，还没安装离线地图？在此下载: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>嘿，看看我在 Organic Maps 上标记的图钉吧！</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>嗨，到 Organic Maps 查看我当前的位置！</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>嗨，
+
+我现在在这：%1。点击此链接 %2 或此链接 %3 来查看在地图上的位置。
+
+谢谢。</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>分享</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>电子邮件</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>已复制到剪贴板：%1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>完成</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap 数据：%1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>是否确定要登出您的 OpenStreetMap 账号？</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>轨迹</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>长度</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>分享我的位置</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>常规设置</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>信息</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>导航</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>地图上的“+”和“-”按钮</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>在屏幕上显示</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>黑暗中导航时的夜间风格</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>夜间模式</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>关闭</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>开启</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>自动</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>透视图</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D 建筑</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D 建筑在省电模式下处于关闭状态</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>语音指导</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>播报街道名称</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>启用后，将大声播报即将进入的街道或出口的名称。</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>语音语言</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>要下载更高质量的语音，请打开“设置”App，然后前往“辅助功能”→“VoiceOver”→“语音”→“声音”。</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>测试语音指令（TTS，文本转语音系统）</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>如果您现在听不到声音，请检查音量或系统文本到语音系统的设置。</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>不可用</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>自动缩放</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>距离</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>在地图上查看</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>菜单</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>网站</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>新闻</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>反馈</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>为我们评分</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>帮助</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>问题和解答</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>捐助我们</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>已捐赠</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>稍后提醒</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>支持 Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>支持本项目</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>版权</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>报告问题</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>通过以 8 字形移动手机来改善箭头方向，以校准罗盘。</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>通过以 8 字形移动手机以校准罗盘，并在地图上固定箭头方向。</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>再次长按地图即可查看界面</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>更新全部</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>取消全部</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>已下载</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>已加入到下载队列</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>在我附近</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>地图</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>下载全部</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>正在下载：</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>要删除地图，请停止导航。</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>路线只能完全处在同一地图里时才能被规划。</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>下载地图</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>重新下载</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>删除地图</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>更新地图</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play 定位服务</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>通过蓝牙、WiFi 或移动网络快速确定您的大致位置</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>下载路线上的所有地图</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>规划路线需要下载并更新好所有从您的位置到目的地的地图。</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>空间不足</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>请启用位置服务</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>保存</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>创建</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>红色</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>黄色</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>蓝色</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>绿色</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>紫色</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>橙色</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>棕色</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>粉色</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>暗紫色</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>天蓝色</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>蓝绿色</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>碧绿色</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>青柠</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>深橙色</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>灰色</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>蓝灰色</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>信息</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps 版本：%1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>外观</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>浅色</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>深色</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>从黎明到黄昏使用浅色</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>其他</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>向数百万用户赠送无广告的免费地图！</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>报告或修复不正确的地图数据</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>志愿者</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>关注并联系我们：</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>尚未设置电子邮件客户端。请进行配置或通过 %1 联系我们</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>电子邮件发送失败</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>指南针校准</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>可用</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>已找到</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>更新</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>失败</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>书签</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>按照路线行进时，请谨记：</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— 路况、交通法规和路标始终优先于导航建议；</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— 地图可能不准确，建议的路线可能并非总是去往目的地的最佳路线；</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— 建议的路线仅作为推荐路线供您采纳；</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— 小心对待国界区的路线：我们的应用生成的路线有时会在未经授权的地方跨越国界。</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>上路时请当心，祝您一路平安！</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>检查 GPS 信号</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>无法规划路线。无法识别当前 GPS 坐标。</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>请检查您的 GPS 信号。启用无线网络将改善定位精度。</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>启用定位服务</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>无法定位当前 GPS 坐标。请启用定位服务以规划路线。</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>无法定位路线</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>无法规划路线。</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>请调整您的起点或目的地。</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>调整出发点</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>路线未规划。无法定位起点。</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>请选择更靠近公路的起点。</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>调整目的地</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>路线未规划。无法定位目的地。</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>请选择更靠近公路的目的地位置。</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>无法定位途径点。</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>请调整您的途径点。</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>系统错误</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>由于应用程序出错，因此无法规划路线。</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>请再试一次</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>以后再说</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>您是否要下载地图，以规划跨越边界的更佳路线？</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>下载地图，以规划一条跨越边界的更佳路线。</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>下载所需文件</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>下载或更新沿预计路线的所有地图，以规划路线。</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>要开始搜索和规划路线，请下载地图，然后您就不再需要网络连接了。</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>选择地图</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>显示</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>隐藏</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>类别</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>历史</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>很抱歉，没有搜到任何地点。</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>下载您要搜索的区域的地图，或尝试输入附近的城镇或村庄名称。</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>搜索历史记录</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>查看您最近的搜索记录。</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>清除搜索记录</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>维基百科</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>文章来自 wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>维基共享资源</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>您的位置</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>开始</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>从这出发</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>到这去</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>导航只能从您目前的位置开始。</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>您是否想要规划当前位置的路线？</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>下一页</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>从</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>到</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>添加计划</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>删除计划</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>全天（24 小时）</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>正在营业</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>已歇业</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>添加休息时间</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>营业时间</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>高级模式</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>简易模式</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>休息时间</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>示例值</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>纠正错误</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>选择地点</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>请详细描述此问题以便 OpenStreetMap 社区能够修复此错误。</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>或者在 https://www.openstreetmap.org/ 上亲自修复此错误</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>发送</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>问题</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>该地点不存在</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>因维护而关闭</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>重复的地点</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>自动下载</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>每天</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7 全天候营业</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>今天不营业</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>不营业</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>今天</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>将于 %1 后营业</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>将于 %1 后不营业</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>已停止营业</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>编辑营业时间</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>没有 OpenStreetMap 账号吗？</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>注册</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>登录</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>未登录</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>登录 OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>密码</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>忘记密码？</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>登出</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>编辑地点</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>添加语言</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>街道</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>门牌号码</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>详细信息</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>社交媒体</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>建筑</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>添加街道</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>请输入街道名称</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>选择语言</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>选择街道</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>菜肴</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>选择菜肴</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>电子邮件或用户名</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>新增电话号码</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>楼层</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>楼层：%1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>所有对地图的修改都将与地图一起被删除。</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>更新地图</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>为了规划路线，您需要更新全部地图并重新规划路线。</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>搜索地图</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>请检查您的设置并确保您的设备已连接至网络。</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>没有足够的空间</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>请删除不必要的数据</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>无法登录。</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>已验证的更改</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>拖动地图，将十字架放在地点或企业的位置。</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>编辑中</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>添加中</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>该地点的名称</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>当地语言写道</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>类别</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>问题的详细描述</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>不同的问题</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>将地点添加到</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>地点不能放置在这里</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>截至 %1 的社区创建的 OpenStreetMap 数据。请访问 OpenStreetMap.org 详细了解如何编辑和更新地图</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org（OSM）是一个构建自由开放地图的社区项目。它是 Organic Maps 地图数据的主要来源，其工作原理类似于维基百科。您可以添加或编辑地点，全世界数以百万计的用户都可以使用它们！
+加入社区，共同完善地图数据，造福每个人！</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>创建 OpenStreetMap 账号或登录，向全世界发布您编辑的地图。</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 / %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>用手机网络连接下载吗？</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>如果您使用移动数据或漫游来进行下载，将可能导致额外的费用。</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>输入正确的门牌号码</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>楼层数量 (最多 %1 层)</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>最多可编辑 %1 层的建筑</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>邮政编码</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>输入正确的邮政编码</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap 志愿者须知（可选）</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>描述地图上的错误或无法使用 Organic Maps 编辑的内容</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>您的编辑内容将上传到公共&lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Zh-hans:关于&quot;&gt;OpenStreetMap&lt;/a&gt;数据库。请勿添加个人或受版权保护的信息。</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>关于 OpenStreetMap 的更多信息</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>您的编辑历史</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>您的地图数据说明</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>操作员</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>操作员: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>找不到合适的类别？</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps 只允许添加简单的点类别，即无法添加城镇、道路、湖泊、建筑轮廓等类别。请直接向 &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; 添加此类类别。请查看我们的&lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;指南&lt;/a&gt;，了解详细的步骤说明。</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>您尚未下载任何地图</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>下载地图来查找位置和离线浏览。</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>当前位置未知。</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>公里每小时</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>英里每小时</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>小时</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>分钟</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>天</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>秒</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>更多</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>编辑书签</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>个人备注（文字或 html）</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>备注…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>重置所有本地更改？</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>重置</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>删除已添加的地点？</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>删除</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>该地点不存在</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>请注明删除该地点的原因</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>输入正确的电话号码</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>请输入有效的网址</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>请输入有效的电子邮件</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>请输入有效的 Facebook 网址、账号或页面名称</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>请输入有效的 Instagram 用户名或网址</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>请输入有效的 Twitter 用户名或网址</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>请输入有效的 VK 用户名或网址</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>请输入有效的 LINE ID 或网址</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>将地点添加到 OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>或者，也可以给 OpenStreetMap 社区留言，以便其他人可以在此添加或修复地点。</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>注释将发送至 OpenStreetMap</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>您想要发送给所有用户吗？</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>确保您没有输入任何个人数据。</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap 编辑人员将检查更改并在有任何问题时与您联系。</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>停止</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>记录轨迹</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>接受</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>拒绝</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>使用移动网络显示更多详细信息吗？</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>始终使用</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>仅在今天</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>今天不使用</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>移动网络</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>要显示地点的详细信息（例如照片、价格和评价），需要使用移动网络。</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>从不使用</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>总是询问</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>若要显示交通数据，必须更新地图。</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>增大地图上的字体大小</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>请更新 Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>交通数据不可用</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>启用日志记录</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>常规反馈</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>我们的语音导航使用“文本转语音”系统。许多 Android 设备使用 Google 的文本转语音系统，您可以从 Google Play 下载或更新这一功能</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>对于某些语言，您需要从应用商店（例如 Google Play 商店、Galaxy Store）中安装其他语音合成器或语言包。
+打开您的设备的设置 → 语言和输入法 → 语音 → 文字转语音 (TTS) 输出。
+您可以在这里管理语音合成的设置（例如，下载语言包供离线使用）和选择其他文字转语音引擎。</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>如需了解更多信息，请查阅此指南。</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>拉丁字母音译</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>了解更多信息</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>请使用搜索、选择书签或点击地图添加路线起点</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>请使用搜索、选择书签或点击地图添加目的地</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>管理路线</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>规划</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>删除站点</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>添加经停点</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>已保存</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>请登录 OpenStreetMap 以自动上传您的所有地图编辑。若要了解更多信息请点击&lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;这里&lt;/a&gt;。</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>存储空间访问问题</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>外部存储空间不可用，很可能是因为 SD 卡已移除、损毁，或者文件系统为只读状态。请进行检查，然后通过 support@organicmaps.app 联系我们</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>模拟不良存储空间</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>请输入正确的名称</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>列表</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>全部隐藏</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>全部显示</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n 个书签</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>创建新的列表</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>导入书签和轨迹</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>由于应用程序出错，导致无法分享</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>无法分享</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>无法分享空列表</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>名字不能为空</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>请输入列表名称</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>新的列表</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>这个名称已经被使用了</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>请选择其他名称</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>请稍候…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>电话号码</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap 资料</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>找到 %n 个文件，转换后您可以看到它们。</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>恢复</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n 个轨迹</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>隐私</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>隐私政策</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>使用条款</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>路况</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>徒步</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>骑行</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>地铁</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>地图样式和图层</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>该列表为空</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>要添加新书签，请点击对象卡片中的星形图标</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>更改所有书签颜色</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>更改所有轨迹颜色</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…更多</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>导出为 KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>导出为 GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>导出为 GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>删除列表</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>限速拍照</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>地点说明</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>加载地图</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>超速行驶时发出警告</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>始终提醒摄像头</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>永远不会对摄像头发出警告</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>省电模式</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>如果开启省电模式，本应用将根据手机的当前电量关闭耗电功能。</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>从不</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>当电量低时</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>最大程度省电</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>地图上的书签名称</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>如果书签太多，在地图上显示其名称可能会降低应用的速度。</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>右侧显示</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>底部显示</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>临时启用此选项，以便使用“报告错误”功能在帮助对话框中记录并手动发送详细诊断日志给我们。日志可能包含位置信息。</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>绕行设置</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>避开收费公路</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>避开未铺砌道路</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>避开轮渡</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>避开高速公路</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>无法规划路线</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>找不到路线。这可能是由于您的绕行设置或 OpenStreetMap 数据不完整造成的。请更改设置，然后重试。</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>选择要避开的道路</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>绕行设置已开启</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>收费公路</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>未铺砌道路</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>轮渡</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>否</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>否</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>容量：%1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>网络：%1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>您已到达目的地！</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>好的</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>排序…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>分类排序</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>使用默认值</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>按类型</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>按距离</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>按时间</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>按名称</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>一周前</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>一个月前</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>一个多月前</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>一年多以前</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>在我附近</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>其他</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>路线计划失败</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>已到达 %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>要规划路线，请下载并更新所有沿路线的地图。</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>您已经改变了世界地图。请别再藏着掖着了！告诉您的朋友们并一起来编辑地图。</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>与朋友分享</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>现已关门</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>明天 %1 营业</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 %2 营业</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1 营业</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1 不营业</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>添加营业时间</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>密码（至少 8 个字符）</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>无效的用户名或密码。</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM 账号</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>最后上传</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>谢谢您</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>地点名称</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>电话</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>请注意</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>下载失败</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>选择类别</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>受欢迎的</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>所有类别</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>添加新地点到地图，并直接通过此应用编辑已存在的地点。</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>更改位置</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>为了下载，您需要更多的存储空间。请删除不必要的文件。</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>我改进了 Organic Maps 地图</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>详细备注</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>您建议的更改将发送至 OpenStreetMap 社区。说明无法在 Organic Maps 编辑的详情。</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>定位到您的当前位置时出错。请检查您的设备是否正常运作，然后再试一次。</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>定位服务已被禁用</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>启用设备设置中的定位服务</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. 打开设置</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. 点击位置</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. 点击“使用 App 期间”</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. 点击“隐私和安全性”</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. 选择“定位服务”</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. 打开“定位服务”</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>或没有定位继续使用 Organic Maps</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>预定</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>呼叫</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>书签名称</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>删除书签</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>您的说明将发送至 OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…更多</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>更新</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>禁止记录您最近去过的路线吗？</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>禁用</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>来看看</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps 在后台使用您的位置记录您最近去过的路线。</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>常规设置</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>若要显示交通数据，必须更新应用。</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>日志文件大小：%1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>拖拽到此处以移除</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>更换停机坪</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>起点</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>请登录 OpenStreetMap 以自动上传您的所有地图编辑。了解更多</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>这里</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>隐藏屏幕</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>正在下載 %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>正在应用 %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>这个名称太长了</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>检测到新文件</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>转换</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>错误</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>有些文件未被转换。</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>发生错误</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>受欢迎的</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>从地图上隐藏</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>加载标签时出错，请重试</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>右侧</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>底部</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>出发</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>目的地</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>重新居中</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>搜索结果</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>然后</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>您想重新规划路线吗？</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>开车时键盘不可用</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>无法从当前位置规划路线</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>无法规划到终点的路线。请选择其它目的地</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>没有 GPS 信号。请沿着空旷区域行驶</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>无法规划路线。请选择其他路线点</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>为了规划路线，请在您的设备中下载所缺少的地图</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>发生了错误，请重新启动应用程序</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>该路线将从您的当前位置重建</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>路线将转换为汽车路线</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>未显示所有书签</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>切换到手机以查看所有书签</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>限速拍照</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>超速警告</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>将 Organic Maps 应用程序中的地图下载至个人设备中</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>第 %1 个出口</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>默认排序</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>按类型排序</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>按距离排序</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>按日期排序</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>按名称排序</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>美食</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>旅游景点</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>博物馆</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>公园</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>游泳</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>山峰</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>动物</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>酒店</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>建筑物</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>货币</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>商店</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>停车场</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>加油站</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>医疗</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>在列表中搜索</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>宗教场所</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>选择列表</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>本区域的地铁导航目前不可用</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>未找到地铁路线图</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>选择地铁站附近的起点和终点</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>等高线</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>如需使用等高线，请更新或下载所需区域的地图</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>暂时无法获取该地区的等高线</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>上坡</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>下坡</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>最低高度</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>最高高度</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>难度</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>距离：</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>时间：</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>放大地图以查看等高线</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>正在下载</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>下载世界地图</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>无法在内部存储或 SD 卡上创建文件夹和移动文件</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>磁盘错误</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>磁盘错误</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>断开 USB 线缆</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>保持屏幕打开</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>启用后，显示地图时屏幕将始终打开。</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>在锁屏上显示</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>启用后，即使设备已锁定，应用程序仍将在锁屏上运行。</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>地图语言</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>地图数据来自 OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/zh-Hans/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/zh-Hans/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Zh-hans:关于</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1，%2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>感谢您使用我们社区构建的地图！</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>有了您的捐赠和支持，我们可以创造世界上最好的地图！</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>您喜欢我们的应用程序吗？请捐款以支持发展！还不喜欢吗？请告诉我们，我们会修复您提到的问题！</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>如果您认识软件开发人员，您可以要求他实现您需要的功能。</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>轻点地图上的任意位置可选择任何内容。长按可隐藏或显示界面。</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>您知道您可以在地图上选择您当前的位置吗？</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>您可以帮助将我们的应用程序翻译成您的语言。</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>我们的应用程序是由一些爱好者和社区开发的。</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>您可以轻松修复和改进地图数据。</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>我们的主要目标是构建您会喜欢的快速、注重隐私、易于使用的地图。</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>您现在正在手机屏幕上使用 Organic Maps</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>您现在正在汽车屏幕上使用 Organic Maps</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>您已连接到 Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>在手机上继续</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>转到汽车屏幕</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps 需要位置访问权限。在安全的情况下，请查看手机上的通知。</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>此应用程序需要您的许可</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto 中的 Organic Maps 需要位置权限才能有效工作</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>授予权限</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>户外</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>网络浏览器不可用</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>音量</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>导出所有书签和轨迹</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>文本转语音系统设置</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>未找到语音合成设置，您确定您的设备支持该设置吗？</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>面下车通道</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>清除搜索</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>放大</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>缩小</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>菜单链接</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>查看菜单</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>在另一个应用中打开</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>自助服务</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>选择选项</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>室外座位</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>为了获得最准确的导航，我们建议在手机电池设置中停用省电模式。</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>录制轨迹</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>停止轨迹记录</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>轨迹记录</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>不保存停止</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>继续录制</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>保存到书签和轨迹？</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>轨迹为空 — 无内容可保存</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>由于您的设备上未安装合适的应用程序，因此无法显示文件夹选择对话框。请安装文件管理器应用程序并重试。</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>选择颜色</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>编辑轨迹</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>未安装可以打开位置的应用</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>自动导航</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>跟随系统</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>分享轨迹</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>删除 %1？</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>难度等级</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>容易</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>中等</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>困难</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>更新</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>更新已下载的地图</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>更新地图可以让对象的信息保持最新状态</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>更新 (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>稍后手动更新</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>删除轨迹</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>您确定要删除这条音轨吗？</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>轨迹名称</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>移动</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>轨迹</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>更改颜色</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>地图</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>您想向开发人员发送错误报告吗？
+由于 Organic Maps 不会自动收集任何错误信息，因此我们只能依靠我们的用户。感谢您对 Organic Maps 的支持！</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>启用 iCloud 同步</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud 同步是一项正在开发的实验性功能。请确保备份了所有书签和轨迹。</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>iCloud 已禁用</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>请在您的设备设置中启用 iCloud，以使用此功能。</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>启用</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>备份</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud 同步失败</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>错误：由于连接错误，导致同步失败</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>错误：由于超过 iCloud 配额，导致同步失败</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>错误：iCloud 不可用</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>最近删除的列表</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>清除</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>全部删除</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>恢复</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>全部恢复</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>贡献至 OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>添加地点</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>更新地图以贡献</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>您需要将 %1 地图更新到最新版本后才能贡献 OpenStreetMap 数据</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>我的位置</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>我的地点</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>内部私人存储</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>内部共享存储</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD 卡</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>外部共享存储</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>无线网络</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>邮政编码</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>地图点</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>米</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>公里</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>英里</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>英尺</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>要显示路线，必须更新地图。</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>出口</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>入口</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>地铁地图不可用</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>您</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>紫色已下载区域</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>路线</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>在背景中定义当前位置对于充分享受此应用的功能来说是必要的。它被要使用于跟随路线与保存您最近走过的路径的选项。</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>定义当前位置在跟随路线和保存您的最近行进路径的选项中被使用。</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>使用密码登录</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>使用浏览器登录</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>最近使用</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>书签颜色已更改</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>轨迹颜色已更改</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>光谱</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>滑块</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>红色</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>绿色</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>蓝色</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB 十六进制颜色 #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>网格</translation>
+</message>
+</context>
+</TS>

--- a/qt/translations/zh-Hant/omim.ts
+++ b/qt/translations/zh-Hant/omim.ts
@@ -1,0 +1,3931 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="zh-Hant">
+<context>
+<name></name>
+<message id="back">
+<extracomment>Button text (should be short)</extracomment>
+<source>Back</source>
+<translation>返回</translation>
+</message>
+<message id="cancel">
+<extracomment>Button text (should be short)</extracomment>
+<source>Cancel</source>
+<translation>取消</translation>
+</message>
+<message id="delete">
+<extracomment>Button which deletes downloaded country</extracomment>
+<source>Delete</source>
+<translation>刪除</translation>
+</message>
+<message id="download_maps">
+<source>Download Maps</source>
+<translation>下載地圖</translation>
+</message>
+<message id="download_has_failed">
+<extracomment>Settings/Downloader - info for country when download fails</extracomment>
+<source>Download has failed. Tap to try again.</source>
+<translation>下載失敗，點擊後再試一次。</translation>
+</message>
+<message id="downloading">
+<extracomment>Settings/Downloader - info for country which started downloading</extracomment>
+<source>Downloading…</source>
+<translation>下載中…</translation>
+</message>
+<message id="kilometres">
+<extracomment>Choose measurement on first launch alert - choose metric system button</extracomment>
+<source>Kilometers</source>
+<translation>公里</translation>
+</message>
+<message id="miles">
+<extracomment>Choose measurement on first launch alert - choose imperial system button</extracomment>
+<source>Miles</source>
+<translation>英哩</translation>
+</message>
+<message id="later">
+<extracomment>Update maps later button text</extracomment>
+<source>Later</source>
+<translation>以後再說</translation>
+</message>
+<message id="search">
+<extracomment>View and button titles for accessibility. Also used in iPhone home screen quick actions.</extracomment>
+<source>Search</source>
+<translation>搜尋</translation>
+</message>
+<message id="search_map">
+<extracomment>Search box placeholder text; Used when searching on the map itself, not when searching for a map</extracomment>
+<source>Search Map</source>
+<translation>搜尋地圖</translation>
+</message>
+<message id="location_is_disabled_long_text">
+<extracomment>Location services are disabled by user alert - message</extracomment>
+<source>You currently have all Location Services for this device or application disabled. Please enable them in Settings.</source>
+<translation>您目前已禁用此裝置或應用程式的所有位置權限，請在設定中啟用。</translation>
+</message>
+<message id="limited_accuracy">
+<extracomment>A dialog title, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>Limited Accuracy</source>
+<translation>精度有限</translation>
+</message>
+<message id="precise_location_is_disabled_long_text">
+<extracomment>A dialog text, that warns a user that Precise Location is disabled and suggests to turn it on</extracomment>
+<source>To ensure accurate navigation enable Precise Location in settings.</source>
+<translation>為了確保准確的導航啟用設置中的精確位置。</translation>
+</message>
+<message id="zoom_to_country">
+<extracomment>View and button titles for accessibility</extracomment>
+<source>Show on the map</source>
+<translation>在地圖上顯示</translation>
+</message>
+<message id="country_status_download_failed">
+<extracomment>Message to display at the center of the screen when the country download has failed</extracomment>
+<source>Download has failed</source>
+<translation>下載失敗</translation>
+</message>
+<message id="try_again">
+<extracomment>Button text for the button under the country_status_download_failed message</extracomment>
+<source>Try Again</source>
+<translation>再試一次</translation>
+</message>
+<message id="about_menu_title">
+<source>About Organic Maps</source>
+<translation>關於 Organic Maps</translation>
+</message>
+<message id="about_headline">
+<extracomment>Text in About screen</extracomment>
+<source>Free for everyone, made with love</source>
+<translation>對每個人都免費，用愛製成</translation>
+</message>
+<message id="about_proposition_1">
+<extracomment>Text in About screen</extracomment>
+<source>• No ads, no tracking, no data collection</source>
+<translation>• 沒有廣告，不會跟蹤您，更不會收集您的數據</translation>
+</message>
+<message id="about_proposition_2">
+<extracomment>Text in About screen</extracomment>
+<source>• No battery drain, works offline</source>
+<translation>• 無需耗費太多電量，可離線工作</translation>
+</message>
+<message id="about_proposition_3">
+<extracomment>Text in About screen</extracomment>
+<source>• Fast, minimalist, developed by the community</source>
+<translation>• 快速且簡約，由社群開發</translation>
+</message>
+<message id="about_developed_by_enthusiasts">
+<extracomment>Text in About screen</extracomment>
+<source>Open-source application created by enthusiasts and volunteers.</source>
+<translation>由愛好者和志願者開發的開源應用程式。</translation>
+</message>
+<message id="location_settings">
+<extracomment>The button that opens system location settings</extracomment>
+<source>Location Settings</source>
+<translation>位置設定</translation>
+</message>
+<message id="close">
+<source>Close</source>
+<translation>關閉</translation>
+</message>
+<message id="unsupported_phone">
+<source>The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</source>
+<translation>該應用程式需要硬體加速的 OpenGL。很遺憾，您的裝置不受支援。</translation>
+</message>
+<message id="download">
+<source>Download</source>
+<translation>下載</translation>
+</message>
+<message id="disconnect_usb_cable">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please disconnect USB cable or insert memory card to use Organic Maps</source>
+<translation>請拔除 USB 線或插入 SD 卡以使用 Organic Maps</translation>
+</message>
+<message id="not_enough_free_space_on_sdcard">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Please free up some space on the SD card/USB storage first in order to use the app</source>
+<translation>請先釋放一些 SD 卡 / USB 儲存空間以使用 Organic Maps</translation>
+</message>
+<message id="download_resources">
+<source>Before you start using the app, please download the world overview map to your device.
+It will use %1 of storage.</source>
+<translation>在您開始使用此應用程式之前，請下載全球地圖到您的裝置。
+它將使用 %1 的儲存空間。</translation>
+</message>
+<message id="download_resources_continue">
+<source>Go to Map</source>
+<translation>前往地圖</translation>
+</message>
+<message id="downloading_country_can_proceed">
+<source>Downloading %1. You can now
+proceed to the map.</source>
+<translation>正在下載%1。您現在可以
+繼續查看地圖。</translation>
+</message>
+<message id="download_country_ask">
+<source>Download %1?</source>
+<translation>下載%1的地圖嗎？</translation>
+</message>
+<message id="update_country_ask">
+<source>Update %1?</source>
+<translation>更新%1的地圖嗎？</translation>
+</message>
+<message id="pause">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Pause</source>
+<translation>暫停</translation>
+</message>
+<message id="continue_button">
+<extracomment>REMOVE THIS STRING AFTER REFACTORING</extracomment>
+<source>Continue</source>
+<translation>繼續</translation>
+</message>
+<message id="download_country_failed">
+<extracomment>Show popup notification on top of the map when country download has failed.</extracomment>
+<source>%1 download has failed</source>
+<translation>%1的地圖下載失敗</translation>
+</message>
+<message id="add_new_set">
+<extracomment>&quot;Add new bookmark list&quot; dialog title</extracomment>
+<source>Add a New List</source>
+<translation>新增新的書籤列表</translation>
+</message>
+<message id="bookmark_set_name">
+<extracomment>Add Bookmark list dialog - hint when the list name is empty</extracomment>
+<source>Bookmark List Name</source>
+<translation>書籤列表名稱</translation>
+</message>
+<message id="bookmarks">
+<extracomment>Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied.</extracomment>
+<source>Bookmarks</source>
+<translation>書籤</translation>
+</message>
+<message id="bookmarks_and_tracks">
+<extracomment>&quot;Bookmarks and Tracks&quot; dialog title. Also used in iPhone home screen quick actions.</extracomment>
+<source>Bookmarks and Tracks</source>
+<translation>書籤和軌跡</translation>
+</message>
+<message id="name">
+<extracomment>Add bookmark dialog - bookmark name</extracomment>
+<source>Name</source>
+<translation>名稱</translation>
+</message>
+<message id="address">
+<extracomment>Editor title above street and house number, duplicates [type.building.address] in types_strings.txt</extracomment>
+<source>Address</source>
+<translation>地址</translation>
+</message>
+<message id="list">
+<extracomment>Add Bookmark dialog/Bookmark list; Bookmarks dialog/Bookmark list cell.</extracomment>
+<source>List</source>
+<translation>清單</translation>
+</message>
+<message id="settings">
+<extracomment>Settings button in system menu</extracomment>
+<source>Settings</source>
+<translation>設定</translation>
+</message>
+<message id="maps_storage">
+<extracomment>Header of settings activity where user defines storage path</extracomment>
+<source>Save maps to</source>
+<translation>將地圖儲存至</translation>
+</message>
+<message id="maps_storage_summary">
+<extracomment>Detailed description of Maps Storage settings button</extracomment>
+<source>Select the folder to download maps to.</source>
+<translation>選擇下載地圖的資料夾。</translation>
+</message>
+<message id="maps_storage_downloaded">
+<extracomment>E.g. &quot;Downloaded maps: 500Mb&quot; in Maps Storage settings</extracomment>
+<source>Downloaded maps</source>
+<translation>已下載的地圖</translation>
+</message>
+<message id="maps_storage_free_size">
+<extracomment>Free space out of total storage size in Maps Storage settings, e.g. &quot;300 MB free of 2 GB&quot;</extracomment>
+<source>%1 free of %2</source>
+<translation>剩餘 %1 / 總計 %2</translation>
+</message>
+<message id="move_maps">
+<extracomment>Question dialog for transferring maps from one storage to another</extracomment>
+<source>Move maps?</source>
+<translation>移動地圖？</translation>
+</message>
+<message id="move_maps_error">
+<extracomment>Error moving map files from one storage to another</extracomment>
+<source>Error moving map files</source>
+<translation>移動地圖檔案時出錯</translation>
+</message>
+<message id="wait_several_minutes">
+<extracomment>Ask user to wait several minutes (some long process in modal dialog).</extracomment>
+<source>This can take several minutes.
+Please wait…</source>
+<translation>這可能需要幾分鐘的時間
+請稍候…</translation>
+</message>
+<message id="measurement_units">
+<extracomment>Measurement units title in settings activity</extracomment>
+<source>Measurement units</source>
+<translation>測量單位</translation>
+</message>
+<message id="measurement_units_summary">
+<extracomment>Detailed description of Measurement Units settings button</extracomment>
+<source>Choose between miles and kilometers</source>
+<translation>選擇公里或英哩</translation>
+</message>
+<message id="cancel_download">
+<extracomment>Button which interrupts country download</extracomment>
+<source>Cancel Download</source>
+<translation>取消下載</translation>
+</message>
+<message id="leave_a_review">
+<extracomment>Leave Review dialog - Review button</extracomment>
+<source>Leave a Review</source>
+<translation>撰寫評論</translation>
+</message>
+<message id="use_cellular_data">
+<extracomment>Settings/Downloader - 3G download warning dialog confirm button</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="country_status_download_without_size">
+<extracomment>Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown</extracomment>
+<source>Download Map</source>
+<translation>下載地圖</translation>
+</message>
+<message id="bookmark_sets">
+<extracomment>&quot;Bookmark Lists&quot; dialog title</extracomment>
+<source>Bookmark Lists</source>
+<translation>書籤列表</translation>
+</message>
+<message id="category_eat">
+<extracomment>Search category for cafes, bars, restaurants; any changes should be duplicated in categories.txt @category_eat!</extracomment>
+<source>Where to eat</source>
+<translation>在哪裡吃</translation>
+</message>
+<message id="category_food">
+<extracomment>Search category for grocery stores; any changes should be duplicated in categories.txt @category_food!</extracomment>
+<source>Groceries</source>
+<translation>食品</translation>
+</message>
+<message id="category_transport">
+<extracomment>Search category for public transport; any changes should be duplicated in categories.txt @category_transport!</extracomment>
+<source>Transport</source>
+<translation>交通</translation>
+</message>
+<message id="category_fuel">
+<extracomment>Search category for fuel stations; any changes should be duplicated in categories.txt @category_fuel!</extracomment>
+<source>Gas</source>
+<translation>加油站</translation>
+</message>
+<message id="category_parking">
+<extracomment>Search category for parking lots; any changes should be duplicated in categories.txt @category_parking!</extracomment>
+<source>Parking</source>
+<translation>停車場</translation>
+</message>
+<message id="category_shopping">
+<extracomment>Search category for malls/clothes/shoes/gifts/jewellery/sport shops; any changes should be duplicated in categories.txt @category_shopping!</extracomment>
+<source>Shopping</source>
+<translation>購物</translation>
+</message>
+<message id="category_secondhand">
+<extracomment>Search category for second_hand/charity/antique/auction shops; any changes should be duplicated in categories.txt @category_secondhand!</extracomment>
+<source>Second Hand</source>
+<translation>二手商店</translation>
+</message>
+<message id="category_hotel">
+<extracomment>Search category for places to stay; any changes should be duplicated in categories.txt @category_hotel!</extracomment>
+<source>Hotel</source>
+<translation>旅館</translation>
+</message>
+<message id="category_tourism">
+<extracomment>Search category sight seeings and touristic attractions; any changes should be duplicated in categories.txt @category_tourism!</extracomment>
+<source>Sights</source>
+<translation>旅遊景點</translation>
+</message>
+<message id="category_entertainment">
+<extracomment>Search category for entertainment; any changes should be duplicated in categories.txt @category_entertainment!</extracomment>
+<source>Entertainment</source>
+<translation>娛樂</translation>
+</message>
+<message id="category_atm">
+<extracomment>Search category for ATMs; any changes should be duplicated in categories.txt @category_atm!</extracomment>
+<source>ATM</source>
+<translation>自動提款機</translation>
+</message>
+<message id="category_nightlife">
+<extracomment>Search category for nightclubs/bars; any changes should be duplicated in categories.txt @category_nightlife!</extracomment>
+<source>Nightlife</source>
+<translation>夜生活</translation>
+</message>
+<message id="category_children">
+<extracomment>Search category for water park/disneyland/playground/toys store; any changes should be duplicated in categories.txt @category_children!</extracomment>
+<source>Family holiday</source>
+<translation>親子休閒</translation>
+</message>
+<message id="category_bank">
+<extracomment>Search category for banks; any changes should be duplicated in categories.txt @category_bank!</extracomment>
+<source>Bank</source>
+<translation>銀行</translation>
+</message>
+<message id="category_pharmacy">
+<extracomment>Search category for pharmacies; any changes should be duplicated in categories.txt @category_pharmacy!</extracomment>
+<source>Pharmacy</source>
+<translation>藥局</translation>
+</message>
+<message id="category_hospital">
+<extracomment>Search category for hospitals; any changes should be duplicated in categories.txt @category_hospital!</extracomment>
+<source>Hospital</source>
+<translation>醫院</translation>
+</message>
+<message id="category_toilet">
+<extracomment>Search category for toilets; any changes should be duplicated in categories.txt @category_toilet!</extracomment>
+<source>Toilet</source>
+<translation>廁所</translation>
+</message>
+<message id="category_post">
+<extracomment>Search category for post offices; any changes should be duplicated in categories.txt @category_post!</extracomment>
+<source>Post</source>
+<translation>郵局</translation>
+</message>
+<message id="category_police">
+<extracomment>Search category for police; any changes should be duplicated in categories.txt @category_police!</extracomment>
+<source>Police</source>
+<translation>警察局</translation>
+</message>
+<message id="category_recycling">
+<extracomment>Search category for recycling; any changes should be duplicated in categories.txt @category_recycling!</extracomment>
+<source>Recycling</source>
+<translation>回收</translation>
+</message>
+<message id="category_water">
+<extracomment>Search category for water; any changes should be duplicated in categories.txt @category_water! also used to sort bookmarks by type</extracomment>
+<source>Water</source>
+<translation>水</translation>
+</message>
+<message id="category_rv">
+<extracomment>Search category for RV facilities; any changes should be duplicated in categories.txt @category_rv!</extracomment>
+<source>RV Facilities</source>
+<translation>露營車設施</translation>
+</message>
+<message id="description">
+<extracomment>Notes field in Bookmarks view</extracomment>
+<source>Notes</source>
+<translation>註釋</translation>
+</message>
+<message id="share_bookmarks_email_subject">
+<extracomment>Email Subject when sharing bookmark list</extracomment>
+<source>Organic Maps bookmarks were shared with you</source>
+<translation>已與您分享 Organic Maps 書籤</translation>
+</message>
+<message id="share_bookmarks_email_body">
+<source>Hello!
+
+Attached are my bookmarks; please open them in Organic Maps. If you don&#x27;t have it installed you can download it here: https://omaps.app/get?kmz
+
+Enjoy travelling with Organic Maps!</source>
+<translation>您好！
+
+附件是我的書籤，請在 Organic Maps 中打開。如果您沒有安裝 Organic Maps，可以在這裡下載: https://omaps.app/get?kmz
+
+祝您使用 Organic Maps 旅行愉快！</translation>
+</message>
+<message id="load_kmz_title">
+<extracomment>message title of loading file</extracomment>
+<source>Loading Bookmarks</source>
+<translation>正在載入書籤</translation>
+</message>
+<message id="load_kmz_successful">
+<extracomment>Kmz file successful loading</extracomment>
+<source>Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.</source>
+<translation>書籤載入成功！ 您可以在地圖或書籤管理畫面中找到它們。</translation>
+</message>
+<message id="load_kmz_failed">
+<extracomment>Kml file loading failed</extracomment>
+<source>Failed to load bookmarks. The file may be corrupted or defective.</source>
+<translation>書籤載入失敗，檔案可能已損壞或不完整。</translation>
+</message>
+<message id="unknown_file_type">
+<extracomment>Failed to recognize the format of a bookmarks or tracks file.</extracomment>
+<source>The file type is not recognized by the app:
+%1</source>
+<translation>應用程式無法識別該文件類型：
+%1</translation>
+</message>
+<message id="failed_to_open_file">
+<extracomment>Failed to open a bookmarks or tracks file in Organic Maps.</extracomment>
+<source>Failed to open file %1
+
+%2</source>
+<translation>無法打開檔案 %1
+
+%2</translation>
+</message>
+<message id="edit">
+<extracomment>resource for context menu</extracomment>
+<source>Edit</source>
+<translation>編輯</translation>
+</message>
+<message id="unknown_current_position">
+<extracomment>Warning message when doing search around current position</extracomment>
+<source>Your location hasn&#x27;t been determined yet</source>
+<translation>您的位置尚未確定</translation>
+</message>
+<message id="cant_change_this_setting">
+<extracomment>Alert message that we can&#x27;t run Map Storage settings due to some reasons.</extracomment>
+<source>Sorry, Map Storage settings are currently disabled.</source>
+<translation>很抱歉，地圖儲存設定目前已停用。</translation>
+</message>
+<message id="downloading_is_active">
+<extracomment>Alert message that downloading is in progress.</extracomment>
+<source>Map download is in progress now.</source>
+<translation>地圖下載進行中。</translation>
+</message>
+<message id="my_position_share_sms">
+<extracomment>Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.</extracomment>
+<source>Check out my current location in Organic Maps! %1 or %2 Don&#x27;t have offline maps? Download here: https://omaps.app/get</source>
+<translation>嘿，在 Organic Maps 查看我的目前的位置吧！請打開 %1 或 %2 鏈接，還沒安裝離線地圖？在此下載: https://omaps.app/get</translation>
+</message>
+<message id="bookmark_share_email_subject">
+<extracomment>Subject for emailed bookmark</extracomment>
+<source>Hey, check out my pin in Organic Maps!</source>
+<translation>嘿，看看我在 Organic Maps 上標記的圖釘吧！</translation>
+</message>
+<message id="my_position_share_email_subject">
+<extracomment>Subject for emailed position</extracomment>
+<source>Hey, check out my current location on the Organic Maps map!</source>
+<translation>嗨，到 Organic Maps 查看我目前的位置！</translation>
+</message>
+<message id="my_position_share_email">
+<extracomment>Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME</extracomment>
+<source>Hi,
+
+I&#x27;m here now: %1. Click this link %2 or this one %3 to see the place on the map.
+
+Thanks.</source>
+<translation>嗨，
+
+我現在在這：%1。點擊此連結 %2 或此連結 %3 來查看在地圖上的位置。
+
+謝謝。</translation>
+</message>
+<message id="share">
+<extracomment>Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.</extracomment>
+<source>Share</source>
+<translation>分享</translation>
+</message>
+<message id="email">
+<extracomment>Share by email button text, also used in editor and About.</extracomment>
+<source>Email</source>
+<translation>電子郵件</translation>
+</message>
+<message id="copied_to_clipboard">
+<extracomment>Text for message when used successfully copied something</extracomment>
+<source>Copied to clipboard: %1</source>
+<translation>已複製到剪貼簿：%1</translation>
+</message>
+<message id="done">
+<extracomment>Used for bookmark editing</extracomment>
+<source>Done</source>
+<translation>完成</translation>
+</message>
+<message id="data_version">
+<extracomment>Data version in «About» screen, %@ is replaced by a local, human readable date.</extracomment>
+<source>OpenStreetMap data: %1</source>
+<translation>OpenStreetMap 數據：%1</translation>
+</message>
+<message id="osm_log_out_confirmation">
+<extracomment>Confirmation for OpenStreetMap log out.</extracomment>
+<source>Are you sure you want to log out of your OpenStreetMap account?</source>
+<translation>您確定要登出您的 OpenStreetMap 帳戶嗎？</translation>
+</message>
+<message id="tracks_title">
+<extracomment>Title for tracks category in bookmarks manager</extracomment>
+<source>Tracks</source>
+<translation>軌跡</translation>
+</message>
+<message id="length">
+<extracomment>Length of track in cell that describes route</extracomment>
+<source>Length</source>
+<translation>長度</translation>
+</message>
+<message id="share_my_location">
+<source>Share My Location</source>
+<translation>分享我的位置</translation>
+</message>
+<message id="prefs_group_general">
+<extracomment>Settings general group in settings screen</extracomment>
+<source>General settings</source>
+<translation>一般設定</translation>
+</message>
+<message id="prefs_group_information">
+<extracomment>Settings information group in settings screen</extracomment>
+<source>Information</source>
+<translation>資訊</translation>
+</message>
+<message id="prefs_group_route">
+<source>Navigation</source>
+<translation>導航</translation>
+</message>
+<message id="pref_zoom_title">
+<extracomment>Setting name which enables or disables zoom buttons on the map screen.</extracomment>
+<source>“+” and “-” buttons on the map</source>
+<translation>地圖上的「+」和「-」按鈕</translation>
+</message>
+<message id="pref_zoom_summary">
+<source>Display on the map</source>
+<translation>在螢幕上顯示</translation>
+</message>
+<message id="pref_auto_night_in_navigation_title">
+<source>Night style when navigating in the dark</source>
+<translation>在黑暗中導航時的夜間風格</translation>
+</message>
+<message id="pref_map_style_title">
+<extracomment>Settings «Map» category: «Night style» title</extracomment>
+<source>Night Mode</source>
+<translation>夜間模式</translation>
+</message>
+<message id="off">
+<extracomment>Generic «Off» string</extracomment>
+<source>Off</source>
+<translation>關閉</translation>
+</message>
+<message id="on">
+<extracomment>Generic «On» string</extracomment>
+<source>On</source>
+<translation>開啟</translation>
+</message>
+<message id="auto">
+<extracomment>Generic «Auto» string</extracomment>
+<source>Auto</source>
+<translation>自動</translation>
+</message>
+<message id="pref_map_3d_title">
+<extracomment>Settings «Map» category: «Perspective view» title</extracomment>
+<source>Perspective view</source>
+<translation>透視圖</translation>
+</message>
+<message id="pref_map_3d_buildings_title">
+<extracomment>Settings «Map» category: «3D buildings» title</extracomment>
+<source>3D buildings</source>
+<translation>3D 建築</translation>
+</message>
+<message id="pref_map_3d_buildings_disabled_summary">
+<extracomment>A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled</extracomment>
+<source>3D buildings are disabled in power saving mode</source>
+<translation>3D 建築在省電模式下將會關閉</translation>
+</message>
+<message id="pref_tts_enable_title">
+<extracomment>Settings «Route» category: «Tts enabled» title</extracomment>
+<source>Voice Instructions</source>
+<translation>語音提示</translation>
+</message>
+<message id="pref_tts_street_names_title">
+<extracomment>Settings «Route» category: «Tts announce street names» title</extracomment>
+<source>Announce Street Names</source>
+<translation>播報街道名稱</translation>
+</message>
+<message id="pref_tts_street_names_description">
+<extracomment>Settings «Route» category: «Tts announce street names» description</extracomment>
+<source>When enabled, the name of the street or exit to turn onto will be spoken aloud.</source>
+<translation>啟用後，將大聲播報即將進入的街道或出口的名稱。</translation>
+</message>
+<message id="pref_tts_language_title">
+<extracomment>Settings «Route» category: «Tts language» title</extracomment>
+<source>Voice Language</source>
+<translation>語音語言</translation>
+</message>
+<message id="pref_tts_download_voices_description">
+<extracomment>Settings «Navigation» category: «Voice language» footer</extracomment>
+<source>To download a higher-quality voice, open the Settings app and go to Accessibility → VoiceOver → Speech → Voice.</source>
+<translation>若要下載更高品質的語音，請打開「設定」App，然後前往「輔助使用」→「VoiceOver」→「語音」→「聲音」。</translation>
+</message>
+<message id="pref_tts_test_voice_title">
+<extracomment>Settings «Route» category: «Test Voice Directions» title</extracomment>
+<source>Test Voice Directions (TTS, Text-To-Speech)</source>
+<translation>測試語音指令（TTS，文字轉語音系統）</translation>
+</message>
+<message id="pref_tts_playing_test_voice">
+<extracomment>Settings «Route» category: Pop-up message when clicking «Test Voice Directions»</extracomment>
+<source>Check the volume or system Text-To-Speech settings if you don&#x27;t hear the voice now.</source>
+<translation>如果您現在聽不到聲音，請檢查音量或系統文字轉語音系統的設定。</translation>
+</message>
+<message id="pref_tts_unavailable">
+<extracomment>Settings «Route» category: «Tts unavailable» subtitle</extracomment>
+<source>Not Available</source>
+<translation>無法使用</translation>
+</message>
+<message id="pref_map_auto_zoom">
+<source>Auto zoom</source>
+<translation>自動縮放</translation>
+</message>
+<message id="placepage_distance">
+<source>Distance</source>
+<translation>距離</translation>
+</message>
+<message id="search_show_on_map">
+<source>View on map</source>
+<translation>在地圖上查看</translation>
+</message>
+<message id="menu">
+<extracomment>Menu button</extracomment>
+<source>Menu</source>
+<translation>菜單</translation>
+</message>
+<message id="website">
+<extracomment>Text in menu</extracomment>
+<source>Website</source>
+<translation>網站</translation>
+</message>
+<message id="news">
+<extracomment>Text in About menu, opens Organic Maps news website</extracomment>
+<source>News</source>
+<translation>新聞</translation>
+</message>
+<message id="feedback">
+<extracomment>Settings: Send feedback button and dialog title</extracomment>
+<source>Feedback</source>
+<translation>回饋</translation>
+</message>
+<message id="rate_the_app">
+<extracomment>Text in menu</extracomment>
+<source>Rate the app</source>
+<translation>為我們評分</translation>
+</message>
+<message id="help">
+<extracomment>Text in menu</extracomment>
+<source>Help</source>
+<translation>幫助</translation>
+</message>
+<message id="faq">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Frequently Asked Questions</source>
+<translation>問題和解答</translation>
+</message>
+<message id="donate">
+<extracomment>Button in the main menu</extracomment>
+<source>Donate</source>
+<translation>捐助我們</translation>
+</message>
+<message id="already_donated">
+<source>Already donated</source>
+<translation>已捐贈</translation>
+</message>
+<message id="remind_me_later">
+<source>Remind later</source>
+<translation>稍後提醒</translation>
+</message>
+<message id="support_organic_maps">
+<source>Support Organic Maps</source>
+<translation>支援 Organic Maps</translation>
+</message>
+<message id="how_to_support_us">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Support the project</source>
+<translation>支持本項目</translation>
+</message>
+<message id="copyright">
+<extracomment>Button in the main Help dialog</extracomment>
+<source>Copyright</source>
+<translation>版權</translation>
+</message>
+<message id="report_a_bug">
+<extracomment>Text in menu + Button in the main Help dialog. Used in home screen quick actions.</extracomment>
+<source>Report a bug</source>
+<translation>報告問題</translation>
+</message>
+<message id="compass_calibration_recommended">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</source>
+<translation>以 8 字形移動手機來改善箭頭方向，以校準羅盤。</translation>
+</message>
+<message id="compass_calibration_required">
+<extracomment>Toast text when compass calibration may improve the correctness of the current position arrow</extracomment>
+<source>Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</source>
+<translation>以 8 字形移動手機以校準指北針，並在地圖上固定箭頭方向。</translation>
+</message>
+<message id="long_tap_toast">
+<extracomment>Toast text when user hides UI with a long tap anywhere on the map</extracomment>
+<source>Long-tap on the map again to see the interface</source>
+<translation>再次長按地圖即可查看介面</translation>
+</message>
+<message id="downloader_update_all_button">
+<extracomment>Update all button text</extracomment>
+<source>Update All</source>
+<translation>更新全部</translation>
+</message>
+<message id="downloader_cancel_all">
+<extracomment>Cancel all button text</extracomment>
+<source>Cancel All</source>
+<translation>取消全部</translation>
+</message>
+<message id="downloader_downloaded_subtitle">
+<extracomment>Downloaded maps list header</extracomment>
+<source>Downloaded</source>
+<translation>已下載</translation>
+</message>
+<message id="downloader_queued">
+<extracomment>Country queued for download</extracomment>
+<source>Queued</source>
+<translation>已加入到下載清單</translation>
+</message>
+<message id="downloader_near_me_subtitle">
+<source>Near me</source>
+<translation>在我附近</translation>
+</message>
+<message id="downloader_status_maps">
+<extracomment>In maps downloader and country place page shows how many maps are downloaded / to download, e.g. &quot;Maps: 3 of 10&quot;</extracomment>
+<source>Maps</source>
+<translation>地圖</translation>
+</message>
+<message id="downloader_download_all_button">
+<source>Download All</source>
+<translation>下載全部</translation>
+</message>
+<message id="downloader_downloading">
+<source>Downloading:</source>
+<translation>正在下載：</translation>
+</message>
+<message id="downloader_delete_map_while_routing_dialog">
+<extracomment>Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode</extracomment>
+<source>To delete map, please stop navigation.</source>
+<translation>要刪除地圖，請停止導航。</translation>
+</message>
+<message id="routing_failed_cross_mwm_building">
+<extracomment>PointsInDifferentMWM</extracomment>
+<source>Routes can only be created that are fully contained within a map of a single region.</source>
+<translation>路線只能完全處在同一地圖裡時才能被規劃。</translation>
+</message>
+<message id="downloader_download_map">
+<extracomment>Context menu item for downloader.</extracomment>
+<source>Download map</source>
+<translation>下載地圖</translation>
+</message>
+<message id="downloader_retry">
+<extracomment>Item status in downloader.</extracomment>
+<source>Retry</source>
+<translation>重新下載</translation>
+</message>
+<message id="downloader_delete_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Delete Map</source>
+<translation>刪除地圖</translation>
+</message>
+<message id="downloader_update_map">
+<extracomment>Item in context menu.</extracomment>
+<source>Update Map</source>
+<translation>更新地圖</translation>
+</message>
+<message id="google_play_services">
+<extracomment>Preference title</extracomment>
+<source>Google Play Location Services</source>
+<translation>Google Play 定位服務</translation>
+</message>
+<message id="pref_use_google_play">
+<extracomment>Preference text</extracomment>
+<source>Quickly determine your approximate location using Bluetooth, WiFi, or mobile network</source>
+<translation>使用藍牙、WiFi 或行動數據快速確定您的大致位置</translation>
+</message>
+<message id="routing_download_maps_along">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Download all of the maps along your route</source>
+<translation>下載路線上的所有地圖</translation>
+</message>
+<message id="routing_requires_all_map">
+<extracomment>Text for routing error dialog</extracomment>
+<source>In order to create a route, we need to download and update all the maps from your location to your destination.</source>
+<translation>規劃路線需要下載並更新好所有從您的位置到目的地的地圖。</translation>
+</message>
+<message id="routing_not_enough_space">
+<extracomment>Text for routing error dialog</extracomment>
+<source>Not enough space</source>
+<translation>空間不足</translation>
+</message>
+<message id="enable_location_services">
+<extracomment>location service disabled</extracomment>
+<source>Please enable Location Services</source>
+<translation>請啟用定位服務</translation>
+</message>
+<message id="save">
+<source>Save</source>
+<translation>儲存</translation>
+</message>
+<message id="create">
+<source>create</source>
+<translation>建立</translation>
+</message>
+<message id="red">
+<extracomment>red color</extracomment>
+<source>Red</source>
+<translation>紅色</translation>
+</message>
+<message id="yellow">
+<extracomment>yellow color</extracomment>
+<source>Yellow</source>
+<translation>黃色</translation>
+</message>
+<message id="blue">
+<extracomment>blue color</extracomment>
+<source>Blue</source>
+<translation>藍色</translation>
+</message>
+<message id="green">
+<extracomment>green color</extracomment>
+<source>Green</source>
+<translation>綠色</translation>
+</message>
+<message id="purple">
+<extracomment>purple color</extracomment>
+<source>Purple</source>
+<translation>紫色</translation>
+</message>
+<message id="orange">
+<extracomment>orange color</extracomment>
+<source>Orange</source>
+<translation>橙色</translation>
+</message>
+<message id="brown">
+<extracomment>brown color</extracomment>
+<source>Brown</source>
+<translation>棕色</translation>
+</message>
+<message id="pink">
+<extracomment>pink color</extracomment>
+<source>Pink</source>
+<translation>粉色</translation>
+</message>
+<message id="deep_purple">
+<extracomment>deep purple color</extracomment>
+<source>Deep Purple</source>
+<translation>暗紫色</translation>
+</message>
+<message id="light_blue">
+<extracomment>light blue color</extracomment>
+<source>Light Blue</source>
+<translation>天藍色</translation>
+</message>
+<message id="cyan">
+<extracomment>cyan color</extracomment>
+<source>Cyan</source>
+<translation>藍綠色</translation>
+</message>
+<message id="teal">
+<extracomment>teal color</extracomment>
+<source>Teal</source>
+<translation>碧綠色</translation>
+</message>
+<message id="lime">
+<extracomment>lime color</extracomment>
+<source>Lime</source>
+<translation>青檸</translation>
+</message>
+<message id="deep_orange">
+<extracomment>deep orange color</extracomment>
+<source>Deep Orange</source>
+<translation>深橙色</translation>
+</message>
+<message id="gray">
+<extracomment>gray color</extracomment>
+<source>Gray</source>
+<translation>灰色</translation>
+</message>
+<message id="blue_gray">
+<extracomment>blue gray color</extracomment>
+<source>Blue Gray</source>
+<translation>藍灰色</translation>
+</message>
+<message id="info">
+<extracomment>place preview title</extracomment>
+<source>Info</source>
+<translation>資訊</translation>
+</message>
+<message id="version">
+<extracomment>Prints version number in About dialog</extracomment>
+<source>Organic Maps version: %1</source>
+<translation>Organic Maps 版本：%1</translation>
+</message>
+<message id="pref_appearance_title">
+<extracomment>Settings «Map» category: «Appearance» title</extracomment>
+<source>Appearance</source>
+<translation>外觀</translation>
+</message>
+<message id="pref_appearance_light">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Light&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light</source>
+<translation>淺色</translation>
+</message>
+<message id="pref_appearance_dark">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Dark&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Dark</source>
+<translation>深色</translation>
+</message>
+<message id="pref_appearance_scheduled">
+<extracomment>Settings &quot;Appearance&quot; category: &quot;Scheduled&quot; title, should be consistent with the pref_appearance_title translation.</extracomment>
+<source>Light from dawn till dusk</source>
+<translation>從黎明到黃昏都是淺色</translation>
+</message>
+<message id="pref_tts_other_section_title">
+<extracomment>Title for &quot;Other&quot; section in TTS settings.</extracomment>
+<source>Other</source>
+<translation>其他</translation>
+</message>
+<message id="donate_description">
+<extracomment>Tex label above the Donate button</extracomment>
+<source>Gift free maps with no ads to millions of users!</source>
+<translation>向數百萬使用者贈送無廣告的免費地圖！</translation>
+</message>
+<message id="report_incorrect_map_bug">
+<extracomment>Button in the About screen</extracomment>
+<source>Report or fix incorrect map data</source>
+<translation>回報或修復不正確的地圖數據</translation>
+</message>
+<message id="volunteer">
+<extracomment>Button in the About screen</extracomment>
+<source>Volunteer</source>
+<translation>志願者</translation>
+</message>
+<message id="follow_us">
+<extracomment>&quot;Social media&quot; section header in the About screen</extracomment>
+<source>Follow and contact us:</source>
+<translation>追蹤並聯絡我們：</translation>
+</message>
+<message id="email_error_body">
+<extracomment>Alert text</extracomment>
+<source>The email client has not been set up. Please configure it or contact us at %1</source>
+<translation>電子郵件客戶端未設定。請配置電子郵件客戶端或通過 %1 聯絡我們</translation>
+</message>
+<message id="email_error_title">
+<extracomment>Alert title</extracomment>
+<source>Error sending email</source>
+<translation>電子郵件發送失敗</translation>
+</message>
+<message id="pref_calibration_title">
+<extracomment>Settings item title</extracomment>
+<source>Compass calibration</source>
+<translation>校正指南針</translation>
+</message>
+<message id="downloader_available_maps">
+<extracomment>Downloaded maps category</extracomment>
+<source>Available</source>
+<translation>可用</translation>
+</message>
+<message id="downloader_search_results">
+<source>Found</source>
+<translation>已找到</translation>
+</message>
+<message id="downloader_status_outdated">
+<extracomment>Status of outdated country in the list</extracomment>
+<source>Update</source>
+<translation>更新</translation>
+</message>
+<message id="downloader_status_failed">
+<extracomment>Status of failed country in the list</extracomment>
+<source>Failed</source>
+<translation>失敗</translation>
+</message>
+<message id="bookmark">
+<extracomment>bookmark button text</extracomment>
+<source>bookmark</source>
+<translation>書籤</translation>
+</message>
+<message id="dialog_routing_disclaimer_title">
+<source>When following the route, please keep in mind:</source>
+<translation>依照路線行進時，請牢記：</translation>
+</message>
+<message id="dialog_routing_disclaimer_priority">
+<source>— Road conditions, traffic laws, and road signs always take priority over navigation hints;</source>
+<translation>— 路況、交通法規和路標始終優先於導航建議；</translation>
+</message>
+<message id="dialog_routing_disclaimer_precision">
+<source>— The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;</source>
+<translation>— 地圖可能不準確，建議的路線可能並非總是前往目的地的最佳路線；</translation>
+</message>
+<message id="dialog_routing_disclaimer_recommendations">
+<source>— Suggested routes should only be understood as recommendations;</source>
+<translation>— 建議的路線僅作為推薦路線供您參考；</translation>
+</message>
+<message id="dialog_routing_disclaimer_borders">
+<source>— Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.</source>
+<translation>— 小心評估經過國界的路線：我們的應用程式建立的路線有時會在未經授權的地方跨越國界。</translation>
+</message>
+<message id="dialog_routing_disclaimer_beware">
+<source>Please stay alert and safe on the roads!</source>
+<translation>上路時請當心，祝您一路平安！</translation>
+</message>
+<message id="dialog_routing_check_gps">
+<source>Check GPS signal</source>
+<translation>檢查 GPS 訊號</translation>
+</message>
+<message id="dialog_routing_error_location_not_found">
+<source>Unable to create route. Current GPS coordinates could not be identified.</source>
+<translation>無法規劃路線。無法識別目前 GPS 座標。</translation>
+</message>
+<message id="dialog_routing_location_turn_wifi">
+<source>Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</source>
+<translation>請檢查您的 GPS 訊號。啟用無線網路將改善定位精度。</translation>
+</message>
+<message id="dialog_routing_location_turn_on">
+<source>Enable location services</source>
+<translation>啟用定位服務</translation>
+</message>
+<message id="dialog_routing_location_unknown_turn_on">
+<source>Unable to locate current GPS coordinates. Enable location services to calculate route.</source>
+<translation>無法定位目前 GPS 座標。請啟用定位服務以規劃路線。</translation>
+</message>
+<message id="dialog_routing_unable_locate_route">
+<source>Unable to locate route</source>
+<translation>無法定位路線</translation>
+</message>
+<message id="dialog_routing_cant_build_route">
+<source>Unable to create route.</source>
+<translation>無法規劃路線。</translation>
+</message>
+<message id="dialog_routing_change_start_or_end">
+<source>Please adjust your starting point or destination.</source>
+<translation>請調整您的起點或目的地。</translation>
+</message>
+<message id="dialog_routing_change_start">
+<source>Adjust starting point</source>
+<translation>調整出發點</translation>
+</message>
+<message id="dialog_routing_start_not_determined">
+<source>Route was not created. Unable to locate starting point.</source>
+<translation>路線未規劃。無法定位起點。</translation>
+</message>
+<message id="dialog_routing_select_closer_start">
+<source>Please select a starting point closer to a road.</source>
+<translation>請選擇更接近道路的起點。</translation>
+</message>
+<message id="dialog_routing_change_end">
+<source>Adjust destination</source>
+<translation>調整目的地</translation>
+</message>
+<message id="dialog_routing_end_not_determined">
+<source>Route was not created. Unable to locate the destination.</source>
+<translation>路線未規劃。無法定位目的地。</translation>
+</message>
+<message id="dialog_routing_select_closer_end">
+<source>Please select a destination point located closer to a road.</source>
+<translation>請選擇更接近道路的目的地位置。</translation>
+</message>
+<message id="dialog_routing_change_intermediate">
+<source>Unable to locate the intermediate point.</source>
+<translation>無法定位途經點。</translation>
+</message>
+<message id="dialog_routing_intermediate_not_determined">
+<source>Please adjust your intermediate point.</source>
+<translation>請調整您的途經點。</translation>
+</message>
+<message id="dialog_routing_system_error">
+<source>System error</source>
+<translation>系統錯誤</translation>
+</message>
+<message id="dialog_routing_application_error">
+<source>Unable to create route due to an application error.</source>
+<translation>由於應用程式出錯，因此無法規劃路線。</translation>
+</message>
+<message id="dialog_routing_try_again">
+<source>Please try again</source>
+<translation>請再試一次</translation>
+</message>
+<message id="not_now">
+<source>Not Now</source>
+<translation>以後再說</translation>
+</message>
+<message id="dialog_routing_download_and_build_cross_route">
+<source>Would you like to download the map and create a more optimal route spanning more than one map?</source>
+<translation>您是否要下載地圖，以規劃跨越邊界的更佳路線？</translation>
+</message>
+<message id="dialog_routing_download_cross_route">
+<source>Download additional maps to create a better route that crosses the boundaries of this map.</source>
+<translation>下載地圖，以規劃一條跨越邊界的更佳路線。</translation>
+</message>
+<message id="dialog_routing_download_files">
+<source>Download required files</source>
+<translation>下載所需檔案</translation>
+</message>
+<message id="dialog_routing_download_and_update_all">
+<source>Download or update all maps along the projected path to calculate a route.</source>
+<translation>下載或更新沿預期路線的所有地圖，以規劃路線。</translation>
+</message>
+<message id="search_without_internet_advertisement">
+<source>To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</source>
+<translation>要開始搜索和規劃路線，請下載地圖，然後您就不再需要網絡連接了。</translation>
+</message>
+<message id="search_select_map">
+<source>Select Map</source>
+<translation>選擇地圖</translation>
+</message>
+<message id="show">
+<extracomment>«Show» context menu</extracomment>
+<source>Show</source>
+<translation>顯示</translation>
+</message>
+<message id="hide">
+<extracomment>«Hide» context menu</extracomment>
+<source>Hide</source>
+<translation>隱藏</translation>
+</message>
+<message id="categories">
+<source>Categories</source>
+<translation>類別</translation>
+</message>
+<message id="history">
+<source>History</source>
+<translation>歷史</translation>
+</message>
+<message id="search_not_found">
+<source>Oops, no results found.</source>
+<translation>很抱歉，沒有搜尋到任何地點。</translation>
+</message>
+<message id="search_not_found_query">
+<extracomment>The message when user did not find anything in the search.</extracomment>
+<source>Download the region where you are searching or try adding a nearby town/village name.</source>
+<translation>下載您要搜尋的區域的地圖，或嘗試輸入附近的城鎮或村莊名稱。</translation>
+</message>
+<message id="search_history_title">
+<source>Search History</source>
+<translation>搜尋歷史紀錄</translation>
+</message>
+<message id="search_history_text">
+<source>View your recent searches.</source>
+<translation>查看您最近的搜尋記錄。</translation>
+</message>
+<message id="clear_search">
+<source>Clear Search History</source>
+<translation>清除搜尋記錄</translation>
+</message>
+<message id="read_in_wikipedia">
+<extracomment>Place Page link to Wikipedia article (if map object has it).</extracomment>
+<source>Wikipedia</source>
+<translation>維基百科</translation>
+</message>
+<message id="article_from_wikipedia">
+<extracomment>Source attribution for Wikipedia articles displayed in the place description screen.</extracomment>
+<source>Article from wikipedia.org</source>
+<translation>文章來自 wikipedia.org</translation>
+</message>
+<message id="wikimedia_commons">
+<extracomment>Place Page link to Wikimedia Commons.</extracomment>
+<source>Wikimedia Commons</source>
+<translation>維基共享資源</translation>
+</message>
+<message id="p2p_your_location">
+<source>Your Location</source>
+<translation>您的位置</translation>
+</message>
+<message id="p2p_start">
+<source>Start</source>
+<translation>開始</translation>
+</message>
+<message id="p2p_from_here">
+<source>Route from</source>
+<translation>從這裡出發</translation>
+</message>
+<message id="p2p_to_here">
+<source>Route to</source>
+<translation>到這裡去</translation>
+</message>
+<message id="p2p_only_from_current">
+<source>Navigation is only available from your current location.</source>
+<translation>導航只能從您目前的位置開始。</translation>
+</message>
+<message id="p2p_reroute_from_current">
+<source>Do you want to plan a route from your current location?</source>
+<translation>您是否想要規劃目前位置的路線？</translation>
+</message>
+<message id="next_button">
+<extracomment>Edit open hours/set time and minutes dialog</extracomment>
+<source>Next</source>
+<translation>下一頁</translation>
+</message>
+<message id="editor_time_from">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>From</source>
+<translation>從</translation>
+</message>
+<message id="editor_time_to">
+<extracomment>Tab title in the Edit Opening Hours time picker</extracomment>
+<source>To</source>
+<translation>到</translation>
+</message>
+<message id="editor_time_add">
+<source>Add Schedule</source>
+<translation>新增排程</translation>
+</message>
+<message id="editor_time_delete">
+<source>Delete Schedule</source>
+<translation>刪除排程</translation>
+</message>
+<message id="editor_time_allday">
+<extracomment>Text for allday switch.</extracomment>
+<source>All Day (24 hours)</source>
+<translation>全天 (24 小時)</translation>
+</message>
+<message id="editor_time_open">
+<source>Open</source>
+<translation>營業中</translation>
+</message>
+<message id="editor_time_close">
+<source>Closed</source>
+<translation>已歇業</translation>
+</message>
+<message id="editor_time_add_closed">
+<source>Add Non-Business Hours</source>
+<translation>新增休息時間</translation>
+</message>
+<message id="editor_time_title">
+<source>Business Hours</source>
+<translation>營業時間</translation>
+</message>
+<message id="editor_time_advanced">
+<source>Advanced Mode</source>
+<translation>高級模式</translation>
+</message>
+<message id="editor_time_simple">
+<source>Simple Mode</source>
+<translation>簡易模式</translation>
+</message>
+<message id="editor_hours_closed">
+<source>Non-Business Hours</source>
+<translation>休息時間</translation>
+</message>
+<message id="editor_example_values">
+<source>Example Values</source>
+<translation>範例值</translation>
+</message>
+<message id="editor_correct_mistake">
+<source>Correct mistake</source>
+<translation>修正錯誤</translation>
+</message>
+<message id="editor_add_select_location">
+<source>Select Location</source>
+<translation>選擇位置</translation>
+</message>
+<message id="editor_report_problem_desription_1">
+<source>Please describe the problem in detail so that the OpenStreetMap community can fix it.</source>
+<translation>請詳細描述此問題以便 OpenStreetMap 社群能夠修復此錯誤。</translation>
+</message>
+<message id="editor_report_problem_desription_2">
+<source>Or do it yourself at https://www.openstreetmap.org/</source>
+<translation>或者在 https://www.openstreetmap.org/ 上親自修復此錯誤</translation>
+</message>
+<message id="editor_report_problem_send_button">
+<source>Send</source>
+<translation>傳送</translation>
+</message>
+<message id="editor_report_problem_title">
+<source>Issue</source>
+<translation>問題</translation>
+</message>
+<message id="editor_report_problem_no_place_title">
+<source>This place does not exist</source>
+<translation>該地點不存在</translation>
+</message>
+<message id="editor_report_problem_under_construction_title">
+<source>Closed for maintenance</source>
+<translation>因維護而關閉</translation>
+</message>
+<message id="editor_report_problem_duplicate_place_title">
+<source>Duplicate place</source>
+<translation>重複的地點</translation>
+</message>
+<message id="autodownload">
+<source>Auto-download maps</source>
+<translation>自動下載</translation>
+</message>
+<message id="daily">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Daily</source>
+<translation>每天</translation>
+</message>
+<message id="twentyfour_seven">
+<source>24/7</source>
+<translation>24/7 全天候營業</translation>
+</message>
+<message id="day_off_today">
+<source>Closed today</source>
+<translation>今天不營業</translation>
+</message>
+<message id="day_off">
+<source>Closed</source>
+<translation>不營業</translation>
+</message>
+<message id="today">
+<source>Today</source>
+<translation>今天</translation>
+</message>
+<message id="opens_in">
+<source>Opens in %1</source>
+<translation>將於 %1 後開業</translation>
+</message>
+<message id="closes_in">
+<source>Closes in %1</source>
+<translation>將於 %1 後歇業</translation>
+</message>
+<message id="closed">
+<source>Closed</source>
+<translation>已停止營業</translation>
+</message>
+<message id="edit_opening_hours">
+<source>Edit business hours</source>
+<translation>編輯營業時間</translation>
+</message>
+<message id="no_osm_account">
+<source>Don&#x27;t have an OpenStreetMap account?</source>
+<translation>沒有 OpenStreetMap 帳號嗎？</translation>
+</message>
+<message id="register_at_openstreetmap">
+<source>Register at OpenStreetMap</source>
+<translation>註冊</translation>
+</message>
+<message id="login">
+<source>Login</source>
+<translation>登入</translation>
+</message>
+<message id="not_signed_in">
+<extracomment>Status message indicating that user did not login to OSM profile yet.</extracomment>
+<source>Not signed in</source>
+<translation>未登入</translation>
+</message>
+<message id="login_osm">
+<source>Login to OpenStreetMap</source>
+<translation>登錄 OpenStreetMap</translation>
+</message>
+<message id="password">
+<source>Password</source>
+<translation>密碼</translation>
+</message>
+<message id="forgot_password">
+<source>Forgot your password?</source>
+<translation>忘記密碼嗎？</translation>
+</message>
+<message id="logout">
+<source>Log Out</source>
+<translation>登出</translation>
+</message>
+<message id="edit_place">
+<source>Edit Place</source>
+<translation>編輯地點</translation>
+</message>
+<message id="add_language">
+<source>Add a language</source>
+<translation>新增語言</translation>
+</message>
+<message id="street">
+<source>Street</source>
+<translation>街道</translation>
+</message>
+<message id="house_number">
+<extracomment>Editable House Number text field (in address block).</extracomment>
+<source>Building number</source>
+<translation>門牌號碼</translation>
+</message>
+<message id="details">
+<source>Details</source>
+<translation>詳細資訊</translation>
+</message>
+<message id="social_media">
+<source>Social Media</source>
+<translation>社群媒體</translation>
+</message>
+<message id="building">
+<source>Building</source>
+<translation>大樓</translation>
+</message>
+<message id="add_street">
+<extracomment>Text field to enter non-existing street name, below list of known streets around</extracomment>
+<source>Add a street</source>
+<translation>新增街道</translation>
+</message>
+<message id="empty_street_name_error">
+<extracomment>Error to display when a new street name is not entered in the New street dialog</extracomment>
+<source>Please enter a street name</source>
+<translation>請輸入街道名稱</translation>
+</message>
+<message id="choose_language">
+<source>Choose a language</source>
+<translation>選擇語言</translation>
+</message>
+<message id="choose_street">
+<source>Choose a street</source>
+<translation>選擇街道</translation>
+</message>
+<message id="cuisine">
+<source>Cuisine</source>
+<translation>料理</translation>
+</message>
+<message id="select_cuisine">
+<source>Select cuisine</source>
+<translation>選擇料理</translation>
+</message>
+<message id="email_or_username">
+<extracomment>login text field</extracomment>
+<source>Email or username</source>
+<translation>電子郵件或使用者名稱</translation>
+</message>
+<message id="editor_add_phone">
+<source>Add Phone</source>
+<translation>新增電話號碼</translation>
+</message>
+<message id="level">
+<source>Floor</source>
+<translation>樓層</translation>
+</message>
+<message id="level_value_generic">
+<extracomment>Building level</extracomment>
+<source>Level: %1</source>
+<translation>樓層：%1</translation>
+</message>
+<message id="downloader_delete_map_dialog">
+<source>All of your map edits will be deleted with the map.</source>
+<translation>所有對地圖的修改都將與地圖一起被刪除。</translation>
+</message>
+<message id="downloader_update_maps">
+<source>Update Maps</source>
+<translation>更新地圖</translation>
+</message>
+<message id="downloader_mwm_migration_dialog">
+<source>To create a route, you need to update all maps and then plan the route again.</source>
+<translation>為了規劃路線，您需要更新全部地圖並重新規劃路線。</translation>
+</message>
+<message id="downloader_search_field_hint">
+<source>Find map</source>
+<translation>搜尋地圖</translation>
+</message>
+<message id="common_check_internet_connection_dialog">
+<source>Please make sure your device is connected to the Internet.</source>
+<translation>請檢查您的設定並確保您的裝置已連接至網路。</translation>
+</message>
+<message id="downloader_no_space_title">
+<source>Not enough space</source>
+<translation>沒有足夠的空間</translation>
+</message>
+<message id="downloader_no_space_message">
+<extracomment>Message shown when there is not enough space to download maps</extracomment>
+<source>Please delete any unnecessary data</source>
+<translation>請刪除不必要的資料</translation>
+</message>
+<message id="editor_login_error_dialog">
+<source>Login error.</source>
+<translation>無法登入。</translation>
+</message>
+<message id="editor_profile_changes">
+<source>Verified Changes</source>
+<translation>已驗證的變更</translation>
+</message>
+<message id="editor_focus_map_on_location">
+<source>Drag the map to place the cross at the location of the place or business.</source>
+<translation>拖曳地圖以將十字放置在地點或企業的位置。</translation>
+</message>
+<message id="editor_edit_place_title">
+<source>Editing</source>
+<translation>編輯中</translation>
+</message>
+<message id="editor_add_place_title">
+<source>Adding</source>
+<translation>新增中</translation>
+</message>
+<message id="editor_edit_place_name_hint">
+<source>Name of the place</source>
+<translation>該地點的名稱</translation>
+</message>
+<message id="editor_default_language_hint">
+<extracomment>The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name</extracomment>
+<source>As it is written in the local language</source>
+<translation>當地語言寫道</translation>
+</message>
+<message id="editor_edit_place_category_title">
+<source>Category</source>
+<translation>類別</translation>
+</message>
+<message id="detailed_problem_description">
+<source>Detailed description of the issue</source>
+<translation>問題的詳細描述</translation>
+</message>
+<message id="editor_report_problem_other_title">
+<source>Different problem</source>
+<translation>不同的問題</translation>
+</message>
+<message id="placepage_add_business_button">
+<source>Add business</source>
+<translation>將地點添加到</translation>
+</message>
+<message id="message_invalid_feature_position">
+<source>No object can be located here</source>
+<translation>地點無法放置在這裡</translation>
+</message>
+<message id="osm_presentation">
+<extracomment>Text in About and OSM Login screens. First %@ is replaced by a local, human readable date.</extracomment>
+<source>Community-created OpenStreetMap data as of %1. Learn more about how to edit and update the map at OpenStreetMap.org</source>
+<translation>截至 %1 的社群創建的開放街圖資料。請訪問 OpenStreetMap.org 以了解有關如何編輯和更新地圖的更多資訊</translation>
+</message>
+<message id="login_osm_presentation">
+<extracomment>OSM explanation on Android login screen</extracomment>
+<source>OpenStreetMap.org (OSM) is a community project to build a free and open map. It&#x27;s the main source of map data in Organic Maps and works similar to Wikipedia. You can add or edit places and they become available to millions of users all over the World.
+Join the community and help to make a better map for everyone!</source>
+<translation>OpenStreetMap.org (OSM) 是一個建立免費開放地圖的社群專案。它是Organic Maps中地圖資料的主要來源，其工作方式類似於維基百科。您可以新增或編輯地點，全世界數百萬用戶都可以使用它們。
+加入社群來幫忙大家建造更好的地圖！</translation>
+</message>
+<message id="login_to_make_edits_visible">
+<source>Create an OpenStreetMap account or log in to publish your map edits to the world.</source>
+<translation>建立 OpenStreetMap 帳戶或登入以向全世界發布您的地圖編輯。</translation>
+</message>
+<message id="downloader_of">
+<extracomment>Downloaded 10 **of** 20 &lt;- it is that &quot;of&quot;</extracomment>
+<source>%1 of %2</source>
+<translation>%1 / %2</translation>
+</message>
+<message id="download_over_mobile_header">
+<source>Download over a cellular network connection?</source>
+<translation>用行動數據連線下載嗎？</translation>
+</message>
+<message id="download_over_mobile_message">
+<source>This could be considerably expensive with some plans or if roaming.</source>
+<translation>如果您使用行動數據或漫遊來進行下載，將可能導致額外的費用。</translation>
+</message>
+<message id="error_enter_correct_house_number">
+<source>Enter a valid building number</source>
+<translation>輸入正確的門牌號碼</translation>
+</message>
+<message id="editor_storey_number">
+<source>Number of floors (maximum of %1)</source>
+<translation>樓層數量（最多 %1 層）</translation>
+</message>
+<message id="error_enter_correct_storey_number">
+<extracomment>Error message in Editor when a user tries to set the number of floors for a building higher than %d floors</extracomment>
+<source>The number of floors must non exceed %1</source>
+<translation>最多可編輯 %1 層的建築</translation>
+</message>
+<message id="editor_zip_code">
+<source>ZIP Code</source>
+<translation>郵遞區號</translation>
+</message>
+<message id="error_enter_correct_zip_code">
+<source>Enter a valid ZIP code</source>
+<translation>輸入正確的郵遞區號</translation>
+</message>
+<message id="editor_other_info">
+<extracomment>Title for OSM note section in the editor</extracomment>
+<source>Note to OpenStreetMap volunteers (optional)</source>
+<translation>OpenStreetMap 志工注意事項（可選）</translation>
+</message>
+<message id="editor_note_hint">
+<extracomment>Hint of the input field in the OSM note section of the editor</extracomment>
+<source>Describe errors on the map or things that cannot be edited with Organic Maps</source>
+<translation>請描述地圖上的錯誤或無法透過 Organic Maps 進行編輯的內容</translation>
+</message>
+<message id="editor_about_osm">
+<extracomment>Information about OSM at the top of the editing page</extracomment>
+<source>Your edits are uploaded to the public &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/About_OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; database. Please do not add personal or copyrighted information.</source>
+<translation>您的編輯內容將上傳至公用 &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap&quot;&gt;OpenStreetMap&lt;/a&gt; 資料庫。請不要添加個人或版權資訊。</translation>
+</message>
+<message id="editor_more_about_osm">
+<source>More about OpenStreetMap</source>
+<translation>關於 OpenStreetMap 的更多資訊</translation>
+</message>
+<message id="editor_osm_history">
+<source>Your editing history</source>
+<translation>您的編輯歷史記錄</translation>
+</message>
+<message id="editor_osm_notes">
+<source>Your map data notes</source>
+<translation>您的地圖資料註釋</translation>
+</message>
+<message id="editor_operator">
+<source>Operator</source>
+<translation>操作員</translation>
+</message>
+<message id="operator">
+<extracomment>To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Operator: %1</source>
+<translation>操作員: %1</translation>
+</message>
+<message id="editor_category_unsuitable_title">
+<source>Can&#x27;t find a suitable category?</source>
+<translation>找不到合適的類別？</translation>
+</message>
+<message id="editor_category_unsuitable_text">
+<source>Organic Maps allows to add simple point categories only, that means no towns, roads, lakes, building outlines, etc. Please add such categories directly to &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt;. Check our &lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;guide&lt;/a&gt; for detailed step by step instructions.</source>
+<translation>Organic Maps 只允許添加簡單的點類別，即無法添加城鎮、道路、湖泊、建築輪廓等類別。請直接向 &lt;a href=&quot;https://www.openstreetmap.org&quot;&gt;OpenStreetMap.org&lt;/a&gt; 新增此類類別。請查看我們的&lt;a href=&quot;https://organicmaps.app/faq/editing/advanced-map-editing&quot;&gt;指南&lt;/a&gt;，以了解詳細的步驟說明。</translation>
+</message>
+<message id="downloader_no_downloaded_maps_title">
+<source>You haven&#x27;t downloaded any maps</source>
+<translation>您尚未下載任何地圖</translation>
+</message>
+<message id="downloader_no_downloaded_maps_message">
+<source>Download maps to search and navigate offline.</source>
+<translation>下載地圖來尋找位置和離線瀏覽。</translation>
+</message>
+<message id="current_location_unknown_error_title">
+<source>Current location is unknown.</source>
+<translation>目前位置未知。</translation>
+</message>
+<message id="kilometers_per_hour">
+<extracomment>abbreviation for kilometers per hour</extracomment>
+<source>km/h</source>
+<translation>公里每小時</translation>
+</message>
+<message id="miles_per_hour">
+<source>mph</source>
+<translation>英哩每小時</translation>
+</message>
+<message id="hour">
+<source>h</source>
+<translation>小時</translation>
+</message>
+<message id="minute">
+<source>min</source>
+<translation>分鐘</translation>
+</message>
+<message id="day">
+<source>d</source>
+<translation>天</translation>
+</message>
+<message id="second">
+<source>s</source>
+<translation>秒</translation>
+</message>
+<message id="placepage_more_button">
+<source>More</source>
+<translation>更多</translation>
+</message>
+<message id="placepage_edit_bookmark_button">
+<extracomment>A disable button text in the explanation dialog that opens hotel details page on Kayak website.</extracomment>
+<source>Edit Bookmark</source>
+<translation>編輯書籤</translation>
+</message>
+<message id="placepage_personal_notes_hint">
+<source>Personal notes (text or html)</source>
+<translation>個人備註（文字或 html）</translation>
+</message>
+<message id="editor_comment_hint">
+<source>Comment…</source>
+<translation>備註…</translation>
+</message>
+<message id="editor_reset_edits_message">
+<source>Discard all local changes?</source>
+<translation>重設所有本機變更？</translation>
+</message>
+<message id="editor_reset_edits_button">
+<source>Discard</source>
+<translation>重設</translation>
+</message>
+<message id="editor_remove_place_message">
+<source>Delete added place?</source>
+<translation>移除已新增的地點？</translation>
+</message>
+<message id="editor_remove_place_button">
+<source>Delete</source>
+<translation>移除</translation>
+</message>
+<message id="editor_place_doesnt_exist">
+<source>Place does not exist</source>
+<translation>該地點不存在</translation>
+</message>
+<message id="delete_place_empty_comment_error">
+<extracomment>Error message for &quot;Place doesn&#x27;t exist&quot; dialog when comment is empty</extracomment>
+<source>Please indicate the reason for deleting the place</source>
+<translation>請註明刪除該地點的原因</translation>
+</message>
+<message id="error_enter_correct_phone">
+<extracomment>Phone number error message</extracomment>
+<source>Enter a valid phone number</source>
+<translation>輸入正確的電話號碼</translation>
+</message>
+<message id="error_enter_correct_web">
+<source>Enter a valid web address</source>
+<translation>請輸入有效的網址</translation>
+</message>
+<message id="error_enter_correct_email">
+<source>Enter a valid email</source>
+<translation>請輸入有效的電子郵件</translation>
+</message>
+<message id="error_enter_correct_facebook_page">
+<source>Enter a valid Facebook web address, account, or page name</source>
+<translation>請輸入有效的 Facebook 網頁地址、帳號或頁面名稱</translation>
+</message>
+<message id="error_enter_correct_instagram_page">
+<source>Enter a valid Instagram username or web address</source>
+<translation>請輸入有效的 Instagram 用戶名或網頁地址</translation>
+</message>
+<message id="error_enter_correct_twitter_page">
+<source>Enter a valid Twitter username or web address</source>
+<translation>請輸入有效的 Twitter 用戶名或網頁地址</translation>
+</message>
+<message id="error_enter_correct_vk_page">
+<source>Enter a valid VK username or web address</source>
+<translation>請輸入有效的 VK 用戶名或網頁地址</translation>
+</message>
+<message id="error_enter_correct_line_page">
+<source>Enter a valid LINE ID or web address</source>
+<translation>請輸入有效的 LINE ID 或網頁地址</translation>
+</message>
+<message id="placepage_add_place_button">
+<source>Add Place to OpenStreetMap</source>
+<translation>將地點新增至 OpenStreetMap</translation>
+</message>
+<message id="osm_note_hint">
+<source>Or, alternatively, leave a note to OpenStreetMap community so that someone else can add or fix a place here.</source>
+<translation>或是，替代的方式是在開放街圖留下註記，由社群成員來新增或是修正這裡的錯誤。</translation>
+</message>
+<message id="osm_note_toast">
+<source>Note will be sent to OpenStreetMap</source>
+<translation>註解會被傳送至開放街圖</translation>
+</message>
+<message id="editor_share_to_all_dialog_title">
+<extracomment>Displayed when saving some edits to the map to warn against publishing personal data</extracomment>
+<source>Do you want to send it to all users?</source>
+<translation>您想要發送給所有使用者嗎？</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_1">
+<extracomment>Dialog before publishing the modifications to the public map.</extracomment>
+<source>Make sure you did not enter any private or personal data.</source>
+<translation>確保您沒有輸入任何個人資料。</translation>
+</message>
+<message id="editor_share_to_all_dialog_message_2">
+<source>OpenStreetMap editors will check the changes and contact you if they have any questions.</source>
+<translation>OpenStreetMap 編輯人員將檢查更改並在有任何問題時與您聯繫。</translation>
+</message>
+<message id="navigation_stop_button">
+<source>Stop</source>
+<translation>停止</translation>
+</message>
+<message id="track_recording">
+<extracomment>Shown as toast when starting the recent track recording</extracomment>
+<source>Recording the track</source>
+<translation>記錄軌跡</translation>
+</message>
+<message id="accept">
+<extracomment>For the first routing</extracomment>
+<source>Accept</source>
+<translation>接受</translation>
+</message>
+<message id="decline">
+<extracomment>For the first routing</extracomment>
+<source>Decline</source>
+<translation>拒絕</translation>
+</message>
+<message id="mobile_data_dialog">
+<source>Use mobile internet to show detailed information?</source>
+<translation>使用手機網路顯示更多詳細資訊嗎？</translation>
+</message>
+<message id="mobile_data_option_always">
+<source>Use Always</source>
+<translation>一律使用</translation>
+</message>
+<message id="mobile_data_option_today">
+<source>Only Today</source>
+<translation>僅限今天</translation>
+</message>
+<message id="mobile_data_option_not_today">
+<source>Do Not Use Today</source>
+<translation>今天不使用</translation>
+</message>
+<message id="mobile_data">
+<source>Mobile Internet</source>
+<translation>手機網路</translation>
+</message>
+<message id="mobile_data_description">
+<extracomment>NOTE to translators: please synchronize your translation with the English one.</extracomment>
+<source>Mobile internet is required for map update notifications and uploading edits.</source>
+<translation>要顯示地點的詳細資訊（例如照片、價格和評價），需要使用手機網絡。</translation>
+</message>
+<message id="mobile_data_option_never">
+<source>Never Use</source>
+<translation>絕不使用</translation>
+</message>
+<message id="mobile_data_option_ask">
+<source>Always Ask</source>
+<translation>一律詢問</translation>
+</message>
+<message id="traffic_update_maps_text">
+<source>To display traffic data, maps must be updated.</source>
+<translation>若要顯示交通資料，必須更新地圖。</translation>
+</message>
+<message id="big_font">
+<source>Increase size for map labels</source>
+<translation>增加地圖上的字體大小</translation>
+</message>
+<message id="traffic_update_app">
+<source>Please update Organic Maps</source>
+<translation>請更新 Organic Maps</translation>
+</message>
+<message id="traffic_data_unavailable">
+<extracomment>&quot;traffic&quot; as in &quot;road congestion&quot;</extracomment>
+<source>Traffic data is not available</source>
+<translation>交通資訊不可用</translation>
+</message>
+<message id="enable_logging">
+<source>Enable logging</source>
+<translation>啟用日誌記錄</translation>
+</message>
+<message id="feedback_general">
+<extracomment>Settings: &quot;Send general feedback&quot; button</extracomment>
+<source>General Feedback</source>
+<translation>一般反應</translation>
+</message>
+<message id="prefs_languages_information">
+<source>We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play</source>
+<translation>我們的語音導航使用“文字轉語音”系統。許多 Android 裝置使用 Google 的文字轉語音系統，您可以從 Google Play 下載或更新這一功能</translation>
+</message>
+<message id="prefs_languages_information_off">
+<source>For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).
+Open your device&#x27;s settings → Language and input → Speech → Text to speech output.
+Here you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</source>
+<translation>對於某些語言，您需要從應用商店（例如 Google Play Store、Galaxy Store）中安裝其他語音合成器或語言套件。
+打開您的裝置的設定 → 語言和輸入法 → 語音 → 文字轉語音 (TTS) 輸出。
+您可以在這裡管理語音合成的設定（例如，下載語言包供離線使用）和選擇其他文字轉語音引擎。</translation>
+</message>
+<message id="prefs_languages_information_off_link">
+<source>For more information please check this guide.</source>
+<translation>如需瞭解更多資訊，請參閱此指南。</translation>
+</message>
+<message id="transliteration_title">
+<source>Transliterate into Latin alphabet</source>
+<translation>拉丁字母音譯</translation>
+</message>
+<message id="learn_more">
+<source>Learn more</source>
+<translation>瞭解更多資訊</translation>
+</message>
+<message id="routing_add_start_point">
+<extracomment>User selected the destination by pressing Route To, but the current position is unknown. User needs to select a starting point of a route using search or by tapping on the map and then pressing &quot;Route From&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a route starting point</source>
+<translation>請搜尋地點、選擇書籤或點擊地圖以新增路線起點</translation>
+</message>
+<message id="routing_add_finish_point">
+<extracomment>User selected the start of a route by pressing Route From. Now the destination of a route should be selected using search or by tapping on the map and then pressing &quot;Route To&quot;.</extracomment>
+<source>Use search, select a bookmark, or tap on the map to add a destination point</source>
+<translation>請搜尋地點、選擇書籤或點擊地圖以新增目的地</translation>
+</message>
+<message id="planning_route_manage_route">
+<source>Manage Route</source>
+<translation>管理路線</translation>
+</message>
+<message id="button_plan">
+<source>Plan</source>
+<translation>計畫</translation>
+</message>
+<message id="placepage_remove_stop">
+<source>Remove Stop</source>
+<translation>刪除停止</translation>
+</message>
+<message id="placepage_add_stop">
+<source>Add Stop</source>
+<translation>新增中途點</translation>
+</message>
+<message id="saved">
+<source>Saved</source>
+<translation>已經儲存</translation>
+</message>
+<message id="alert_reauth_message">
+<extracomment>Alert to ask user relogin to OpenStreetMap with OAuth2 flow after OAuth1 authentication is deprecated.</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more &lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;here&lt;/a&gt;.</source>
+<translation>請登入 OpenStreetMap 以自動上傳您的所有地圖編輯。若要了解更多資訊請點擊&lt;a href=&quot;https://github.com/organicmaps/organicmaps/issues/6144&quot;&gt;這裡&lt;/a&gt;。</translation>
+</message>
+<message id="dialog_error_storage_title">
+<source>Storage access problem</source>
+<translation>儲存空間存儲問題</translation>
+</message>
+<message id="dialog_error_storage_message">
+<source>External storage is not accessible. The SD card may have been removed, damaged, or the file system is read-only. Please, check your SD card or contact us at support@organicmaps.app</source>
+<translation>外部儲存空間不可用，很可能是因為 SD 卡已移除、毀損，或檔案系統處於唯讀狀態。請進行檢查，然後透過 support@organicmaps.app 聯絡我們</translation>
+</message>
+<message id="setting_emulate_bad_storage">
+<source>Emulate bad storage</source>
+<translation>模擬不良儲存空間</translation>
+</message>
+<message id="error_enter_correct_name">
+<source>Please enter a correct name</source>
+<translation>請輸入正確的名稱</translation>
+</message>
+<message id="bookmark_lists">
+<source>Lists</source>
+<translation>列表</translation>
+</message>
+<message id="bookmark_lists_hide_all">
+<extracomment>Do not display all bookmark lists on the map</extracomment>
+<source>Hide all</source>
+<translation>全部隱藏</translation>
+</message>
+<message id="bookmark_lists_show_all">
+<source>Show all</source>
+<translation>全部顯示</translation>
+</message>
+<message id="bookmarks_places" numerus="yes">
+<source>%n bookmarks</source>
+<translation>
+<numerusform>%n 個書籤</numerusform>
+</translation>
+</message>
+<message id="bookmarks_create_new_group">
+<source>Create a new list</source>
+<translation>創建新的列表</translation>
+</message>
+<message id="bookmarks_import">
+<extracomment>Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files</extracomment>
+<source>Import Bookmarks and Tracks</source>
+<translation>導入書籤和軌跡</translation>
+</message>
+<message id="bookmarks_error_message_share_general">
+<source>Unable to share due to an application error</source>
+<translation>由於應用程式出錯，導致無法分享</translation>
+</message>
+<message id="bookmarks_error_title_share_empty">
+<source>Sharing error</source>
+<translation>無法分享</translation>
+</message>
+<message id="bookmarks_error_message_share_empty">
+<source>Cannot share an empty list</source>
+<translation>無法分享空列表</translation>
+</message>
+<message id="bookmarks_error_title_empty_list_name">
+<source>The name can&#x27;t be empty</source>
+<translation>名字不能為空白</translation>
+</message>
+<message id="bookmarks_error_message_empty_list_name">
+<source>Please enter the list name</source>
+<translation>請輸入列表名稱</translation>
+</message>
+<message id="bookmarks_new_list_hint">
+<source>New list</source>
+<translation>新的列表</translation>
+</message>
+<message id="bookmarks_error_title_list_name_already_taken">
+<source>This name is already taken</source>
+<translation>這個名稱已經被使用了</translation>
+</message>
+<message id="bookmarks_error_message_list_name_already_taken">
+<source>Please choose another name</source>
+<translation>請選擇其他名稱</translation>
+</message>
+<message id="please_wait">
+<source>Please wait…</source>
+<translation>請稍候…</translation>
+</message>
+<message id="phone_number">
+<source>Phone number</source>
+<translation>電話號碼</translation>
+</message>
+<message id="profile">
+<source>OpenStreetMap profile</source>
+<translation>OpenStreetMap 資料</translation>
+</message>
+<message id="bookmarks_detect_message" numerus="yes">
+<source>%n files were found. You can see them after conversion.</source>
+<translation>
+<numerusform>找到 %n 個文件，轉換後您可以看到它們。</numerusform>
+</translation>
+</message>
+<message id="restore">
+<source>Restore</source>
+<translation>恢復</translation>
+</message>
+<message id="tracks" numerus="yes">
+<source>%n tracks</source>
+<translation>
+<numerusform>%n 軌跡</numerusform>
+</translation>
+</message>
+<message id="privacy">
+<extracomment>Settings privacy group in settings screen</extracomment>
+<source>Privacy</source>
+<translation>隱私</translation>
+</message>
+<message id="privacy_policy">
+<source>Privacy policy</source>
+<translation>隱私政策</translation>
+</message>
+<message id="terms_of_use">
+<source>Terms of use</source>
+<translation>使用條款</translation>
+</message>
+<message id="button_layer_traffic">
+<source>Traffic</source>
+<translation>路況</translation>
+</message>
+<message id="button_layer_hiking">
+<extracomment>Hiking routes layer name in the Styles and Layers dialog</extracomment>
+<source>Hiking</source>
+<translation>登山</translation>
+</message>
+<message id="button_layer_cycling">
+<extracomment>Cycling routes layer name in the Styles and Layers dialog</extracomment>
+<source>Cycling</source>
+<translation>單車</translation>
+</message>
+<message id="button_layer_subway">
+<source>Subway</source>
+<translation>捷運</translation>
+</message>
+<message id="layers_title">
+<source>Map Styles and Layers</source>
+<translation>地圖樣式和圖層</translation>
+</message>
+<message id="bookmarks_empty_list_title">
+<source>This list is empty</source>
+<translation>該列表為空</translation>
+</message>
+<message id="bookmarks_empty_list_message">
+<source>To add a bookmark, tap a place on the map and then tap the star icon</source>
+<translation>要增加新書籤，請點擊對象卡片中的星型圖標</translation>
+</message>
+<message id="change_all_bookmarks_color">
+<extracomment>Button to change the color of all bookmarks in the current list</extracomment>
+<source>Change color of all bookmarks</source>
+<translation>更改所有書籤顏色</translation>
+</message>
+<message id="change_all_tracks_color">
+<extracomment>Button to change the color of all tracks in the current list</extracomment>
+<source>Change color of all tracks</source>
+<translation>更改所有軌跡顏色</translation>
+</message>
+<message id="category_desc_more">
+<source>…more</source>
+<translation>…更多</translation>
+</message>
+<message id="export_file">
+<extracomment>Menu title for exporting a file in the default KMZ format</extracomment>
+<source>Export KMZ</source>
+<translation>導出為 KMZ</translation>
+</message>
+<message id="export_file_gpx">
+<extracomment>Menu title for exporting a file in GPX format</extracomment>
+<source>Export GPX</source>
+<translation>導出為 GPX</translation>
+</message>
+<message id="export_file_geojson">
+<extracomment>Menu title for exporting a file in GeoJSON format</extracomment>
+<source>Export GeoJSON</source>
+<translation>導出為 GeoJSON</translation>
+</message>
+<message id="delete_list">
+<source>Delete list</source>
+<translation>刪除列表</translation>
+</message>
+<message id="speedcams_alert_title">
+<source>Speed cameras</source>
+<translation>測速照相</translation>
+</message>
+<message id="place_description_title">
+<source>Place Description</source>
+<translation>地點說明</translation>
+</message>
+<message id="notification_channel_downloader">
+<extracomment>this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.</extracomment>
+<source>Map downloader</source>
+<translation>載入地圖</translation>
+</message>
+<message id="pref_tts_speedcams_auto">
+<extracomment>&quot;Speed cameras&quot; settings menu option (should be short! no more than 47-50 chars) to warn a driver if there is a risk of exceeding the speed limit</extracomment>
+<source>Warn if speeding</source>
+<translation>超速行駛時發出警告</translation>
+</message>
+<message id="pref_tts_speedcams_always">
+<extracomment>Speed camera settings menu option - Always warn (about speedcams)</extracomment>
+<source>Always warn</source>
+<translation>始終提醒測速照相機</translation>
+</message>
+<message id="pref_tts_speedcams_never">
+<extracomment>Speed camera settings menu option - Never warn (about speedcams)</extracomment>
+<source>Never warn</source>
+<translation>永遠不會對測速照相機發出警告</translation>
+</message>
+<message id="power_managment_title">
+<source>Power saving mode</source>
+<translation>省電模式</translation>
+</message>
+<message id="power_managment_description">
+<source>Try to reduce power usage at the expense of some functionality.</source>
+<translation>如果開啟省電模式，應用程序將根據手機的當前電量關閉耗電功能。</translation>
+</message>
+<message id="power_managment_setting_never">
+<source>Never</source>
+<translation>從不</translation>
+</message>
+<message id="power_managment_setting_auto">
+<source>When battery is low</source>
+<translation>當電量低時</translation>
+</message>
+<message id="power_managment_setting_manual_max">
+<source>Always</source>
+<translation>最大程度省電</translation>
+</message>
+<message id="bookmarks_text_placement_title">
+<extracomment>Settings/Bookmark Text Placement</extracomment>
+<source>Bookmark names on the map</source>
+<translation>將地圖上的名稱加入書籤</translation>
+</message>
+<message id="bookmarks_text_placement_description">
+<source>If there are too many bookmarks, displaying their names on the map may slow down the app.</source>
+<translation>如果有太多書籤，將這些名稱顯示在地圖上將拖慢 app 的速度。</translation>
+</message>
+<message id="show_to_the_right">
+<source>Show to the right</source>
+<translation>顯示在右側</translation>
+</message>
+<message id="show_at_the_bottom">
+<source>Show at the bottom</source>
+<translation>顯示在底部</translation>
+</message>
+<message id="enable_logging_warning_message">
+<source>Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using &quot;Report a bug&quot; in the Help dialog. Logs may include location info.</source>
+<translation>暫時啟用此選項，以便使用“報告問題”功能在幫助對話框中記錄並手動發送詳細的診斷日誌給我們。日誌可能包含位置資訊。</translation>
+</message>
+<message id="driving_options_title">
+<source>Routing options</source>
+<translation>繞行設定</translation>
+</message>
+<message id="avoid_tolls">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid tolls</source>
+<translation>避開收費公路</translation>
+</message>
+<message id="avoid_unpaved">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid unpaved roads</source>
+<translation>避開無鋪面道路</translation>
+</message>
+<message id="avoid_ferry">
+<extracomment>Recommended length for CarPlay and Android Auto is around 25-27 characters</extracomment>
+<source>Avoid ferries</source>
+<translation>避開渡輪</translation>
+</message>
+<message id="avoid_motorways">
+<source>Avoid freeways</source>
+<translation>避開高速公路</translation>
+</message>
+<message id="unable_to_calc_alert_title">
+<source>Unable to calculate route</source>
+<translation>無法規劃路線</translation>
+</message>
+<message id="unable_to_calc_alert_subtitle">
+<source>A route could not be found. This may be caused by your routing options or incomplete OpenStreetMap data. Please change your routing options and retry.</source>
+<translation>很遺憾，我們無法使用所選的繞行設定規劃路線。請更改設定，然後重試。</translation>
+</message>
+<message id="define_to_avoid_btn">
+<source>Define roads to avoid</source>
+<translation>選擇要避開的道路</translation>
+</message>
+<message id="change_driving_options_btn">
+<source>Routing options enabled</source>
+<translation>繞行設定已開啟</translation>
+</message>
+<message id="toll_road">
+<source>Toll road</source>
+<translation>收費公路</translation>
+</message>
+<message id="unpaved_road">
+<source>Unpaved road</source>
+<translation>未鋪面道路</translation>
+</message>
+<message id="ferry_crossing">
+<source>Ferry crossing</source>
+<translation>渡輪</translation>
+</message>
+<message id="yes">
+<extracomment>A generic &quot;Yes&quot; button in dialogs</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="no">
+<extracomment>A generic &quot;No&quot; button in dialogs</extracomment>
+<source>No</source>
+<translation>否</translation>
+</message>
+<message id="yes_available">
+<extracomment>E.g. &quot;WiFi:Yes&quot;</extracomment>
+<source>Yes</source>
+<translation>是</translation>
+</message>
+<message id="no_available">
+<extracomment>E.g. &quot;WiFi:No&quot;</extracomment>
+<source>No</source>
+<translation>否</translation>
+</message>
+<message id="capacity">
+<extracomment>To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations…</extracomment>
+<source>Capacity: %1</source>
+<translation>容量：%1</translation>
+</message>
+<message id="network">
+<extracomment>To indicate the network of ATMs, bicycle rentals, electric vehicle charging stations…</extracomment>
+<source>Network: %1</source>
+<translation>網路： %1</translation>
+</message>
+<message id="trip_finished">
+<source>You have arrived!</source>
+<translation>您已到達目的地！</translation>
+</message>
+<message id="ok">
+<source>OK</source>
+<translation>好的</translation>
+</message>
+<message id="sort">
+<extracomment>max. 10 symbols, both iOS and Android</extracomment>
+<source>Sort…</source>
+<translation>排序…</translation>
+</message>
+<message id="sort_bookmarks">
+<extracomment>Android, title, max 20-22 symbols</extracomment>
+<source>Sort bookmarks</source>
+<translation>分類排序</translation>
+</message>
+<message id="by_default">
+<extracomment>Android</extracomment>
+<source>By default</source>
+<translation>使用默認值</translation>
+</message>
+<message id="by_type">
+<extracomment>Android</extracomment>
+<source>By type</source>
+<translation>按類型</translation>
+</message>
+<message id="by_distance">
+<extracomment>Android</extracomment>
+<source>By distance</source>
+<translation>按距離</translation>
+</message>
+<message id="by_date">
+<extracomment>Android</extracomment>
+<source>By date</source>
+<translation>按時間</translation>
+</message>
+<message id="by_name">
+<extracomment>Android</extracomment>
+<source>By name</source>
+<translation>按名字</translation>
+</message>
+<message id="week_ago_sorttype">
+<source>A week ago</source>
+<translation>一週前</translation>
+</message>
+<message id="month_ago_sorttype">
+<source>A month ago</source>
+<translation>一個月前</translation>
+</message>
+<message id="moremonth_ago_sorttype">
+<source>More than a month ago</source>
+<translation>一個多月前</translation>
+</message>
+<message id="moreyear_ago_sorttype">
+<source>More than a year ago</source>
+<translation>一年多以前</translation>
+</message>
+<message id="near_me_sorttype">
+<source>Near me</source>
+<translation>在我附近</translation>
+</message>
+<message id="others_sorttype">
+<source>Others</source>
+<translation>其他</translation>
+</message>
+<message id="routing_planning_error">
+<extracomment>Failed planning route message in navigation view</extracomment>
+<source>Route Planning Failed</source>
+<translation>路線規劃失敗</translation>
+</message>
+<message id="routing_arrive">
+<extracomment>Arrive routing message in navigation view</extracomment>
+<source>Arrival at %1</source>
+<translation>已抵達 %1</translation>
+</message>
+<message id="dialog_routing_download_and_update_maps">
+<extracomment>Text for routing::RouterResultCode::FileTooOld dialog.</extracomment>
+<source>Download and update all map along the projected path to calculate route.</source>
+<translation>要規劃路線，請下載並更新所有沿線的地圖。</translation>
+</message>
+<message id="editor_done_dialog_1">
+<source>You’ve changed the world map! Don&#x27;t keep it to yourself; tell your friends and edit it together.</source>
+<translation>您已經改變了世界地圖。請別再藏私了！告訴您的朋友們並一起來編輯地圖。</translation>
+</message>
+<message id="share_with_friends">
+<source>Share with friends</source>
+<translation>與朋友分享</translation>
+</message>
+<message id="closed_now">
+<extracomment>Place Page opening hours text</extracomment>
+<source>Closed now</source>
+<translation>現已關門</translation>
+</message>
+<message id="opens_tomorrow_at">
+<source>Opens tomorrow at %1</source>
+<translation>明天 %1 營業</translation>
+</message>
+<message id="opens_dayoftheweek_at">
+<source>Opens %1 at %2</source>
+<translation>%1 %2 營業</translation>
+</message>
+<message id="opens_at">
+<source>Opens at %1</source>
+<translation>%1 營業</translation>
+</message>
+<message id="closes_at">
+<source>Closes at %1</source>
+<translation>%1 關門</translation>
+</message>
+<message id="add_opening_hours">
+<source>Add opening hours</source>
+<translation>新增營業時間</translation>
+</message>
+<message id="password_8_chars_min">
+<source>Password (8 characters minimum)</source>
+<translation>密碼（至少 8 個字符）</translation>
+</message>
+<message id="invalid_username_or_password">
+<source>Invalid username or password.</source>
+<translation>無效的使用者名稱或密碼。</translation>
+</message>
+<message id="osm_account">
+<source>OSM Account</source>
+<translation>OSM 帳號</translation>
+</message>
+<message id="last_upload">
+<extracomment>Information text: &quot;Last upload 11.01.2016&quot;</extracomment>
+<source>Last upload</source>
+<translation>最後上傳</translation>
+</message>
+<message id="thank_you">
+<source>Thank You</source>
+<translation>謝謝您</translation>
+</message>
+<message id="place_name">
+<source>Place Name</source>
+<translation>地點名稱</translation>
+</message>
+<message id="phone">
+<source>Phone</source>
+<translation>電話</translation>
+</message>
+<message id="please_note">
+<source>Please note</source>
+<translation>請注意</translation>
+</message>
+<message id="migration_download_error_dialog">
+<source>Download error</source>
+<translation>下載失敗</translation>
+</message>
+<message id="editor_add_select_category">
+<source>Select category</source>
+<translation>選擇類別</translation>
+</message>
+<message id="editor_add_select_category_popular_subtitle">
+<source>Popular</source>
+<translation>受歡迎的</translation>
+</message>
+<message id="editor_add_select_category_all_subtitle">
+<source>All Categories</source>
+<translation>所有類別</translation>
+</message>
+<message id="whatsnew_editor_message_1">
+<source>Add new places to the map, and edit existing ones directly from the app.</source>
+<translation>新增新地點到地圖，並直接透過此應用編輯已存在的地點。</translation>
+</message>
+<message id="dialog_incorrect_feature_position">
+<source>Change location</source>
+<translation>更改位置</translation>
+</message>
+<message id="migration_no_space_message">
+<extracomment>Error dialog no space</extracomment>
+<source>To download, you need more space. Please delete any unnecessary data.</source>
+<translation>為了下載，您需要更多的儲存空間。請刪除不必要的檔案。</translation>
+</message>
+<message id="editor_sharing_title">
+<source>I improved the Organic Maps maps</source>
+<translation>我改進了 Organic Maps 地圖</translation>
+</message>
+<message id="editor_detailed_description_hint">
+<source>Detailed comment</source>
+<translation>詳細註釋</translation>
+</message>
+<message id="editor_detailed_description">
+<source>Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</source>
+<translation>您建議的變更將傳送至 OpenStreetMap 社群。說明無法在 Organic Maps 中編輯的詳細資料。</translation>
+</message>
+<message id="current_location_unknown_error_message">
+<source>An error occurred while determining your location. Check that your device is working properly and try again later.</source>
+<translation>定位到您的當前位置時出錯。請檢查您的裝置是否正常運作，然後再試一次。</translation>
+</message>
+<message id="location_services_disabled_header">
+<source>Location services are disabled</source>
+<translation>定位服務已被禁用</translation>
+</message>
+<message id="location_services_disabled_message">
+<source>Enable access to geolocation in the device settings</source>
+<translation>啟用裝置設定中的定位服務</translation>
+</message>
+<message id="location_services_disabled_1">
+<source>1. Open Settings</source>
+<translation>1. 開啟設定</translation>
+</message>
+<message id="location_services_disabled_2">
+<source>2. Tap Location</source>
+<translation>2. 點擊位置</translation>
+</message>
+<message id="location_services_disabled_3">
+<extracomment>iOS Dialog for the case when the location permission is not granted; you might find the exact wording for your language here: https://support.apple.com/en-us/102647 (replace &#x27;en-us&#x27; in URL with your language/region)</extracomment>
+<source>3. Select While Using the App</source>
+<translation>3. 點擊“僅在使用該應用程式時允許”</translation>
+</message>
+<message id="location_services_disabled_on_device_2">
+<source>2. Select Privacy</source>
+<translation>2. 點擊“隱私權”</translation>
+</message>
+<message id="location_services_disabled_on_device_3">
+<source>3. Select Location Services</source>
+<translation>3. 選擇“定位服務”</translation>
+</message>
+<message id="location_services_disabled_on_device_4">
+<source>4. Turn on Location Services</source>
+<translation>4. 開啟“定位服務”</translation>
+</message>
+<message id="location_services_disabled_on_device_additional_message">
+<source>Or continue using Organic Maps without Location</source>
+<translation>或繼續使用 Organic Maps，但無法定位到您目前所在的位置</translation>
+</message>
+<message id="book_button">
+<source>Book</source>
+<translation>預定</translation>
+</message>
+<message id="placepage_call_button">
+<source>Call</source>
+<translation>呼叫</translation>
+</message>
+<message id="placepage_bookmark_name_hint">
+<source>Bookmark Name</source>
+<translation>書籤名稱</translation>
+</message>
+<message id="placepage_delete_bookmark_button">
+<source>Delete Bookmark</source>
+<translation>刪除書籤</translation>
+</message>
+<message id="editor_edits_sent_message">
+<source>Your note will be sent to OpenStreetMap</source>
+<translation>您的註解將發送至 OpenStreetMap</translation>
+</message>
+<message id="text_more_button">
+<source>…more</source>
+<translation>…更多</translation>
+</message>
+<message id="refresh">
+<source>Update</source>
+<translation>更新</translation>
+</message>
+<message id="recent_track_background_dialog_title">
+<extracomment>iOS dialog for the case when recent track recording is on and the app comes back from background</extracomment>
+<source>Disable recording of your recently travelled route?</source>
+<translation>取消記錄您最近去過的路線嗎？</translation>
+</message>
+<message id="off_recent_track_background_button">
+<source>Disable</source>
+<translation>禁用</translation>
+</message>
+<message id="sharing_call_action_look">
+<extracomment>For sharing via SMS and so on</extracomment>
+<source>Check out</source>
+<translation>查看</translation>
+</message>
+<message id="recent_track_background_dialog_message">
+<source>Organic Maps uses your location in the background to record your recently travelled route.</source>
+<translation>Organic Maps 在後臺使用您的位置記錄您最近去過的路線。</translation>
+</message>
+<message id="general_settings">
+<source>General settings</source>
+<translation>一般設定</translation>
+</message>
+<message id="traffic_update_app_message">
+<extracomment>&quot;traffic&quot; as in road congestion</extracomment>
+<source>To display traffic data, the application must be updated.</source>
+<translation>諾要顯示交通資訊，必須更新應用。</translation>
+</message>
+<message id="log_file_size">
+<source>Log file size: %1</source>
+<translation>日誌檔案大小：%1</translation>
+</message>
+<message id="planning_route_remove_title">
+<source>Drag here to remove</source>
+<translation>拖曳到此處以移除</translation>
+</message>
+<message id="placepage_replace_stop">
+<source>Replace Stop</source>
+<translation>更换停机坪</translation>
+</message>
+<message id="start_from_my_position">
+<source>Start from</source>
+<translation>起點</translation>
+</message>
+<message id="alert_reauth_message_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s first part</extracomment>
+<source>Please login to OpenStreetMap to automatically upload all your map edits. Learn more</source>
+<translation>請登入 OpenStreetMap 以自動上傳您的所有地圖編輯。了解更多</translation>
+</message>
+<message id="alert_reauth_link_text_ios">
+<extracomment>For iOS message &#x27;alert_reauth_message&#x27; should be splitted in two parts: message + link. Here&#x27;s link part</extracomment>
+<source>here</source>
+<translation>這裡</translation>
+</message>
+<message id="downloader_hide_screen">
+<source>Hide Screen</source>
+<translation>隱藏畫面</translation>
+</message>
+<message id="downloader_percent">
+<source>%1 (%2 of %3)</source>
+<translation>%1 (%2 / %3)</translation>
+</message>
+<message id="downloader_process">
+<source>Downloading %1…</source>
+<translation>正在下載 %1…</translation>
+</message>
+<message id="downloader_applying">
+<source>Applying %1…</source>
+<translation>正在應用 %1…</translation>
+</message>
+<message id="bookmarks_error_title_list_name_too_long">
+<source>This name is too long</source>
+<translation>這個名稱太長了</translation>
+</message>
+<message id="bookmarks_detect_title">
+<source>New files detected</source>
+<translation>檢測到新文件</translation>
+</message>
+<message id="button_convert">
+<source>Convert</source>
+<translation>轉換</translation>
+</message>
+<message id="bookmarks_convert_error_title">
+<source>Error</source>
+<translation>錯誤</translation>
+</message>
+<message id="bookmarks_convert_error_message">
+<source>Some files were not converted.</source>
+<translation>有些文件未被轉換。</translation>
+</message>
+<message id="title_error_downloading_bookmarks">
+<source>An error occurred</source>
+<translation>發生錯誤</translation>
+</message>
+<message id="popular_place">
+<source>Popular</source>
+<translation>受歡迎的</translation>
+</message>
+<message id="hide_from_map">
+<source>Hide from map</source>
+<translation>從地圖上隱藏</translation>
+</message>
+<message id="tags_loading_error_subtitle">
+<source>An error occurred while loading tags, please try again</source>
+<translation>載入標籤時出錯，請重試</translation>
+</message>
+<message id="right">
+<extracomment>Position of the name label on the map relative to the bookmark pin (on the right)</extracomment>
+<source>Right</source>
+<translation>右側</translation>
+</message>
+<message id="bottom">
+<extracomment>Position of the name label on the map relative to the bookmark pin (at the bottom)</extracomment>
+<source>Bottom</source>
+<translation>底部</translation>
+</message>
+<message id="trip_start">
+<source>Let&#x27;s go</source>
+<translation>出發</translation>
+</message>
+<message id="pick_destination">
+<source>Destination</source>
+<translation>目的地</translation>
+</message>
+<message id="follow_my_position">
+<source>Re-center</source>
+<translation>重新置中</translation>
+</message>
+<message id="search_results">
+<source>Search results</source>
+<translation>搜尋結果</translation>
+</message>
+<message id="then_turn">
+<source>Then</source>
+<translation>然後</translation>
+</message>
+<message id="redirect_route_alert">
+<source>Do you want to rebuild the route?</source>
+<translation>您想要重新規劃路線嗎？</translation>
+</message>
+<message id="keyboard_availability_alert">
+<source>Keyboard is not available while driving</source>
+<translation>開車時鍵盤不可用</translation>
+</message>
+<message id="dialog_routing_change_start_carplay">
+<source>Unable to build a route from your current location</source>
+<translation>無法從當前位置規劃路線</translation>
+</message>
+<message id="dialog_routing_change_end_carplay">
+<source>Unable to find a route to your destination. Please choose another end point</source>
+<translation>無法規劃到終點的路線。請選擇其它目的地</translation>
+</message>
+<message id="dialog_routing_check_gps_carplay">
+<source>No GPS signal. Please move to an open area</source>
+<translation>沒有 GPS 信號。請沿著空曠區域行駛</translation>
+</message>
+<message id="dialog_routing_unable_locate_route_carplay">
+<source>Unable to build a route. Please specify other route points</source>
+<translation>無法規劃路線。請選擇其他路線點</translation>
+</message>
+<message id="dialog_routing_download_files_carplay">
+<source>To create a route, download missing maps on your device</source>
+<translation>為了規劃路線，請在您的裝置中下載所缺少的地圖</translation>
+</message>
+<message id="dialog_routing_system_error_carplay">
+<source>An error occurred. Please restart the application</source>
+<translation>發生了錯誤，請重新啟動應用程式</translation>
+</message>
+<message id="dialog_routing_rebuild_from_current_location_carplay">
+<source>The route will be rebuilt from your current location</source>
+<translation>該路線將從您的當前位置重建</translation>
+</message>
+<message id="dialog_routing_rebuild_for_vehicle_carplay">
+<source>The route will be converted into an automobile route</source>
+<translation>路線將轉換為汽車路線</translation>
+</message>
+<message id="not_all_shown_bookmarks_carplay">
+<source>Not all bookmarks are shown</source>
+<translation>未顯示所有書籤</translation>
+</message>
+<message id="switch_to_phone_bookmarks_carplay">
+<source>Switch to the phone to see all bookmarks</source>
+<translation>切換到手機以查看所有書籤</translation>
+</message>
+<message id="speedcams_alert_title_carplay_1">
+<source>Speedcams</source>
+<translation>測速照相</translation>
+</message>
+<message id="speedcams_alert_title_carplay_2">
+<source>Speed warnings</source>
+<translation>超速警告</translation>
+</message>
+<message id="download_map_carplay">
+<source>Please download maps in the app on your mobile device</source>
+<translation>將Organic Maps 應用程式中的地圖下載至個人裝置中</translation>
+</message>
+<message id="carplay_roundabout_exit">
+<source>%1 exit</source>
+<translation>第 %1 个出口</translation>
+</message>
+<message id="sort_default">
+<extracomment>iOS</extracomment>
+<source>Sort by default</source>
+<translation>默認排序</translation>
+</message>
+<message id="sort_type">
+<source>Sort by type</source>
+<translation>按類型排序</translation>
+</message>
+<message id="sort_distance">
+<source>Sort by distance</source>
+<translation>按距離排序</translation>
+</message>
+<message id="sort_date">
+<source>Sort by date</source>
+<translation>按日期排序</translation>
+</message>
+<message id="sort_name">
+<source>Sort by name</source>
+<translation>按名稱分類</translation>
+</message>
+<message id="food_places">
+<source>Food</source>
+<translation>食物</translation>
+</message>
+<message id="tourist_places">
+<source>Sights</source>
+<translation>旅遊景點</translation>
+</message>
+<message id="museums">
+<source>Museums</source>
+<translation>博物館</translation>
+</message>
+<message id="parks">
+<source>Parks</source>
+<translation>公園</translation>
+</message>
+<message id="swim_places">
+<source>Swim</source>
+<translation>游泳</translation>
+</message>
+<message id="mountains">
+<source>Mountains</source>
+<translation>山峰</translation>
+</message>
+<message id="animals">
+<source>Animals</source>
+<translation>動物</translation>
+</message>
+<message id="hotels">
+<source>Hotels</source>
+<translation>旅館</translation>
+</message>
+<message id="buildings">
+<source>Buildings</source>
+<translation>建築物</translation>
+</message>
+<message id="money">
+<source>Money</source>
+<translation>貨幣</translation>
+</message>
+<message id="shops">
+<source>Shops</source>
+<translation>商店</translation>
+</message>
+<message id="parkings">
+<source>Parking</source>
+<translation>停車場</translation>
+</message>
+<message id="fuel_places">
+<source>Gas Stations</source>
+<translation>加油站</translation>
+</message>
+<message id="medicine">
+<source>Medicine</source>
+<translation>醫療</translation>
+</message>
+<message id="search_in_the_list">
+<source>Search in the list</source>
+<translation>在列表中搜尋</translation>
+</message>
+<message id="religious_places">
+<source>Religious places</source>
+<translation>宗教場所</translation>
+</message>
+<message id="select_list">
+<source>Select list</source>
+<translation>選擇列表</translation>
+</message>
+<message id="transit_not_found">
+<source>Subway navigation in this region is not available yet</source>
+<translation>本區域的捷運導航目前不可用</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_header">
+<source>No subway route found</source>
+<translation>未找到捷運路線</translation>
+</message>
+<message id="dialog_pedestrian_route_is_long_message">
+<source>Please choose a start or end point closer to a subway station</source>
+<translation>選擇捷運站附近的起點和終點</translation>
+</message>
+<message id="button_layer_isolines">
+<source>Contour Lines</source>
+<translation>等高線</translation>
+</message>
+<message id="isolines_activation_error_dialog">
+<source>Activating contour lines requires downloading map data for this area</source>
+<translation>如需使用等高線，請更新或下載所需區域的地圖</translation>
+</message>
+<message id="isolines_location_error_dialog">
+<source>Contour lines are not yet available in this area</source>
+<translation>暫時無法獲取該地區的等高線</translation>
+</message>
+<message id="elevation_profile_ascent">
+<source>Ascent</source>
+<translation>上坡</translation>
+</message>
+<message id="elevation_profile_descent">
+<source>Descent</source>
+<translation>下坡</translation>
+</message>
+<message id="elevation_profile_min_elevation">
+<source>Min. elevation</source>
+<translation>最低高度</translation>
+</message>
+<message id="elevation_profile_max_elevation">
+<source>Max. elevation</source>
+<translation>最高高度</translation>
+</message>
+<message id="elevation_profile_difficulty">
+<source>Difficulty</source>
+<translation>難度</translation>
+</message>
+<message id="elevation_profile_distance">
+<source>Dist.:</source>
+<translation>距離：</translation>
+</message>
+<message id="elevation_profile_time">
+<source>Time:</source>
+<translation>時間：</translation>
+</message>
+<message id="isolines_toast_zooms_1_10">
+<source>Zoom in to explore isolines</source>
+<translation>放大地圖以查看等高線</translation>
+</message>
+<message id="downloader_loading_ios">
+<source>Downloading</source>
+<translation>正在下載</translation>
+</message>
+<message id="download_map_title">
+<source>Download the world overview map</source>
+<translation>下載世界總覽地圖</translation>
+</message>
+<message id="disk_error">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Unable to create folder and move files on internal device&#x27;s memory or sdcard</source>
+<translation>無法在內部儲存或 SD 卡上建立資料夾和移動檔案</translation>
+</message>
+<message id="disk_error_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disk error</source>
+<translation>磁碟錯誤</translation>
+</message>
+<message id="connection_failure">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Connection failure</source>
+<translation>磁碟錯誤</translation>
+</message>
+<message id="disconnect_usb_cable_title">
+<extracomment>Used in DownloadResources startup screen</extracomment>
+<source>Disconnect USB cable</source>
+<translation>斷開 USB 線路</translation>
+</message>
+<message id="enable_keep_screen_on">
+<source>Keep the screen on</source>
+<translation>保持螢幕開啟</translation>
+</message>
+<message id="enable_keep_screen_on_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the screen will always be on when displaying the map.</source>
+<translation>啟用後，顯示地圖時畫面將始終開啟。</translation>
+</message>
+<message id="enable_show_on_lock_screen">
+<extracomment>A preference title; keep short!</extracomment>
+<source>Show on the lock screen</source>
+<translation>在鎖定螢幕上顯示</translation>
+</message>
+<message id="enable_show_on_lock_screen_description">
+<extracomment>Description in preferences</extracomment>
+<source>When enabled, the app will work on the lock screen even when the device is locked.</source>
+<translation>啟用後，即使裝置已鎖定，應用程式仍會在鎖定螢幕上運作。</translation>
+</message>
+<message id="change_map_locale">
+<extracomment>Current language of the map!</extracomment>
+<source>Map language</source>
+<translation>地圖語言</translation>
+</message>
+<message id="splash_subtitle">
+<extracomment>OpenStreetMap text on splash screen</extracomment>
+<source>Map data from OpenStreetMap</source>
+<translation>地圖數據來自 OpenStreetMap</translation>
+</message>
+<message id="telegram_url">
+<extracomment>Telegram group url for the &quot;?&quot; About page</extracomment>
+<source>https://t.me/OrganicMapsApp</source>
+<translation>https://t.me/OrganicMapsApp</translation>
+</message>
+<message id="instagram_url">
+<extracomment>Instagram account url for the &quot;?&quot; About page</extracomment>
+<source>https://www.instagram.com/organicmaps.app</source>
+<translation>https://www.instagram.com/organicmaps.app</translation>
+</message>
+<message id="tts_info_link">
+<extracomment>A link to the TTS FAQ</extracomment>
+<source>https://organicmaps.app/faq/text-to-speech-android-tts/</source>
+<translation>https://organicmaps.app/zh-Hans/faq/voice/text-to-speech-android-tts/</translation>
+</message>
+<message id="translated_om_site_url">
+<extracomment>Include only languages supported on the website, add new translations here: https://github.com/organicmaps/website/tree/master/content</extracomment>
+<source>https://organicmaps.app/</source>
+<translation>https://organicmaps.app/zh-Hans/</translation>
+</message>
+<message id="osm_wiki_about_url">
+<extracomment>Link to OSM wiki for Editor, Profile and About pages</extracomment>
+<source>https://wiki.openstreetmap.org/wiki/About_OpenStreetMap</source>
+<translation>https://wiki.openstreetmap.org/wiki/Zh-hant:關於OpenStreetMap</translation>
+</message>
+<message id="comma_separated_pair">
+<extracomment>A number of bookmarks and a number of tracks, separated by comma, like: 1 bookmark, 5 tracks</extracomment>
+<source>%1, %2</source>
+<translation>%1, %2</translation>
+</message>
+<message id="app_tip_00">
+<extracomment>App Tip #00</extracomment>
+<source>Thank you for using our community-built maps!</source>
+<translation>感謝您使用我們社區構建的地圖！</translation>
+</message>
+<message id="app_tip_01">
+<extracomment>App tip #01</extracomment>
+<source>With your donations and support, we can create the best maps in the world!</source>
+<translation>有了您的捐贈和支持，我們可以創造世界上最好的地圖！</translation>
+</message>
+<message id="app_tip_02">
+<extracomment>App tip #02</extracomment>
+<source>Do you like our app? Please donate to support the development! Don&#x27;t like it yet? Please let us know why, and we will fix it!</source>
+<translation>您喜歡我們的應用程式嗎？請捐款以支持發展！還不喜歡嗎？請告訴我們，我們會修復您提到的問題！</translation>
+</message>
+<message id="app_tip_03">
+<extracomment>App tip #03</extracomment>
+<source>If you know a software developer, you can ask him or her to implement a feature that you need.</source>
+<translation>如果您認識軟體開發人員，您可以要求他實現您需要的功能。</translation>
+</message>
+<message id="app_tip_04">
+<extracomment>App tip #04</extracomment>
+<source>Tap anywhere on the map to select anything. A long tap is used to hide and show the interface.</source>
+<translation>點擊地圖上的任何位置即可選擇任何內容。長按可隱藏和顯示介面。</translation>
+</message>
+<message id="app_tip_05">
+<extracomment>App tip #05</extracomment>
+<source>Did you know that your current location on the map can be selected?</source>
+<translation>您知道您可以在地圖上選擇您目前的位置嗎？</translation>
+</message>
+<message id="app_tip_06">
+<extracomment>App tip #06</extracomment>
+<source>You can help to translate our app into your language.</source>
+<translation>您可以幫助將我們的應用程序翻譯成您的語言。</translation>
+</message>
+<message id="app_tip_07">
+<extracomment>App tip #07</extracomment>
+<source>Our app is developed by a few enthusiasts and the community.</source>
+<translation>我們的應用程序是由一些愛好者和社區開發的。</translation>
+</message>
+<message id="app_tip_08">
+<extracomment>App tip #08</extracomment>
+<source>You can easily fix and improve the map data.</source>
+<translation>您可以輕鬆修復和改進地圖數據。</translation>
+</message>
+<message id="app_tip_09">
+<extracomment>App tip #09</extracomment>
+<source>Our main goal is to build fast, privacy-focused, easy-to-use maps that you will love.</source>
+<translation>我們的主要目標是構建您會喜歡的快速、注重隱私、易於使用的地圖。</translation>
+</message>
+<message id="car_used_on_the_phone_screen">
+<extracomment>Text on the Android Auto or CarPlay placeholder screen that maps are displayed on the phone screen</extracomment>
+<source>You are now using Organic Maps on the phone screen</source>
+<translation>您現在正在手機螢幕上使用 Organic Maps</translation>
+</message>
+<message id="car_used_on_the_car_screen">
+<extracomment>Text on the phone placeholder screen that maps are displayed on the car screen</extracomment>
+<source>You are now using Organic Maps on the car screen</source>
+<translation>您現在正在汽車螢幕上使用 Organic Maps</translation>
+</message>
+<message id="aa_connected_title">
+<extracomment>Displayed on the phone screen. Android Auto connected</extracomment>
+<source>You are connected to Android Auto</source>
+<translation>您已連接到 Android Auto</translation>
+</message>
+<message id="car_continue_on_the_phone">
+<extracomment>Displayed on the phone screen. Button to display maps on the phone screen instead of a car</extracomment>
+<source>Continue on the phone</source>
+<translation>在手機上繼續</translation>
+</message>
+<message id="car_continue_in_the_car">
+<extracomment>Displayed on the Android Auto or CarPlay screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!</extracomment>
+<source>To the car screen</source>
+<translation>轉到汽車螢幕</translation>
+</message>
+<message id="aa_location_permissions_request">
+<extracomment>Ask user to grant location permissions</extracomment>
+<source>Organic Maps needs location access. When it&#x27;s safe, check the notification on your phone.</source>
+<translation>Organic Maps 需要位置存取權限。在安全的情況下，請查看手機上的通知。</translation>
+</message>
+<message id="aa_request_permission_notification">
+<extracomment>Notification title for permission request from AA.</extracomment>
+<source>This app needs your permission</source>
+<translation>此應用程式需要您的許可</translation>
+</message>
+<message id="aa_request_permission_activity_text">
+<extracomment>The text in the activity for location permission request.</extracomment>
+<source>Organic Maps in Android Auto needs location permissions to work effectively</source>
+<translation>Android Auto 中的 Organic Maps 需要位置權限才能有效運作</translation>
+</message>
+<message id="aa_grant_permissions">
+<extracomment>Grant Permissions button.</extracomment>
+<source>Grant Permissions</source>
+<translation>授予權限</translation>
+</message>
+<message id="button_layer_outdoor">
+<extracomment>Outdoors/hiking map style (activity) name in the Styles and Layers dialog</extracomment>
+<source>Outdoors</source>
+<translation>徒步旅行</translation>
+</message>
+<message id="browser_not_available">
+<extracomment>Text displayed when a webview or a browser are disabled, and external links can&#x27;t be opened.</extracomment>
+<source>Web browser is not available</source>
+<translation>網路瀏覽器不可用</translation>
+</message>
+<message id="volume">
+<source>Volume</source>
+<translation>音量</translation>
+</message>
+<message id="bookmarks_export">
+<extracomment>Bookmark categories screen, button that opens share dialog to export all bookmarks and tracks</extracomment>
+<source>Export all Bookmarks and Tracks</source>
+<translation>匯出所有書籤和軌跡</translation>
+</message>
+<message id="pref_tts_open_system_settings">
+<extracomment>button in (app) TTS settings, to open the system TTS settings.</extracomment>
+<source>Speech synthesis system settings</source>
+<translation>文字轉語音系統設定</translation>
+</message>
+<message id="pref_tts_no_system_tts">
+<extracomment>toast displayed when pressing the &quot;Speech synthesis system settings&quot; button, and the system settings aren&#x27;t found.</extracomment>
+<source>Speech Synthesis settings were not found, are you sure your device supports it?</source>
+<translation>未找到語音合成設定，您確定您的裝置支援該設定嗎？</translation>
+</message>
+<message id="drive_through">
+<source>Drive-through</source>
+<translation>得來速通道</translation>
+</message>
+<message id="clear_the_search">
+<source>Clear the search</source>
+<translation>清除搜尋</translation>
+</message>
+<message id="zoom_in">
+<source>Zoom in</source>
+<translation>放大</translation>
+</message>
+<message id="zoom_out">
+<extracomment>Accessibility text for the zoom-out button on the map</extracomment>
+<source>Zoom out</source>
+<translation>縮小</translation>
+</message>
+<message id="website_menu">
+<extracomment>Restaurant or other food place&#x27;s menu URL field in the Editor</extracomment>
+<source>Menu Link</source>
+<translation>選單連結</translation>
+</message>
+<message id="view_menu">
+<extracomment>Button in the Place Page which opens a restaurant or other food place&#x27;s menu in a browser</extracomment>
+<source>View Menu</source>
+<translation>查看選單</translation>
+</message>
+<message id="open_in_app">
+<extracomment>Title for the &quot;Open in Another App&quot; button on the PlacePage.</extracomment>
+<source>Open in Another App</source>
+<translation>在另一個應用程式中開啟</translation>
+</message>
+<message id="self_service">
+<extracomment>To indicate if the place proposed self service…</extracomment>
+<source>Self-service</source>
+<translation>自助服務</translation>
+</message>
+<message id="select_option">
+<source>Select option</source>
+<translation>選擇選項</translation>
+</message>
+<message id="outdoor_seating">
+<extracomment>To indicate if restaurant or other place has outdoor seating</extracomment>
+<source>Outdoor seating</source>
+<translation>戶外座位</translation>
+</message>
+<message id="power_save_dialog_summary">
+<extracomment>Disclaimer summary shown when Power Saving Mode is enabled</extracomment>
+<source>For the most accurate navigation, we recommend disabling power saving mode in phone&#x27;s battery settings.</source>
+<translation>為了獲得最準確的導航，我們建議在手機電池設定中停用省電模式。</translation>
+</message>
+<message id="start_track_recording">
+<extracomment>Prompt to start recording a track.</extracomment>
+<source>Record Track</source>
+<translation>錄製軌跡</translation>
+</message>
+<message id="stop_track_recording">
+<extracomment>Prompt for stopping a track recording.</extracomment>
+<source>Stop Track Recording</source>
+<translation>停止軌跡記錄</translation>
+</message>
+<message id="track_recording_title">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Track Recording</source>
+<translation>軌跡記錄</translation>
+</message>
+<message id="stop_without_saving">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Stop Without Saving</source>
+<translation>停止而不保存</translation>
+</message>
+<message id="continue_recording">
+<extracomment>Title for the &quot;Stop Without Saving&quot; action for the alert when saving a track recording.</extracomment>
+<source>Continue Recording</source>
+<translation>繼續錄製</translation>
+</message>
+<message id="track_recording_alert_title">
+<extracomment>Title for the alert when saving a track recording.</extracomment>
+<source>Save into Bookmarks and Tracks?</source>
+<translation>儲存到書籤和軌跡？</translation>
+</message>
+<message id="track_recording_toast_nothing_to_save">
+<extracomment>Message for the toast when saving the track recording is finished but nothing to save.</extracomment>
+<source>Track is empty - nothing to save</source>
+<translation>軌跡為空 - 沒有可保存的內容</translation>
+</message>
+<message id="error_no_file_manager_app">
+<extracomment>Error message when there are no File Manager apps installed to select a folder when importing Bookmarks and Tracks</extracomment>
+<source>Unable to display folder selection dialog because no suitable app is installed on your device. Please install a file manager app and try again.</source>
+<translation>無法顯示資料夾選擇對話框，因為您的裝置上沒有安裝合適的應用程式。請安裝檔案總管應用程式並重試。</translation>
+</message>
+<message id="choose_color">
+<source>Choose Color</source>
+<translation>選擇顏色</translation>
+</message>
+<message id="edit_track">
+<source>Edit Track</source>
+<translation>編輯軌跡</translation>
+</message>
+<message id="uri_open_location_failed">
+<source>No app installed that can open the location</source>
+<translation>沒有安裝可以打開該位置的應用程式</translation>
+</message>
+<message id="nav_auto">
+<extracomment>preference string for using auto theme only in navigation mode</extracomment>
+<source>Auto in navigation</source>
+<translation>自動導航</translation>
+</message>
+<message id="follow_system">
+<extracomment>Setting option to sync the app&#x27;s theme with the operating system&#x27;s dark/light mode</extracomment>
+<source>Follow the system</source>
+<translation>跟隨系統</translation>
+</message>
+<message id="share_track">
+<extracomment>Title of the bottom sheet when sharing the track</extracomment>
+<source>Share Track</source>
+<translation>分享軌跡</translation>
+</message>
+<message id="delete_track_dialog_title">
+<extracomment>Title for the dialog when deleting a track with the track name passed in %@</extracomment>
+<source>Delete %1?</source>
+<translation>刪除 %1？</translation>
+</message>
+<message id="elevation_profile_diff_level">
+<source>Difficulty level</source>
+<translation>難度等級</translation>
+</message>
+<message id="elevation_profile_diff_level_easy">
+<source>Easy</source>
+<translation>容易</translation>
+</message>
+<message id="elevation_profile_diff_level_moderate">
+<source>Moderate</source>
+<translation>中等</translation>
+</message>
+<message id="elevation_profile_diff_level_hard">
+<source>Hard</source>
+<translation>困難</translation>
+</message>
+<message id="downloader_updating_ios">
+<source>Updating</source>
+<translation>更新</translation>
+</message>
+<message id="whats_new_auto_update_title">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update downloaded maps</source>
+<translation>更新已下載的地圖</translation>
+</message>
+<message id="whats_new_auto_update_message">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Updating maps keeps the information about objects up to date</source>
+<translation>更新地圖以讓對象的資訊保持在最新狀態</translation>
+</message>
+<message id="whats_new_auto_update_button_size">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Update (%1)</source>
+<translation>更新 (%1)</translation>
+</message>
+<message id="whats_new_auto_update_button_later">
+<extracomment>Autoupdate dialog on start</extracomment>
+<source>Manually update later</source>
+<translation>稍後手動更新</translation>
+</message>
+<message id="placepage_delete_track_button">
+<extracomment>Delete track button on track edit screen</extracomment>
+<source>Delete Track</source>
+<translation>刪除軌跡</translation>
+</message>
+<message id="placepage_delete_track_confirmation_alert_message">
+<extracomment>The track deletion confirmaion alert message.</extracomment>
+<source>Are you sure you want to delete this track?</source>
+<translation>您確定要刪除該曲目嗎？</translation>
+</message>
+<message id="placepage_track_name_hint">
+<extracomment>Placeholder for track name input on track edit screen</extracomment>
+<source>Track Name</source>
+<translation>軌跡名稱</translation>
+</message>
+<message id="move">
+<extracomment>move track or bookmark from the list button text</extracomment>
+<source>Move</source>
+<translation>移動</translation>
+</message>
+<message id="track_title">
+<extracomment>edit track screen title</extracomment>
+<source>Track</source>
+<translation>軌跡</translation>
+</message>
+<message id="change_color">
+<extracomment>Text for the editing the Track&#x27;s color button.</extracomment>
+<source>Change Color</source>
+<translation>更改顏色</translation>
+</message>
+<message id="map">
+<extracomment>Main screen title &quot;Map&quot; displayed in the navigation back button&#x27;s menu.</extracomment>
+<source>Map</source>
+<translation>地圖</translation>
+</message>
+<message id="bugreport_alert_message">
+<extracomment>Message for the bug report alert.</extracomment>
+<source>Would you like to send a bug report to the developers?
+We rely on our users as Organic Maps doesn&#x27;t collect any error information automatically. Thank you in advance for supporting Organic Maps!</source>
+<translation>您想向開發人員發送錯誤報告嗎？
+由於 Organic Maps 不會自動收集任何錯誤資訊，因此我們只能依靠用戶的協助。感謝您對 Organic Maps 的支持！</translation>
+</message>
+<message id="enable_icloud_synchronization_title">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>Enable iCloud Synchronization</source>
+<translation>啟用 iCloud 同步</translation>
+</message>
+<message id="enable_icloud_synchronization_message">
+<extracomment>Message for the &quot;Enable iCloud Syncronization&quot; alert.</extracomment>
+<source>iCloud synchronization is an experimental feature under development. Make sure that you have made a backup of all your bookmarks and tracks.</source>
+<translation>iCloud 同步是一項正在開發中的實驗性功能。確保您已備份所有書籤和軌跡。</translation>
+</message>
+<message id="icloud_disabled_title">
+<extracomment>Title for the &quot;iCloud Is Disabled&quot; alert.</extracomment>
+<source>iCloud Is Disabled</source>
+<translation>已停用 iCloud</translation>
+</message>
+<message id="icloud_disabled_message">
+<extracomment>Message for the &quot;iCloud is Disabled&quot; alert.</extracomment>
+<source>Please enable iCloud in your device&#x27;s settings to use this feature.</source>
+<translation>請在您的裝置設定中啟用 iCloud 以使用此功能。</translation>
+</message>
+<message id="enable">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Enable&quot; action button.</extracomment>
+<source>Enable</source>
+<translation>啟用</translation>
+</message>
+<message id="backup">
+<extracomment>Title for the &quot;Enable iCloud Syncronization&quot; alert&#x27;s &quot;Backup&quot; action button.</extracomment>
+<source>Backup</source>
+<translation>備份</translation>
+</message>
+<message id="icloud_synchronization_error_alert_title">
+<extracomment>Title for the &quot;iCloud synchronization failure&quot; alert.</extracomment>
+<source>iCloud synchronization failure</source>
+<translation>iCloud 同步失敗</translation>
+</message>
+<message id="icloud_synchronization_error_connection_error">
+<extracomment>iCloud error message: Failed to synchronize due to connection error</extracomment>
+<source>Error: Failed to synchronize due to connection error</source>
+<translation>錯誤：由於連線錯誤，導致無法同步</translation>
+</message>
+<message id="icloud_synchronization_error_quota_exceeded">
+<extracomment>iCloud error message: Failed to synchronize due to iCloud quota exceeded</extracomment>
+<source>Error: Failed to synchronize due to iCloud quota exceeded</source>
+<translation>錯誤：由於超出 iCloud 配額，導致同步失敗</translation>
+</message>
+<message id="icloud_synchronization_error_cloud_is_unavailable">
+<extracomment>iCloud error message: iCloud is not available</extracomment>
+<source>Error: iCloud is not available</source>
+<translation>錯誤：iCloud 不可用</translation>
+</message>
+<message id="bookmarks_recently_deleted">
+<extracomment>Title for the &quot;Recently Deleted Lists&quot; button on the Bookmarks and Lists screen.</extracomment>
+<source>Recently Deleted Lists</source>
+<translation>最近刪除的列表</translation>
+</message>
+<message id="clear">
+<extracomment>Title for the &quot;Clear&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Clear</source>
+<translation>清除</translation>
+</message>
+<message id="delete_all">
+<extracomment>Title for the &quot;Delete All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Delete All</source>
+<translation>刪除所有</translation>
+</message>
+<message id="recover">
+<extracomment>Title for the &quot;Recover&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover</source>
+<translation>恢復</translation>
+</message>
+<message id="recover_all">
+<extracomment>Title for the &quot;Recover All&quot; button on the Recently Deleted Lists screen.</extracomment>
+<source>Recover All</source>
+<translation>全部恢復</translation>
+</message>
+<message id="contribute_to_osm">
+<extracomment>OpenStreetMap contribution section on the PlacePage.</extracomment>
+<source>Contribute to OpenStreetMap</source>
+<translation>貢獻至 OpenStreetMap</translation>
+</message>
+<message id="contribute_to_osm_add_place">
+<source>Add Place</source>
+<translation>新增地點</translation>
+</message>
+<message id="contribute_to_osm_update_map">
+<source>Update the Map to Contribute</source>
+<translation>更新地圖以貢獻</translation>
+</message>
+<message id="contribute_to_osm_update_map_description">
+<source>You need to update the %1 map to the latest version before you can contribute to the OpenStreetMap data</source>
+<translation>您需要先將 %1 地圖更新至最新版本，才能貢獻 OpenStreetMap 資料</translation>
+</message>
+<message id="mb">
+<extracomment>Settings/Downloader - size string, only strings different from English should be translated</extracomment>
+<source>MB</source>
+<translation>MB</translation>
+</message>
+<message id="gb">
+<source>GB</source>
+<translation>GB</translation>
+</message>
+<message id="core_my_position">
+<extracomment>A text for current gps location point/arrow selected on the map</extracomment>
+<source>My Position</source>
+<translation>我的位置</translation>
+</message>
+<message id="core_my_places">
+<extracomment>Default bookmark list name</extracomment>
+<source>My Places</source>
+<translation>我的地點</translation>
+</message>
+<message id="maps_storage_internal">
+<extracomment>Internal storage type in Maps Storage settings (not accessible by the user)</extracomment>
+<source>Internal private storage</source>
+<translation>內部私人儲存</translation>
+</message>
+<message id="maps_storage_shared">
+<extracomment>Shared storage type in Maps Storage settings (a primary storage usually)</extracomment>
+<source>Internal shared storage</source>
+<translation>內部共享儲存</translation>
+</message>
+<message id="maps_storage_removable">
+<extracomment>Removable external storage type in Maps Storage settings, e.g. an SD card</extracomment>
+<source>SD card</source>
+<translation>SD 卡</translation>
+</message>
+<message id="maps_storage_external">
+<extracomment>Generic external storage type in Maps Storage settings</extracomment>
+<source>External shared storage</source>
+<translation>外部共享儲存</translation>
+</message>
+<message id="category_wifi">
+<extracomment>Search category for WiFi access; any changes should be duplicated in categories.txt @category_wifi!</extracomment>
+<source>WiFi</source>
+<translation>無線網路</translation>
+</message>
+<message id="postal_code">
+<source>Postal Code</source>
+<translation>郵遞區號</translation>
+</message>
+<message id="core_placepage_unknown_place">
+<extracomment>Place Page title for long tap</extracomment>
+<source>Map Point</source>
+<translation>地圖點</translation>
+</message>
+<message id="m">
+<extracomment>abbreviation for meters</extracomment>
+<source>m</source>
+<translation>公尺</translation>
+</message>
+<message id="km">
+<extracomment>abbreviation for kilometers</extracomment>
+<source>km</source>
+<translation>公里</translation>
+</message>
+<message id="mi">
+<extracomment>abbreviation for mile(s)</extracomment>
+<source>mi</source>
+<translation>英哩</translation>
+</message>
+<message id="ft">
+<extracomment>A unit of measure</extracomment>
+<source>ft</source>
+<translation>英尺</translation>
+</message>
+<message id="routes_update_maps_text">
+<extracomment>Toast text when the maps version should be updated to display the OSM hiking and cycling routes</extracomment>
+<source>To display routes, maps must be updated.</source>
+<translation>要顯示路線，必須先更新地圖。</translation>
+</message>
+<message id="core_exit">
+<extracomment>Subway exits for public transport marks on the map</extracomment>
+<source>Exit</source>
+<translation>退出</translation>
+</message>
+<message id="core_entrance">
+<source>Entrance</source>
+<translation>入口</translation>
+</message>
+<message id="subway_data_unavailable">
+<source>Subway map is unavailable</source>
+<translation>捷運圖層不可用</translation>
+</message>
+<message id="you">
+<source>You</source>
+<translation>您</translation>
+</message>
+<message id="show_downloaded_regions">
+<extracomment>Settings/Highlight downloaded regions on the map</extracomment>
+<source>Purple downloaded regions</source>
+<translation>紫色已下載區域</translation>
+</message>
+<message id="desktop_preferences">
+<source>Preferences</source>
+<translation>Preferences</translation>
+</message>
+<message id="desktop_preferences_ellipsis">
+<source>Preferences...</source>
+<translation>Preferences...</translation>
+</message>
+<message id="desktop_about">
+<source>About</source>
+<translation>About</translation>
+</message>
+<message id="desktop_about_ellipsis">
+<source>About...</source>
+<translation>About...</translation>
+</message>
+<message id="desktop_exit">
+<source>Exit</source>
+<translation>Exit</translation>
+</message>
+<message id="desktop_upload_edits">
+<source>Upload Edits</source>
+<translation>Upload Edits</translation>
+</message>
+<message id="desktop_welcome_to">
+<source>Welcome to %1</source>
+<translation>Welcome to %1</translation>
+</message>
+<message id="desktop_looking_for_position">
+<source>Looking for position...</source>
+<translation>Looking for position...</translation>
+</message>
+<message id="desktop_navigation_bar">
+<source>Navigation Bar</source>
+<translation>Navigation Bar</translation>
+</message>
+<message id="desktop_public_transport">
+<source>Public transport</source>
+<translation>Public transport</translation>
+</message>
+<message id="desktop_bookmarks_tooltip">
+<source>Show bookmarks and tracks; use ALT + RMB to add a bookmark</source>
+<translation>Show bookmarks and tracks; use ALT + RMB to add a bookmark</translation>
+</message>
+<message id="desktop_start_point">
+<source>Start point</source>
+<translation>Start point</translation>
+</message>
+<message id="desktop_intermediate_point">
+<source>Intermediate point</source>
+<translation>Intermediate point</translation>
+</message>
+<message id="desktop_finish_point">
+<source>Finish point</source>
+<translation>Finish point</translation>
+</message>
+<message id="desktop_route_point_tooltip">
+<source>Select mode and use SHIFT + LMB to set point</source>
+<translation>Select mode and use SHIFT + LMB to set point</translation>
+</message>
+<message id="desktop_follow_route">
+<source>Follow route</source>
+<translation>Follow route</translation>
+</message>
+<message id="desktop_follow_route_tooltip">
+<source>Build route and use ALT + LMB to emulate current position</source>
+<translation>Build route and use ALT + LMB to emulate current position</translation>
+</message>
+<message id="desktop_clear_route">
+<source>Clear route</source>
+<translation>Clear route</translation>
+</message>
+<message id="desktop_routing_settings">
+<source>Routing settings</source>
+<translation>Routing settings</translation>
+</message>
+<message id="desktop_create_feature">
+<source>Create Feature</source>
+<translation>Create Feature</translation>
+</message>
+<message id="desktop_create_feature_tooltip">
+<source>Push to select position, next push to create Feature</source>
+<translation>Push to select position, next push to create Feature</translation>
+</message>
+<message id="desktop_roads_selection_mode">
+<source>Roads selection mode</source>
+<translation>Roads selection mode</translation>
+</message>
+<message id="desktop_city_boundaries_selection_mode">
+<source>City boundaries selection mode</source>
+<translation>City boundaries selection mode</translation>
+</message>
+<message id="desktop_city_roads_selection_mode">
+<source>City roads selection mode</source>
+<translation>City roads selection mode</translation>
+</message>
+<message id="desktop_cross_mwm_segments_selection_mode">
+<source>Cross MWM segments selection mode</source>
+<translation>Cross MWM segments selection mode</translation>
+</message>
+<message id="desktop_mwms_borders_selection_mode">
+<source>MWMs borders selection mode</source>
+<translation>MWMs borders selection mode</translation>
+</message>
+<message id="desktop_selection_mode_tooltip">
+<source>Select mode and use RMB to define selection box</source>
+<translation>Select mode and use RMB to define selection box</translation>
+</message>
+<message id="desktop_offline_search">
+<source>Offline Search</source>
+<translation>Offline Search</translation>
+</message>
+<message id="desktop_ruler">
+<source>Ruler</source>
+<translation>Ruler</translation>
+</message>
+<message id="desktop_ruler_tooltip">
+<source>Check this button and use ALT + LMB to set points</source>
+<translation>Check this button and use ALT + LMB to set points</translation>
+</message>
+<message id="desktop_build_style">
+<source>Build style</source>
+<translation>Build style</translation>
+</message>
+<message id="desktop_recalculate_geometry_index">
+<source>Recalculate geometry index</source>
+<translation>Recalculate geometry index</translation>
+</message>
+<message id="desktop_debug_style">
+<source>Debug style</source>
+<translation>Debug style</translation>
+</message>
+<message id="desktop_get_statistics">
+<source>Get statistics</source>
+<translation>Get statistics</translation>
+</message>
+<message id="desktop_run_tests">
+<source>Run tests</source>
+<translation>Run tests</translation>
+</message>
+<message id="desktop_build_phone_package">
+<source>Build phone package</source>
+<translation>Build phone package</translation>
+</message>
+<message id="desktop_retry_downloading">
+<source>Retry downloading</source>
+<translation>Retry downloading</translation>
+</message>
+<message id="desktop_system_of_measurement">
+<source>System of measurement</source>
+<translation>System of measurement</translation>
+</message>
+<message id="desktop_metric">
+<source>Metric</source>
+<translation>Metric</translation>
+</message>
+<message id="desktop_imperial_foot">
+<source>Imperial (foot)</source>
+<translation>Imperial (foot)</translation>
+</message>
+<message id="desktop_use_larger_font_on_map">
+<source>Use larger font on the map</source>
+<translation>Use larger font on the map</translation>
+</message>
+<message id="desktop_transliterate_to_latin">
+<source>Transliterate to Latin</source>
+<translation>Transliterate to Latin</translation>
+</message>
+<message id="desktop_developer_mode">
+<source>Developer Mode</source>
+<translation>Developer Mode</translation>
+</message>
+<message id="desktop_night_mode">
+<source>Night Mode</source>
+<translation>Night Mode</translation>
+</message>
+<message id="desktop_enable_auto_regeneration_geometry_index">
+<source>Enable auto regeneration of geometry index</source>
+<translation>Enable auto regeneration of geometry index</translation>
+</message>
+<message id="desktop_search_everywhere">
+<source>Everywhere</source>
+<translation>Everywhere</translation>
+</message>
+<message id="desktop_search_viewport">
+<source>Viewport</source>
+<translation>Viewport</translation>
+</message>
+<message id="desktop_category_request">
+<source>Category request</source>
+<translation>Category request</translation>
+</message>
+<message id="desktop_unuploaded_edits_delete_map">
+<source>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</source>
+<translation>Some map edits are not uploaded yet. Are you sure you want to delete map anyway?</translation>
+</message>
+<message id="desktop_country">
+<source>Country</source>
+<translation>Country</translation>
+</message>
+<message id="desktop_status">
+<source>Status</source>
+<translation>Status</translation>
+</message>
+<message id="desktop_size">
+<source>Size</source>
+<translation>Size</translation>
+</message>
+<message id="desktop_matched_by">
+<source>Matched by</source>
+<translation>Matched by</translation>
+</message>
+<message id="desktop_rank">
+<source>Rank</source>
+<translation>Rank</translation>
+</message>
+<message id="desktop_locale_label">
+<source>locale:</source>
+<translation>locale:</translation>
+</message>
+<message id="desktop_search_query_label">
+<source>search query:</source>
+<translation>search query:</translation>
+</message>
+<message id="desktop_geographical_regions">
+<source>Geographical Regions</source>
+<translation>Geographical Regions</translation>
+</message>
+<message id="desktop_update_or_delete_region">
+<source>Do you want to update or delete %1?</source>
+<translation>Do you want to update or delete %1?</translation>
+</message>
+<message id="desktop_update">
+<source>Update</source>
+<translation>Update</translation>
+</message>
+<message id="desktop_delete_region">
+<source>Do you want to delete %1?</source>
+<translation>Do you want to delete %1?</translation>
+</message>
+<message id="desktop_click_to_download">
+<source>Click to download</source>
+<translation>Click to download</translation>
+</message>
+<message id="desktop_installed_click_to_delete">
+<source>Installed (click to delete)</source>
+<translation>Installed (click to delete)</translation>
+</message>
+<message id="desktop_out_of_date_click_to_update_or_delete">
+<source>Out of date (click to update or delete)</source>
+<translation>Out of date (click to update or delete)</translation>
+</message>
+<message id="desktop_downloading_ellipsis">
+<source>Downloading ...</source>
+<translation>Downloading ...</translation>
+</message>
+<message id="desktop_applying_ellipsis">
+<source>Applying ...</source>
+<translation>Applying ...</translation>
+</message>
+<message id="desktop_marked_for_download">
+<source>Marked for download</source>
+<translation>Marked for download</translation>
+</message>
+<message id="desktop_open_bookmark_files">
+<source>Open KML, KMZ, GPX, JSON, GeoJSON...</source>
+<translation>Open KML, KMZ, GPX, JSON, GeoJSON...</translation>
+</message>
+<message id="desktop_bookmark_files_filter">
+<source>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</source>
+<translation>KML, KMZ, GPX, JSON, GeoJSON files (*.kml *.KML *.kmz *.KMZ *.gpx *.GPX *.json *.JSON *.geojson *.GEOJSON)</translation>
+</message>
+<message id="desktop_select_bookmark_category_to_export">
+<source>Select one of the bookmark categories to export.</source>
+<translation>Select one of the bookmark categories to export.</translation>
+</message>
+<message id="desktop_selected_item_not_bookmark_category">
+<source>Selected item is not a bookmark category.</source>
+<translation>Selected item is not a bookmark category.</translation>
+</message>
+<message id="desktop_export_gpx_caption">
+<source>Export GPX...</source>
+<translation>Export GPX...</translation>
+</message>
+<message id="desktop_gpx_filter">
+<source>GPX files (*.gpx)</source>
+<translation>GPX files (*.gpx)</translation>
+</message>
+<message id="desktop_export_geojson_caption">
+<source>Export GeoJSON...</source>
+<translation>Export GeoJSON...</translation>
+</message>
+<message id="desktop_geojson_filter">
+<source>GeoJSON files (*.geojson);JSON files (*.json)</source>
+<translation>GeoJSON files (*.geojson);JSON files (*.json)</translation>
+</message>
+<message id="desktop_export_kmz_caption">
+<source>Export KMZ...</source>
+<translation>Export KMZ...</translation>
+</message>
+<message id="desktop_kmz_filter">
+<source>KMZ files (*.kmz)</source>
+<translation>KMZ files (*.kmz)</translation>
+</message>
+<message id="desktop_bookmarks_exported">
+<source>Bookmarks successfully exported.</source>
+<translation>Bookmarks successfully exported.</translation>
+</message>
+<message id="desktop_bookmarks_export_error">
+<source>Could not export bookmarks: %1</source>
+<translation>Could not export bookmarks: %1</translation>
+</message>
+<message id="desktop_cannot_delete_last_category">
+<source>Could not delete the last category.</source>
+<translation>Could not delete the last category.</translation>
+</message>
+<message id="desktop_select_bookmark_item_to_delete">
+<source>Select category, bookmark or track to delete.</source>
+<translation>Select category, bookmark or track to delete.</translation>
+</message>
+<message id="desktop_no_name">
+<source>No name</source>
+<translation>No name</translation>
+</message>
+<message id="desktop_loading_in_progress">
+<source>Loading in progress...</source>
+<translation>Loading in progress...</translation>
+</message>
+<message id="desktop_mwms_borders_selection_settings">
+<source>MWMs borders selection settings</source>
+<translation>MWMs borders selection settings</translation>
+</message>
+<message id="desktop_get_borders_from_packed_polygon">
+<source>Get borders from packed_polygon.bin</source>
+<translation>Get borders from packed_polygon.bin</translation>
+</message>
+<message id="desktop_get_borders_from_poly_files">
+<source>Get borders from *.poly files</source>
+<translation>Get borders from *.poly files</translation>
+</message>
+<message id="desktop_show_borders_with_vertices">
+<source>Show borders with vertices</source>
+<translation>Show borders with vertices</translation>
+</message>
+<message id="desktop_show_just_borders">
+<source>Show just borders</source>
+<translation>Show just borders</translation>
+</message>
+<message id="desktop_show_bounding_box">
+<source>Show bounding box</source>
+<translation>Show bounding box</translation>
+</message>
+<message id="desktop_enter_login">
+<source>Please enter Login</source>
+<translation>Please enter Login</translation>
+</message>
+<message id="desktop_enter_password">
+<source>Please enter Password</source>
+<translation>Please enter Password</translation>
+</message>
+<message id="desktop_auth_failed_invalid_login_or_password">
+<source>Auth failed: invalid login or password</source>
+<translation>Auth failed: invalid login or password</translation>
+</message>
+<message id="desktop_auth_failed">
+<source>Auth failed: %1</source>
+<translation>Auth failed: %1</translation>
+</message>
+<message id="desktop_place_page">
+<extracomment>Place page dialog window title</extracomment>
+<source>Place Page</source>
+<translation>Place Page</translation>
+</message>
+<message id="desktop_place_page_bookmarked">
+<extracomment>Place page dialog window title when the place is a bookmark</extracomment>
+<source>Place Page (bookmarked)</source>
+<translation>Place Page (bookmarked)</translation>
+</message>
+<message id="desktop_place_routes">
+<extracomment>Place page row label listing public transit routes serving this stop</extracomment>
+<source>Routes</source>
+<translation>Routes</translation>
+</message>
+<message id="desktop_place_opening_hours">
+<extracomment>Place page row label showing business hours</extracomment>
+<source>Opening hours</source>
+<translation>Opening hours</translation>
+</message>
+<message id="desktop_place_coordinates">
+<extracomment>Place page row label showing latitude and longitude</extracomment>
+<source>Coordinates</source>
+<translation>Coordinates</translation>
+</message>
+<message id="route">
+<extracomment>Used in home screen quick actions.</extracomment>
+<source>Route</source>
+<translation>路線</translation>
+</message>
+<message id="NSLocationAlwaysUsageDescription">
+<extracomment>Needed to explain why we always require access to GPS coordinates, and not only when the app is active.</extracomment>
+<source>Detecting location in the background is necessary to fully enjoy the functionality of the app. It is used for navigation and saving your recently traveled track.</source>
+<translation>在背景中判定您目前的位置對於完整使用此應用程式的功能是必要的。它會用於跟隨路線與儲存您最近走過的路徑。</translation>
+</message>
+<message id="NSLocationWhenInUseUsageDescription">
+<extracomment>Needed to explain why we require access to GPS coordinates when the app is active.</extracomment>
+<source>Determining your location is necessary for navigation and for saving your recently traveled track.</source>
+<translation>判定您目前的位置會用於導航與儲存您最近走過的軌跡。</translation>
+</message>
+<message id="login_osm_credentials">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login with password</source>
+<translation>使用密碼登入</translation>
+</message>
+<message id="login_osm_browser">
+<extracomment>Login to OSM button text</extracomment>
+<source>Login using Browser</source>
+<translation>使用瀏覽器登入</translation>
+</message>
+<message id="editor_add_select_category_recent_subtitle">
+<extracomment>Editor section title that shows recently used categories (types of objects) when adding a place on the map</extracomment>
+<source>Recently Used</source>
+<translation>最近使用</translation>
+</message>
+<message id="toast_bookmarks_color_changed">
+<extracomment>Toast message shown when bookmark colors are changed in category settings</extracomment>
+<source>Bookmarks color changed</source>
+<translation>書籤顏色已更改</translation>
+</message>
+<message id="toast_tracks_color_changed">
+<extracomment>Toast message shown when track colors are changed in category settings</extracomment>
+<source>Tracks color changed</source>
+<translation>軌跡顏色已更改</translation>
+</message>
+<message id="color_picker_spectrum">
+<extracomment>Tab label for the spectrum color picker mode</extracomment>
+<source>Spectrum</source>
+<translation>頻譜</translation>
+</message>
+<message id="color_picker_sliders">
+<extracomment>Tab label for the RGB sliders color picker mode</extracomment>
+<source>Sliders</source>
+<translation>滑桿</translation>
+</message>
+<message id="color_picker_red">
+<extracomment>Label for the red channel slider in the color picker</extracomment>
+<source>RED</source>
+<translation>紅色</translation>
+</message>
+<message id="color_picker_green">
+<extracomment>Label for the green channel slider in the color picker</extracomment>
+<source>GREEN</source>
+<translation>綠色</translation>
+</message>
+<message id="color_picker_blue">
+<extracomment>Label for the blue channel slider in the color picker</extracomment>
+<source>BLUE</source>
+<translation>藍色</translation>
+</message>
+<message id="color_picker_hex_label">
+<extracomment>Label for the hex color input field in the color picker</extracomment>
+<source>sRGB Hex Color #</source>
+<translation>sRGB 十六進制顏色 #</translation>
+</message>
+<message id="color_picker_grid">
+<extracomment>Tab label for the grid color picker mode</extracomment>
+<source>Grid</source>
+<translation>網格</translation>
+</message>
+</context>
+</TS>

--- a/qt/update_dialog.cpp
+++ b/qt/update_dialog.cpp
@@ -1,4 +1,5 @@
 #include "qt/update_dialog.hpp"
+#include "qt/qt_common/translations.hpp"
 
 #include "storage/downloader_search_params.hpp"
 #include "storage/storage_defines.hpp"
@@ -52,7 +53,7 @@ size_t const kIrrelevantPos = numeric_limits<int32_t>::max() - 1;
 bool DeleteNotUploadedEditsConfirmation()
 {
   QMessageBox msb;
-  msb.setText("Some map edits are not uploaded yet. Are you sure you want to delete map anyway?");
+  msb.setText(qt::Tr("desktop_unuploaded_edits_delete_map"));
   msb.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
   msb.setDefaultButton(QMessageBox::Cancel);
   return QMessageBox::Yes == msb.exec();
@@ -68,14 +69,15 @@ UpdateDialog::UpdateDialog(QWidget * parent, Framework & framework)
 {
   setWindowModality(Qt::WindowModal);
 
-  QPushButton * closeButton = new QPushButton(QObject::tr("Close"), this);
+  QPushButton * closeButton = new QPushButton(Tr("close"), this);
   closeButton->setDefault(true);
   connect(closeButton, &QAbstractButton::clicked, this, &UpdateDialog::OnCloseClick);
 
   m_tree = new QTreeWidget(this);
   m_tree->setColumnCount(KNumberOfColumns);
   QStringList columnLabels;
-  columnLabels << tr("Country") << tr("Status") << tr("Size") << tr("Matched by") << tr("Rank");
+  columnLabels << Tr("desktop_country") << Tr("desktop_status") << Tr("desktop_size") << Tr("desktop_matched_by")
+               << Tr("desktop_rank");
   m_tree->setHeaderLabels(columnLabels);
 
   m_tree->setColumnHidden(KColumnIndexPositionInRanking, true);
@@ -91,12 +93,12 @@ UpdateDialog::UpdateDialog(QWidget * parent, Framework & framework)
   horizontalLayout->addStretch();
   horizontalLayout->addWidget(closeButton);
 
-  QLabel * localeLabel = new QLabel(tr("locale:"));
+  QLabel * localeLabel = new QLabel(Tr("desktop_locale_label"));
   QLineEdit * localeEdit = new QLineEdit(this);
   localeEdit->setText(m_locale.c_str());
   connect(localeEdit, &QLineEdit::textChanged, this, &UpdateDialog::OnLocaleTextChanged);
 
-  QLabel * queryLabel = new QLabel(tr("search query:"));
+  QLabel * queryLabel = new QLabel(Tr("desktop_search_query_label"));
   QLineEdit * queryEdit = new QLineEdit(this);
   connect(queryEdit, &QLineEdit::textChanged, this, &UpdateDialog::OnQueryTextChanged);
 
@@ -113,7 +115,7 @@ UpdateDialog::UpdateDialog(QWidget * parent, Framework & framework)
   verticalLayout->addLayout(horizontalLayout);
   setLayout(verticalLayout);
 
-  setWindowTitle(tr("Geographical Regions"));
+  setWindowTitle(Tr("desktop_geographical_regions"));
   resize(900, 600);
 
   // We want to receive all download progress and result events.
@@ -152,10 +154,10 @@ void UpdateDialog::OnItemClick(QTreeWidgetItem * item, int column)
     // Map is already downloaded, so ask user about deleting.
     QMessageBox ask(this);
     ask.setIcon(QMessageBox::Question);
-    ask.setText(tr("Do you want to update or delete %1?").arg(countryId.c_str()));
-    QPushButton * const btnUpdate = ask.addButton(tr("Update"), QMessageBox::ActionRole);
-    QPushButton * const btnDelete = ask.addButton(tr("Delete"), QMessageBox::ActionRole);
-    QPushButton * const btnCancel = ask.addButton(tr("Cancel"), QMessageBox::NoRole);
+    ask.setText(Tr("desktop_update_or_delete_region").arg(countryId.c_str()));
+    QPushButton * const btnUpdate = ask.addButton(Tr("desktop_update"), QMessageBox::ActionRole);
+    QPushButton * const btnDelete = ask.addButton(Tr("delete"), QMessageBox::ActionRole);
+    QPushButton * const btnCancel = ask.addButton(Tr("cancel"), QMessageBox::NoRole);
     UNUSED_VALUE(btnCancel);
 
     ask.exec();
@@ -177,9 +179,9 @@ void UpdateDialog::OnItemClick(QTreeWidgetItem * item, int column)
     // Map is already downloaded, so ask user about deleting.
     QMessageBox ask(this);
     ask.setIcon(QMessageBox::Question);
-    ask.setText(tr("Do you want to delete %1?").arg(countryId.c_str()));
-    QPushButton * const btnDelete = ask.addButton(tr("Delete"), QMessageBox::ActionRole);
-    QPushButton * const btnCancel = ask.addButton(tr("Cancel"), QMessageBox::NoRole);
+    ask.setText(Tr("desktop_delete_region").arg(countryId.c_str()));
+    QPushButton * const btnDelete = ask.addButton(Tr("delete"), QMessageBox::ActionRole);
+    QPushButton * const btnCancel = ask.addButton(Tr("cancel"), QMessageBox::NoRole);
     UNUSED_VALUE(btnCancel);
 
     ask.exec();
@@ -379,38 +381,38 @@ void UpdateDialog::UpdateRowWithCountryInfo(QTreeWidgetItem * item, CountryId co
   {
   case NodeStatus::NotDownloaded:
     ASSERT(size.second > 0, (countryId));
-    statusString = tr("Click to download");
+    statusString = Tr("desktop_click_to_download");
     rowColor = COLOR_NOTDOWNLOADED;
     break;
 
   case NodeStatus::OnDisk:
   case NodeStatus::Partly:
-    statusString = tr("Installed (click to delete)");
+    statusString = Tr("desktop_installed_click_to_delete");
     rowColor = COLOR_ONDISK;
     break;
 
   case NodeStatus::OnDiskOutOfDate:
-    statusString = tr("Out of date (click to update or delete)");
+    statusString = Tr("desktop_out_of_date_click_to_update_or_delete");
     rowColor = COLOR_OUTOFDATE;
     break;
 
   case NodeStatus::Error:
-    statusString = tr("Download has failed");
+    statusString = Tr("country_status_download_failed");
     rowColor = COLOR_DOWNLOADFAILED;
     break;
 
   case NodeStatus::Downloading:
-    statusString = tr("Downloading ...");
+    statusString = Tr("desktop_downloading_ellipsis");
     rowColor = COLOR_INPROGRESS;
     break;
 
   case NodeStatus::Applying:
-    statusString = tr("Applying ...");
+    statusString = Tr("desktop_applying_ellipsis");
     rowColor = COLOR_INPROGRESS;
     break;
 
   case NodeStatus::InQueue:
-    statusString = tr("Marked for download");
+    statusString = Tr("desktop_marked_for_download");
     rowColor = COLOR_INQUEUE;
     break;
 

--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -18,9 +18,9 @@ function GenerateStringResource() {
   args=${@:6}
   include=translated
 
-  if [[ $format == apple* ]]
+  if [[ $format == apple* || $format == qt* ]]
   then
-    # Apple strings file should fallback to English in case of missing translation.
+    # Apple and Qt strings files should fallback to English in case of missing translation.
     include=all
   fi
 
@@ -66,6 +66,9 @@ GenerateStringResource "strings.txt" iphone/Maps/LocalizedStrings apple apple-ma
 GenerateStringResource "strings.txt" iphone/Maps/LocalizedStrings apple-plural apple-maps ""
 GenerateStringResource "strings.txt" iphone/Maps/LocalizedStrings apple apple-infoplist "InfoPlist.strings"
 GenerateStringResource "strings.txt" iphone/Chart/Chart apple apple-chart ""
+
+# Generate Qt desktop strings
+GenerateStringResource "strings.txt" qt/translations qt "" "" "-r"
 
 # Generate Android types strings
 GenerateStringResource "types_strings.txt" android/sdk/src/main/res android "" types_strings.xml


### PR DESCRIPTION
## Summary
- Switches desktop string generation to upstream Twine (Qt formatter, picked up via the earlier `3party/twine` submodule bump).
- Replaces hard-coded English UI text in the place page and editor/routing dialogs with `Tr()` lookups, reusing existing translation keys where the wording matches.
- Adds five new `qt`-tagged keys for place-page labels with no existing match: `desktop_place_page`, `desktop_place_page_bookmarked`, `desktop_place_routes`, `desktop_place_opening_hours`, `desktop_place_coordinates`.
- Generates per-language Qt translation files (`qt/translations/*.ts`) for all supported locales.
- Adds `qt/qt_common/translations.{hpp,cpp}` helper and a `strict_lrelease.cmake` build step.

## Out of scope (still hard-coded for now)
- Routing-settings form field labels.
- `mainwindow` download-button templates.
- Developer-only dialogs: `place_page_dialog_developer`, screenshoter, `BUILD_DESIGNER` blocks, CLI flag descriptions.